### PR TITLE
Treat ENSEMBL versioned identifier as identical to their non-versioned representation

### DIFF
--- a/src/createcompendia/gene.py
+++ b/src/createcompendia/gene.py
@@ -1,3 +1,5 @@
+import re
+
 from src.prefixes import OMIM,ENSEMBL,NCBIGENE,WORMBASE, MGI, ZFIN, DICTYBASE, FLYBASE, RGD, SGD, HGNC, UMLS
 from src.categories import GENE
 
@@ -55,11 +57,21 @@ def build_gene_ensembl_relationships(ensembl_dir, outfile):
                             #Protein coding is not actually relevant.
                             #if x[protein_column] == '':
                             #    continue
-                            gid = f'{ENSEMBL}:{x[gene_column]}'
+                            gene_id = x[gene_column]
+                            gid = f'{ENSEMBL}:{gene_id}'
                             for cno,pref in columnno_to_prefix.items():
                                 value = x[cno]
                                 if len(value) > 0:
                                     outf.write(f'{gid}\teq\t{pref}:{value}\n')
+
+                                    # If the ENSEMBL ID is a version string (e.g. ENSEMBL:ENSP00000263368.3),
+                                    # then we should indicate that this is identical to the non-versioned string
+                                    # as well.
+                                    # See https://github.com/TranslatorSRI/Babel/issues/72 for details.
+                                    res = re.match(r"^([A-Z]+\d+)\.\d+", gene_id)
+                                    if res:
+                                        ensembl_id_without_version = res.group(1)
+                                        outf.write(f'{ENSEMBL}:{ensembl_id_without_version}\teq\t{gid}\n')
 
 def write_zfin_ids(infile,outfile):
     with open(infile,'r') as inf, open(outfile,'w') as outf:

--- a/src/createcompendia/gene.py
+++ b/src/createcompendia/gene.py
@@ -173,6 +173,15 @@ def build_gene_ncbi_ensembl_relationships(infile,ncbi_idfile,outfile):
             outf.write(f'{ncbigene_id}\teq\t{ensembl_id}\n')
             last=new
 
