### PR TITLE
Paginate UberGraph results and remove EFO

### DIFF
--- a/config.json
+++ b/config.json
@@ -26,9 +26,9 @@
 
   "geneprotein_output": "GeneProtein.txt",
 
-  "disease_labelsandsynonyms": ["MONDO","DOID","Orphanet","EFO","HP","MESH","NCIT","UMLS","SNOMEDCT"],
-  "disease_ids": ["MONDO","DOID","Orphanet","EFO","HP","MESH","NCIT","UMLS","OMIM"],
-  "disease_concords": ["HP","MONDO","EFO","UMLS","DOID"],
+  "disease_labelsandsynonyms": ["MONDO","DOID","Orphanet","HP","MESH","NCIT","UMLS","SNOMEDCT"],
+  "disease_ids": ["MONDO","DOID","Orphanet","HP","MESH","NCIT","UMLS","OMIM"],
+  "disease_concords": ["HP","MONDO","UMLS","DOID"],
   "disease_outputs": ["Disease.txt", "PhenotypicFeature.txt"],
 
   "process_labels": ["GO","REACT","RHEA","EC","SMPDB","PANTHER.PATHWAY"],

--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
   "biolink_version": "2.2.7",
 
   "ncbi_files": ["gene2ensembl.gz", "gene_info.gz", "gene_orthologs.gz", "gene_refseq_uniprotkb_collab.gz", "mim2gene_medgen"],
-  "ubergraph_ontologies": ["UBERON", "CL", "GO", "NCIT", "ECO", "ECTO", "EFO", "ENVO", "HP", "UPHENO","BFO","BSPO","CARO","CHEBI","CP","GOREL","IAO","MAXO","MONDO","PATO","PR","RO","UBPROP"],
+  "ubergraph_ontologies": ["UBERON", "CL", "GO", "NCIT", "ECO", "ECTO", "ENVO", "HP", "UPHENO","BFO","BSPO","CARO","CHEBI","CP","GOREL","IAO","MAXO","MONDO","PATO","PR","RO","UBPROP"],
   "mods": ["WormBase","FB","MGI","ZFIN","RGD","SGD"],
 
   "anatomy_prefixes": ["UBERON","GO","CL","UMLS","MESH","NCIT","SNOMEDCT"],


### PR DESCRIPTION
Large UberGraph queries continue to time out. This PR adds code to paginate UberGraph queries so that we can retrieve larger result sets.

It also removes EFO from the list of UberGraph ontologies as removed in https://github.com/INCATools/ubergraph/pull/66.