### PR TITLE
Add UMLS IDs to taxon

### DIFF
--- a/config.json
+++ b/config.json
@@ -44,8 +44,8 @@
   "chemical_ids": ["CHEMBL.COMPOUND","GTOPDB","KEGG.COMPOUND","CHEBI","UNII","HMDB","PUBCHEM.COMPOUND","DrugCentral","DRUGBANK","MESH","UMLS"],
   "chemical_outputs": ["MolecularMixture.txt", "SmallMolecule.txt", "Polypeptide.txt", "ComplexMolecularMixture.txt",  "ChemicalEntity.txt", "ChemicalMixture.txt"],
 
-  "taxon_labels": ["NCBITaxon","MESH"],
-  "taxon_synonyms": ["NCBITaxon"],
+  "taxon_labels": ["NCBITaxon","MESH","UMLS"],
+  "taxon_synonyms": ["NCBITaxon","UMLS"],
   "taxon_ids": ["NCBITaxon","MESH","UMLS"],
   "taxon_concords": ["NCBI_MESH", "UMLS"],
   "taxon_outputs": ["OrganismTaxon.txt"],

--- a/config.json
+++ b/config.json
@@ -46,8 +46,8 @@
 
   "taxon_labels": ["NCBITaxon","MESH"],
   "taxon_synonyms": ["NCBITaxon"],
-  "taxon_ids": ["NCBITaxon","MESH"],
-  "taxon_concords": ["NCBI_MESH"],
+  "taxon_ids": ["NCBITaxon","MESH","UMLS"],
+  "taxon_concords": ["NCBI_MESH", "UMLS"],
   "taxon_outputs": ["OrganismTaxon.txt"],
 
   "genefamily_labels": ["PANTHER.FAMILY","HGNC.FAMILY"],

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "download_directory": "babel_downloads",
   "intermediate_directory": "babel_outputs/intermediate",
   "output_directory": "babel_outputs",
-  "biolink_version": "2.2.7",
+  "biolink_version": "3.0.3",
 
   "ncbi_files": ["gene2ensembl.gz", "gene_info.gz", "gene_orthologs.gz", "gene_refseq_uniprotkb_collab.gz", "mim2gene_medgen"],
   "ubergraph_ontologies": ["UBERON", "CL", "GO", "NCIT", "ECO", "ECTO", "ENVO", "HP", "UPHENO","BFO","BSPO","CARO","CHEBI","CP","GOREL","IAO","MAXO","MONDO","PATO","PR","RO","UBPROP"],

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -199,17 +199,26 @@ def pull_via_urllib(url: str, in_file_name: str, decompress = True, subpath=None
     # return the filename to the caller
     return out_file_name
 
-def write_compendium(synonym_list,ofname,node_type,labels={}):
+def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[]):
+    """
+    :param synonym_list:
+    :param ofname:
+    :param node_type:
+    :param labels:
+    :param extra_prefixes: We default to only allowing the prefixes allowed for a particular type in Biolink.
+        If you want to allow additional prefixes, list them here.
+    :return:
+    """
     config = get_config()
     cdir = config['output_directory']
     biolink_version = config['biolink_version']
     node_factory = NodeFactory(make_local_name(''),biolink_version)
     synonym_factory = SynonymFactory(make_local_name(''))
     ic_factory = InformationContentFactory(f'{get_config()["input_directory"]}/icRDF.tsv')
-    node_test = node_factory.create_node(input_identifiers=[],node_type=node_type,labels={})
+    node_test = node_factory.create_node(input_identifiers=[],node_type=node_type,labels={},extra_prefixes = extra_prefixes)
     with jsonlines.open(os.path.join(cdir,'compendia',ofname),'w') as outf, open(os.path.join(cdir,'synonyms',ofname),'w') as sfile:
         for slist in synonym_list:
-            node = node_factory.create_node(input_identifiers=slist, node_type=node_type,labels = labels)
+            node = node_factory.create_node(input_identifiers=slist, node_type=node_type,labels = labels, extra_prefixes = extra_prefixes)
             if node is not None:
                 nw = {"type": node['type']}
                 ic = ic_factory.get_ic(node)

--- a/src/createcompendia/taxon.py
+++ b/src/createcompendia/taxon.py
@@ -104,7 +104,5 @@ def build_compendia(concordances, identifiers):
         glom(dicts, pairs, unique_prefixes=uniques)
     gene_sets = set([frozenset(x) for x in dicts.values()])
     baretype = ORGANISM_TAXON.split(':')[-1]
-    # We need to use extra_prefixes since UMLS is not listed as an identifier prefix at
-    # https://biolink.github.io/biolink-model/docs/OrganismTaxon.html
-    write_compendium(gene_sets, f'{baretype}.txt', ORGANISM_TAXON, {}, extra_prefixes=[UMLS])
+    write_compendium(gene_sets, f'{baretype}.txt', ORGANISM_TAXON, {})
 

--- a/src/createcompendia/taxon.py
+++ b/src/createcompendia/taxon.py
@@ -2,6 +2,7 @@ from src.prefixes import NCBITAXON,MESH
 from src.categories import ORGANISM_TAXON
 
 import src.datahandlers.mesh as mesh
+import src.datahandlers.umls as umls
 
 from src.babel_utils import read_identifier_file,glom,write_compendium
 import src.eutil as eutil
@@ -20,6 +21,45 @@ def write_mesh_ids(outfile):
     meshmap = { f'B{str(i).zfill(2)}': ORGANISM_TAXON for i in range(1, 6)}
     #Also add anything from SCR_Chemical, if it doesn't have a tree map
     mesh.write_ids(meshmap,outfile,order=[ORGANISM_TAXON],extra_vocab={'SCR_Organism':ORGANISM_TAXON})
+
+def write_umls_ids(outfile):
+    # UMLS categories that should be classified as taxa:
+    # - A1.1.3: Eukaryote (https://uts.nlm.nih.gov/uts/umls/semantic-network/T204)
+    # - A1.1.2: Bacterium (https://uts.nlm.nih.gov/uts/umls/semantic-network/T007)
+    # - A1.1.3.3: Plant (https://uts.nlm.nih.gov/uts/umls/semantic-network/T002)
+    # - A1.1.3.2: Fungus (https://uts.nlm.nih.gov/uts/umls/semantic-network/T004)
+    # - A1.1.3.1.1.3: Fish (https://uts.nlm.nih.gov/uts/umls/semantic-network/T013)
+    # - A1.1.3.1.1.2: Bird (https://uts.nlm.nih.gov/uts/umls/semantic-network/T012)
+    # - A1.1.4: Virus (https://uts.nlm.nih.gov/uts/umls/semantic-network/T005)
+    # - A1.1.3.1.1.4: Mammal (https://uts.nlm.nih.gov/uts/umls/semantic-network/T015)
+    # - A1.1.3.1.1.5: Reptile (https://uts.nlm.nih.gov/uts/umls/semantic-network/T014)
+    # - A1.1.3.1.1.1: Amphibian (https://uts.nlm.nih.gov/uts/umls/semantic-network/T011)
+    # - A1.1.1: Archaeon (https://uts.nlm.nih.gov/uts/umls/semantic-network/T194)
+    # - A1.1.3.1: Animal (https://uts.nlm.nih.gov/uts/umls/semantic-network/T008)
+    # - A1.1: Organism (https://uts.nlm.nih.gov/uts/umls/semantic-network/T001)
+    # - A1.1.3.1.1: Vertebrate (https://uts.nlm.nih.gov/uts/umls/semantic-network/T010)
+    #
+    # Not clear if these should be included, so left out for now:
+    # - A1.1.3.1.1.4.1: Human (https://uts.nlm.nih.gov/uts/umls/semantic-network/T016)
+    #   (presumably the human taxon is represented as _Homo sapiens_, which is http://id.nlm.nih.gov/mesh/D006801)
+
+    umlsmap = {x: ORGANISM_TAXON for x in [
+        'A1.1.3',
+        'A1.1.2',
+        'A1.1.3.3',
+        'A1.1.3.2',
+        'A1.1.3.1.1.3',
+        'A1.1.3.1.1.2',
+        'A1.1.4',
+        'A1.1.3.1.1.4',
+        'A1.1.3.1.1.5',
+        'A1.1.3.1.1.1',
+        'A1.1.1',
+        'A1.1.3.1',
+        'A1.1',
+        'A1.1.3.1.1'
+    ]}
+    umls.write_umls_ids(umlsmap,outfile)
 
 def build_relationships(outfile,mesh_ids):
     regis = mesh.pull_mesh_registry()

