### PR TITLE
Increased babel-downloads size

### DIFF
--- a/kubernetes/babel-downloads.k8s.yaml
+++ b/kubernetes/babel-downloads.k8s.yaml
@@ -13,5 +13,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 400Gi
+      storage: 500Gi
   storageClassName: basic


### PR DESCRIPTION
This PR increases the size of the babel-downloads PVC as we now require more than 400Gi to complete building the compendia.