### PR TITLE
Fix CHEBI:CHEBI: bug (#69)

### DIFF
--- a/src/datahandlers/drugcentral.py
+++ b/src/datahandlers/drugcentral.py
@@ -5,15 +5,26 @@ def pull_drugcentral(structfile, labelfile, xreffile):
     #DrugCentral is only available as a postgres db, but fortunately they run a public instance.
     conn = psycopg2.connect("host=unmtid-dbs.net dbname=drugcentral user=drugman port=5433 password=dosage")
     cur = conn.cursor()
-    cur.execute("SELECT * FROM identifier;")
+    cur.execute("SELECT id, identifier, id_type, struct_id, parent_match FROM identifier;")
     x = cur.fetchall()
     #Pull xrefs.  Output format is "1396790	C1172734	UMLSCUI	4970	None"
     # meaning UMLSCUI:C1172734 == DrugBank:4970
     with open(xreffile,'w') as outf:
         for xi in x:
             xs = [str(y) for y in xi]
-            outf.write('\t'.join(xs))
-            outf.write('\n')
+
+            row_id = xs[0]
+            identifier = xs[1]
+            id_type = xs[2]
+            struct_id = xs[3]
+            parent_match = xs[4]
+
+            # Sometimes (always?) CHEBI identifiers have a CHEBI: prefix. If this occurs, we remove the prefix before
+            # writing it out to this file.
+            if id_type == 'CHEBI' and identifier.startswith('CHEBI:'):
+                identifier = identifier[6:]
+
+            outf.write(f'{row_id}\t{identifier}\t{id_type}\t{struct_id}\t{parent_match}\n')
     cur.execute("SELECT id, smiles, name FROM structures;")
     x = cur.fetchall()
     with open(labelfile, 'w') as outf, open(structfile, 'w') as sf:

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -476,12 +476,6 @@ rule pubchem_synonyms:
 
 # DRUGCENTRAL
 
-rule get_drugcentralx:
-    output:
-        config['download_directory'] + '/DrugCentral/structures.smiles.tsv'
-    run:
-        drugcentral.pull_drugcentralx()
-
 rule get_drugcentral:
     output:
         structfile = config['download_directory'] + '/DrugCentral/structures',


### PR DESCRIPTION
The CHEBI:CHEBI: bug is caused by DrugCentral adding a `CHEBI:` prefix to its identifier. This PR checks for that prefix and removes it so the rest of our code can work correctly. Since it only works on `CHEBI` entries with the prefix, it should be fairly safe to leave in even if DrugCentral removes the prefix at a later date. Fixes #69.

This also deletes the non-functional `get_drugcentralx` target, which refers to a function that no longer exists in this repository. Closes #77.