--- a/src/createcompendia/taxon.py
+++ b/src/createcompendia/taxon.py
@@ -1,4 +1,4 @@
-from src.prefixes import NCBITAXON,MESH
+from src.prefixes import NCBITAXON,MESH,UMLS
 from src.categories import ORGANISM_TAXON
 
 import src.datahandlers.mesh as mesh
@@ -87,7 +87,7 @@ def build_compendia(concordances, identifiers):
        :identifiers: a list of files from which to read identifiers and optional categories"""
     dicts = {}
     types = {}
-    uniques = [NCBITAXON,MESH]
+    uniques = [NCBITAXON,MESH,UMLS]
     for ifile in identifiers:
         print('loading',ifile)
         new_identifiers, new_types = read_identifier_file(ifile)

--- a/src/createcompendia/taxon.py
+++ b/src/createcompendia/taxon.py
@@ -104,5 +104,7 @@ def build_compendia(concordances, identifiers):
         glom(dicts, pairs, unique_prefixes=uniques)
     gene_sets = set([frozenset(x) for x in dicts.values()])
     baretype = ORGANISM_TAXON.split(':')[-1]
-    write_compendium(gene_sets, f'{baretype}.txt', ORGANISM_TAXON, {})
+    # We need to use extra_prefixes since UMLS is not listed as an identifier prefix at
+    # https://biolink.github.io/biolink-model/docs/OrganismTaxon.html
+    write_compendium(gene_sets, f'{baretype}.txt', ORGANISM_TAXON, {}, extra_prefixes=[UMLS])
 

--- a/src/createcompendia/taxon.py
+++ b/src/createcompendia/taxon.py
@@ -61,6 +61,9 @@ def write_umls_ids(outfile):
     ]}
     umls.write_umls_ids(umlsmap,outfile)
 
+def build_taxon_umls_relationships(idfile,outfile):
+    umls.build_sets(idfile, outfile, {'MSH': MESH, 'NCBITaxon': NCBITAXON})
+
 def build_relationships(outfile,mesh_ids):
     regis = mesh.pull_mesh_registry()
     with open(mesh_ids,'r') as inf:

--- a/src/node.py
+++ b/src/node.py
@@ -65,7 +65,7 @@ class InformationContentFactory:
 
 class NodeFactory:
     def __init__(self,label_dir,biolink_version):
-        self.toolkit = Toolkit(f'https://raw.githubusercontent.com/biolink/biolink-model/v{biolink_version}/biolink-model.yaml')
+        self.toolkit = Toolkit()
         self.ancestor_map = {}
         self.prefix_map = {}
         self.ignored_prefixes = set()

--- a/src/node.py
+++ b/src/node.py
@@ -172,12 +172,12 @@ class NodeFactory:
                     labeled_list.append(iid)
         return labeled_list
 
-    def create_node(self,input_identifiers,node_type,labels={}):
+    def create_node(self,input_identifiers,node_type,labels={},extra_prefixes=[]):
         #This is where we will normalize, i.e. choose the best id, and add types in accord with BL.
         #we should also include provenance and version information for the node set build.
         #ancestors = self.get_ancestors(node_type)
         #ancestors.reverse()
-        prefixes = self.get_prefixes(node_type)
+        prefixes = self.get_prefixes(node_type) + extra_prefixes
         if len(input_identifiers) == 0:
             return None
         if len(input_identifiers) > 1000:

--- a/src/node.py
+++ b/src/node.py
@@ -65,7 +65,7 @@ class InformationContentFactory:
 
 class NodeFactory:
     def __init__(self,label_dir,biolink_version):
-        self.toolkit = Toolkit()
+        self.toolkit = Toolkit(f'https://raw.githubusercontent.com/biolink/biolink-model/v{biolink_version}/biolink-model.yaml')
         self.ancestor_map = {}
         self.prefix_map = {}
         self.ignored_prefixes = set()

--- a/src/node.py
+++ b/src/node.py
@@ -65,7 +65,7 @@ class InformationContentFactory:
 
 class NodeFactory:
     def __init__(self,label_dir,biolink_version):
-        self.toolkit = Toolkit(f'https://raw.githubusercontent.com/biolink/biolink-model/{biolink_version}/biolink-model.yaml')
+        self.toolkit = Toolkit(f'https://raw.githubusercontent.com/biolink/biolink-model/v{biolink_version}/biolink-model.yaml')
         self.ancestor_map = {}
         self.prefix_map = {}
         self.ignored_prefixes = set()

--- a/src/snakefiles/taxon.snakefile
+++ b/src/snakefiles/taxon.snakefile
@@ -24,6 +24,14 @@ rule taxon_umls_ids:
     run:
         taxon.write_umls_ids(output.outfile)
 
+rule get_taxon_umls_relationships:
+    input:
+        infile=config['intermediate_directory']+"/taxon/ids/UMLS"
+    output:
+        outfile=config['intermediate_directory']+'/taxon/concords/UMLS',
+    run:
+        taxon.build_taxon_umls_relationships(input.infile,output.outfile)
+
 rule get_taxon_relationships:
     input:
         meshfile=config['download_directory']+"/MESH/mesh.nt",

--- a/src/snakefiles/taxon.snakefile
+++ b/src/snakefiles/taxon.snakefile
@@ -36,7 +36,6 @@ rule get_taxon_relationships:
     input:
         meshfile=config['download_directory']+"/MESH/mesh.nt",
         meshids=config['intermediate_directory']+"/taxon/ids/MESH",
-        # TODO: do I need to generate a NCBI_MESH_UMLS concord here?
     output:
         outfile=config['intermediate_directory']+'/taxon/concords/NCBI_MESH'
     run:

--- a/src/snakefiles/taxon.snakefile
+++ b/src/snakefiles/taxon.snakefile
@@ -18,10 +18,17 @@ rule taxon_mesh_ids:
     run:
         taxon.write_mesh_ids(output.outfile)
 
+rule taxon_umls_ids:
+    output:
+        outfile=config['intermediate_directory']+"/taxon/ids/UMLS"
+    run:
+        taxon.write_umls_ids(output.outfile)
+
 rule get_taxon_relationships:
     input:
         meshfile=config['download_directory']+"/MESH/mesh.nt",
         meshids=config['intermediate_directory']+"/taxon/ids/MESH",
+        # TODO: do I need to generate a NCBI_MESH_UMLS concord here?
     output:
         outfile=config['intermediate_directory']+'/taxon/concords/NCBI_MESH'
     run:


### PR DESCRIPTION
We identified many UMLS IDs that correspond to taxa but aren't currently imported in https://github.com/TranslatorSRI/NodeNormalization/issues/119#issuecomment-1229860214. This PR updates the taxon compendia to include taxa from UMLS. Since Biolink Model v3.0.2 doesn't include UMLS as an identifier prefix for OrganismTaxon, this PR adds an `extra_prefixes` argument to `write_compendium()` to add `UMLS` to that list, since `UMLS` was added to the Biolink Model OrganismTaxon class (https://github.com/biolink/biolink-model/issues/1084), we don't actually use this functionality here. But I'm leaving it in since we might need it in the future.