### PR TITLE
Add EFO

### DIFF
--- a/src/createcompendia/diseasephenotype.py
+++ b/src/createcompendia/diseasephenotype.py
@@ -124,7 +124,7 @@ def build_disease_umls_relationships(idfile,outfile,omimfile,ncitfile):
             for line in inf:
                 x = line.split()[0]
                 good_ids[prefix].add(x)
-    umls.build_sets(idfile, outfile, {'SNOMEDCT_US':SNOMEDCT,'MSH': MESH, 'NCI': NCIT, 'HPO': HP, 'MDR':MEDDRA, 'OMIM': OMIM},acceptable_identifiers=good_ids)
+    umls.build_sets(idfile, outfile, {'SNOMEDCT_US':SNOMEDCT,'MSH': MESH, 'NCI': NCIT, 'HPO': HP, 'MDR':MEDDRA, 'OMIM': OMIM, 'EFO': EFO},acceptable_identifiers=good_ids)
 
 def build_disease_doid_relationships(idfile,outfile):
     doid.build_xrefs(idfile, outfile, other_prefixes={'ICD10CM':ICD10, 'ICD9CM':ICD9, 'ICDO': ICD0, 'NCI': NCIT,


### PR DESCRIPTION
WIP: This PR is an attempt to fix #48 by importing EFO directly into Babel. The challenge is that EFO "combines parts of several biological ontologies, such as UBERON anatomy, ChEBI chemical compounds, and Cell Ontology", all of which we pull in from other sources (mainly Ubergraph). So rather than pulling everything from EFO as we might with another ontology, we should probably try to selectively choose the parts of this ontology that Babel needs and that isn't already covered by another ontology.