+            # If the ENSEMBL ID is a version string (e.g. ENSEMBL:ENSP00000263368.3),
+            # then we should indicate that this is identical to the non-versioned string
+            # as well.
+            # See https://github.com/TranslatorSRI/Babel/issues/72 for details.
+            res = re.match(r"^([A-Z]+\d+)\.\d+", x[2])
+            if res:
+                ensembl_id_without_version = res.group(1)
+                outf.write(f'{ncbigene_id}\teq\t{ENSEMBL}:{ensembl_id_without_version}\n')
+
 def build_gene_ncbigene_xrefs(infile,ncbi_idfile,outfile):
     mappings = {'WormBase': WORMBASE, 'FLYBASE': FLYBASE, 'ZFIN': ZFIN,
                 'HGNC': HGNC, 'MGI': MGI, 'RGD': RGD, 'dictyBase': DICTYBASE,

--- a/src/createcompendia/protein.py
+++ b/src/createcompendia/protein.py
@@ -109,10 +109,10 @@ def build_protein_uniprotkb_ensemble_relationships(infile,outfile):
                 # then we should indicate that this is identical to the non-versioned string
                 # as well.
                 # See https://github.com/TranslatorSRI/Babel/issues/72 for details.
-                res = re.match(r"^([A-Z]+\d+)\.\d+")
+                res = re.match(r"^([A-Z]+\d+)\.\d+", x[2])
                 if res:
                     ensembl_id_without_version = res.group(1)
-                    outf.write(f'{ensembl_id}\teq\t{ensembl_id_without_version}\n')
+                    outf.write(f'{ensembl_id}\teq\t{ENSEMBL}:{ensembl_id_without_version}\n')
 
 
 def build_ncit_uniprot_relationships(infile,outfile):

--- a/src/createcompendia/protein.py
+++ b/src/createcompendia/protein.py
@@ -1,3 +1,5 @@
+import re
+
 from src.prefixes import ENSEMBL, UMLS, PR, UNIPROTKB, NCIT
 from src.categories import PROTEIN
 
@@ -102,6 +104,15 @@ def build_protein_uniprotkb_ensemble_relationships(infile,outfile):
                 uniprot_id = f'{UNIPROTKB}:{x[0]}'
                 ensembl_id = f'{ENSEMBL}:{x[2]}'
                 outf.write(f'{uniprot_id}\teq\t{ensembl_id}\n')
+
+                # If the ENSEMBL ID is a version string (e.g. ENSEMBL:ENSP00000263368.3),
+                # then we should indicate that this is identical to the non-versioned string
+                # as well.
+                # See https://github.com/TranslatorSRI/Babel/issues/72 for details.
+                res = re.match(r"^([A-Z]+\d+)\.\d+")
+                if res:
+                    ensembl_id_without_version = res.group(1)
+                    outf.write(f'{ensembl_id}\teq\t{ensembl_id_without_version}\n')
 
 
 def build_ncit_uniprot_relationships(infile,outfile):

--- a/src/datahandlers/ensembl.py
+++ b/src/datahandlers/ensembl.py
@@ -1,23 +1,24 @@
 from src.babel_utils import make_local_name
-from apybiomart import find_datasets,query,find_attributes
+from apybiomart import find_datasets, query, find_attributes
 import os
 
-#Note that Ensembl doesn't seem to assign its own labels or synonyms to its gene identifiers.  It appears that
+
+# Note that Ensembl doesn't seem to assign its own labels or synonyms to its gene identifiers.  It appears that
 # they are all imported from other sources.   Therefore, we will not generate labels or synonym files.  We
 # do pull down data so that we can get the full list of ensembl identifiers though.
 
-#In principle, we want to pull some file from somewhere, but ensembl, in all of its glory, lacks a list of
+# In principle, we want to pull some file from somewhere, but ensembl, in all of its glory, lacks a list of
 # genes that can be gathered without downloading hundreds of gigs of other stuff.  So, we'll use biomart to pull
 # just what we need.
 def pull_ensembl(complete_file):
     f = find_datasets()
-    cols = set(["ensembl_gene_id", "ensembl_peptide_id", "description", "external_gene_name", "external_gene_source",
-                "external_synonym","chromosome_name","source","gene_biotype","entrezgene_id",
-                "zfin_id_id",'mgi_id','rgd_id','flybase_gene_id','sgd_gene','wormbase_gene'])
+    cols = {"ensembl_gene_id", "ensembl_peptide_id", "description", "external_gene_name", "external_gene_source",
+            "external_synonym", "chromosome_name", "source", "gene_biotype", "entrezgene_id", "zfin_id_id", 'mgi_id',
+            'rgd_id', 'flybase_gene_id', 'sgd_gene', 'wormbase_gene'}
     for ds in f['Dataset_ID']:
         print(ds)
-        outfile = make_local_name('BioMart.tsv',subpath=f'ENSEMBL/{ds}')
-        #Really, we should let snakemake handle this, but then we would need to put a list of all the 200+ sets in our
+        outfile = make_local_name('BioMart.tsv', subpath=f'ENSEMBL/{ds}')
+        # Really, we should let snakemake handle this, but then we would need to put a list of all the 200+ sets in our
         # config, and keep it up to date.  Maybe you could have a job that gets the datasets and writes a dataset file,
         # but then updates the config? That sounds bogus.
         if os.path.exists(outfile):
@@ -25,10 +26,11 @@ def pull_ensembl(complete_file):
         atts = find_attributes(ds)
         existingatts = set(atts['Attribute_ID'].to_list())
         attsIcanGet = cols.intersection(existingatts)
-        df = query(attributes=attsIcanGet, filters={}, dataset=ds)
-        df.to_csv(outfile,index=False,sep='\t')
-    with open(complete_file,'w') as outf:
+        df = query(attributes=list(attsIcanGet), filters={}, dataset=ds)
+        df.to_csv(outfile, index=False, sep='\t')
+    with open(complete_file, 'w') as outf:
         outf.write(f'Downloaded gene sets for {len(f)} data sets.')
+
 
 if __name__ == '__main__':
     pull_ensembl()

--- a/src/node.py
+++ b/src/node.py
@@ -181,8 +181,7 @@ class NodeFactory:
         if len(input_identifiers) == 0:
             return None
         if len(input_identifiers) > 1000:
-            print('this seems like a lot')
-            print(len(input_identifiers))
+            print(f'this seems like a lot of input_identifiers in node.create_node() [{len(input_identifiers)}]: {input_identifiers}')
         cleaned = self.apply_labels(input_identifiers,labels)
         try:
             idmap = defaultdict(list)


### PR DESCRIPTION
This PR modifies the ENSEMBL identifiers we get from BioMart so that versioned identifiers (e.g. `ENSEMBL:ENSP00000263368.3`) are treated as identical to the non-versioned identifier (in this case, `ENSEMBL:ENSP00000263368`). Note that this will not apply to ENSEMBL identifiers we get from any other source, but I think most of our ENSEMBL identifiers are from BioMart.

Relates to #72.