### PR TITLE
Split cliques that contain both MolecularMixtures and SmallMolecules

### DIFF
--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -355,6 +355,10 @@ def glom(conc_set, newgroups, unique_prefixes=['INCHIKEY'],pref='HP',close={}):
             conc_set[element] = newset
 
 def get_prefixes(idlist):
+    """ Return a dictionary of identifiers from idlist with their prefix as the key.
+
+    :param idlist: A list of identifiers. Should NOT contain any LabeledIDs.
+    """
     prefs = defaultdict(list)
     for ident in idlist:
         if isinstance(ident,LabeledID):

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -558,9 +558,9 @@ def create_typed_sets(eqsets, types):
                     all_other_ids = set()
                     for eq_id in equivalent_ids:
                         if 'biolink:MolecularMixture' in types[eq_id]:
-                            molecular_mixture_ids.update(eq_id)
+                            molecular_mixture_ids.add(eq_id)
                         else:
-                            all_other_ids.update(eq_id)
+                            all_other_ids.add(eq_id)
 
                     logging.info(
                         f"Found a clique that that contains PUBCHEM types " +

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -521,7 +521,7 @@ def create_typed_sets(eqsets, types):
     being a subclass of ChemicalEntity.
 
     :param eqsets: A list of lists of identifiers (should NOT be a list of LabeledIDs, but a list of strings).
-    :param types: A dictionary of known types for each identifier. (I'm guessing some identifiers don't have known types.)
+    :param types: A dictionary of known types for each identifier. (Some identifiers don't have known types.)
     """
     order = [MOLECULAR_MIXTURE, SMALL_MOLECULE, POLYPEPTIDE,  COMPLEX_CHEMICAL_MIXTURE, CHEMICAL_MIXTURE, CHEMICAL_ENTITY]
     typed_sets = defaultdict(set)
@@ -555,6 +555,8 @@ def create_typed_sets(eqsets, types):
                     # type information to split these cliques. Instead, as a temporary solution, we will split
                     # everything we're _sure_ is a biolink:MolecularMixture into a separate clique, and leave all
                     # the other identifiers as a biolink:SmallMolecule.
+                    #
+                    # First reported in https://github.com/TranslatorSRI/Babel/issues/83
                     molecular_mixture_ids = set()
                     all_other_ids = set()
                     for eq_id in equivalent_ids:

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -541,8 +541,7 @@ def create_typed_sets(eqsets, types):
                         pass
 
                 if len(pctypes) == 1:
-                    mytype = types[prefixes[prefix][0]]
-                    typed_sets[mytype].add(equivalent_ids)
+                    typed_sets[list(pctypes)[0]].add(equivalent_ids)
                     found = True
                 elif pctypes == {'biolink:SmallMolecule', 'biolink:MolecularMixture'}:
                     # This is a common case (8,178 cases in 2022oct13) which occurs in cases where the InChI for

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -535,7 +535,7 @@ def create_typed_sets(eqsets, types):
                 pctypes = set()
                 for x in prefixes[prefix]:
                     if x in types:
-                        pctypes.update([types[x]])
+                        pctypes.add(types[x])
                     else:
                         # logging.warning(f"No type found for {x}, skipping.")
                         pass

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -520,7 +520,7 @@ def create_typed_sets(eqsets, types):
     Given a set of sets of equivalent identifiers, we want to type each one into
     being a subclass of ChemicalEntity.
 
-    :param eqsets: A list of identifiers (should NOT be a list of LabeledIDs, but a list of strings).
+    :param eqsets: A list of lists of identifiers (should NOT be a list of LabeledIDs, but a list of strings).
     :param types: A dictionary of known types for each identifier. (I'm guessing some identifiers don't have known types.)
     """
     order = [MOLECULAR_MIXTURE, SMALL_MOLECULE, POLYPEPTIDE,  COMPLEX_CHEMICAL_MIXTURE, CHEMICAL_MIXTURE, CHEMICAL_ENTITY]
@@ -557,7 +557,7 @@ def create_typed_sets(eqsets, types):
                     molecular_mixture_ids = set()
                     all_other_ids = set()
                     for eq_id in equivalent_ids:
-                        if 'biolink:MolecularMixture' in types[eq_id]:
+                        if eq_id in types and 'biolink:MolecularMixture' in types[eq_id]:
                             molecular_mixture_ids.add(eq_id)
                         else:
                             all_other_ids.add(eq_id)

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -557,14 +557,14 @@ def create_typed_sets(eqsets, types):
                     molecular_mixture_ids = set()
                     all_other_ids = set()
                     for eq_id in equivalent_ids:
-                        if eq_id in types and 'biolink:MolecularMixture' in types[eq_id]:
+                        if eq_id in types and types[eq_id] == 'biolink:MolecularMixture':
                             molecular_mixture_ids.add(eq_id)
                         else:
                             all_other_ids.add(eq_id)
 
                     logging.info(
                         f"Found a clique that that contains PUBCHEM types " +
-                        f"({'biolink:SmallMolecule', 'biolink:MolecularMixture'}). This clique will be split " +
+                        "({'biolink:SmallMolecule', 'biolink:MolecularMixture'}). This clique will be split " +
                         f"into a biolink:MolecularMixture ({molecular_mixture_ids}) and " +
                         f"a biolink:SmallMolecule ({all_other_ids})"
                     )

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -1,3 +1,4 @@
+import logging
 from collections import defaultdict
 import jsonlines
 import requests
@@ -534,6 +535,8 @@ def create_typed_sets(eqsets, types):
                         mytype = types[prefixes[prefix][0]]
                         typed_sets[mytype].add(equivalent_ids)
                         found = True
+                    else:
+                        logging.warning(f"An unexpected number of PUBCHEM types found for ${equivalent_ids} (${len(pctypes)}): ${pctypes}")
                 except:
                     pass
         if not found:

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -525,7 +525,9 @@ def create_typed_sets(eqsets, types):
     """
     order = [MOLECULAR_MIXTURE, SMALL_MOLECULE, POLYPEPTIDE,  COMPLEX_CHEMICAL_MIXTURE, CHEMICAL_MIXTURE, CHEMICAL_ENTITY]
     typed_sets = defaultdict(set)
+    logging.warning(f"create_typed_sets: eqsets={eqsets}, types=...")
     for equivalent_ids in eqsets:
+        logging.warning(f"Processing equivalent_ids={equivalent_ids}.")
         # prefixes = set([ Text.get_curie(x) for x in equivalent_ids])
         prefixes = get_prefixes(equivalent_ids)
         found = False

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -518,7 +518,10 @@ def build_compendia(type_file,untyped_compendia_file):
 def create_typed_sets(eqsets, types):
     """
     Given a set of sets of equivalent identifiers, we want to type each one into
-    being a subclass of ChemicalEntity
+    being a subclass of ChemicalEntity.
+
+    :param eqsets: A list of identifiers (should NOT be a list of LabeledIDs, but a list of strings).
+    :param types: A dictionary of known types for each identifier. (I'm guessing some identifiers don't have known types.)
     """
     order = [MOLECULAR_MIXTURE, SMALL_MOLECULE, POLYPEPTIDE,  COMPLEX_CHEMICAL_MIXTURE, CHEMICAL_MIXTURE, CHEMICAL_ENTITY]
     typed_sets = defaultdict(set)
@@ -534,6 +537,33 @@ def create_typed_sets(eqsets, types):
                     if len(pctypes) == 1:
                         mytype = types[prefixes[prefix][0]]
                         typed_sets[mytype].add(equivalent_ids)
+                        found = True
+                    elif pctypes == {'biolink:SmallMolecule', 'biolink:MolecularMixture'}:
+                        # This is a common case (8,178 cases in 2022oct13) which occurs in cases where the InChI for
+                        # e.g. water (SMILES: O) and hydron;hydroxide ([H+].[OH-]) are identical, causing them to be
+                        # merged. (They may also be merged if we combine two identifiers into a single clique that is
+                        # linked to two PubChem entries.)
+                        #
+                        # The comprehensive solution would be to use SMILES or molecular formula or per-database
+                        # type information to split these cliques. Instead, as a temporary solution, we will split
+                        # everything we're _sure_ is a biolink:MolecularMixture into a separate clique, and leave all
+                        # the other identifiers as a biolink:SmallMolecule.
+                        molecular_mixture_ids = set()
+                        all_other_ids = set()
+                        for eq_id in equivalent_ids:
+                            if 'biolink:MolecularMixture' in types[eq_id]:
+                                molecular_mixture_ids.update(eq_id)
+                            else:
+                                all_other_ids.update(eq_id)
+
+                        logging.info(
+                            f"Found a clique that that contains PUBCHEM types " +
+                            f"({'biolink:SmallMolecule', 'biolink:MolecularMixture'}). This clique will be split " +
+                            f"into a biolink:MolecularMixture ({molecular_mixture_ids}) and " +
+                            f"a biolink:SmallMolecule ({all_other_ids})"
+                        )
+                        typed_sets['biolink:MolecularMixture'].add(molecular_mixture_ids)
+                        typed_sets['biolink:SmallMolecule'].add(all_other_ids)
                         found = True
                     else:
                         logging.warning(f"An unexpected number of PUBCHEM types found for {equivalent_ids} ({len(pctypes)}): {pctypes}")

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -536,7 +536,7 @@ def create_typed_sets(eqsets, types):
                         typed_sets[mytype].add(equivalent_ids)
                         found = True
                     else:
-                        logging.warning(f"An unexpected number of PUBCHEM types found for ${equivalent_ids} (${len(pctypes)}): ${pctypes}")
+                        logging.warning(f"An unexpected number of PUBCHEM types found for {equivalent_ids} ({len(pctypes)}): {pctypes}")
                 except:
                     pass
         if not found:

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -554,13 +554,13 @@ def create_typed_sets(eqsets, types):
                     # type information to split these cliques. Instead, as a temporary solution, we will split
                     # everything we're _sure_ is a biolink:MolecularMixture into a separate clique, and leave all
                     # the other identifiers as a biolink:SmallMolecule.
-                    molecular_mixture_ids = set()
-                    all_other_ids = set()
+                    molecular_mixture_ids = list()
+                    all_other_ids = list()
                     for eq_id in equivalent_ids:
                         if eq_id in types and types[eq_id] == 'biolink:MolecularMixture':
-                            molecular_mixture_ids.add(eq_id)
+                            molecular_mixture_ids.append(eq_id)
                         else:
-                            all_other_ids.add(eq_id)
+                            all_other_ids.append(eq_id)
 
                     logging.info(
                         f"Found a clique that that contains PUBCHEM types " +

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -535,9 +535,10 @@ def create_typed_sets(eqsets, types):
                 pctypes = set()
                 for x in prefixes[prefix]:
                     if x in types:
-                        pctypes.update(types[x])
+                        pctypes.update([types[x]])
                     else:
-                        logging.warning(f"No type found for {x}, skipping.")
+                        # logging.warning(f"No type found for {x}, skipping.")
+                        pass
 
                 if len(pctypes) == 1:
                     mytype = types[prefixes[prefix][0]]

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -525,9 +525,9 @@ def create_typed_sets(eqsets, types):
     """
     order = [MOLECULAR_MIXTURE, SMALL_MOLECULE, POLYPEPTIDE,  COMPLEX_CHEMICAL_MIXTURE, CHEMICAL_MIXTURE, CHEMICAL_ENTITY]
     typed_sets = defaultdict(set)
-    logging.warning(f"create_typed_sets: eqsets={eqsets}, types=...")
+    # logging.warning(f"create_typed_sets: eqsets={eqsets}, types=...")
     for equivalent_ids in eqsets:
-        logging.warning(f"Processing equivalent_ids={equivalent_ids}.")
+        # logging.warning(f"Processing equivalent_ids={equivalent_ids}.")
         # prefixes = set([ Text.get_curie(x) for x in equivalent_ids])
         prefixes = get_prefixes(equivalent_ids)
         found = False
@@ -555,13 +555,13 @@ def create_typed_sets(eqsets, types):
                     # type information to split these cliques. Instead, as a temporary solution, we will split
                     # everything we're _sure_ is a biolink:MolecularMixture into a separate clique, and leave all
                     # the other identifiers as a biolink:SmallMolecule.
-                    molecular_mixture_ids = list()
-                    all_other_ids = list()
+                    molecular_mixture_ids = set()
+                    all_other_ids = set()
                     for eq_id in equivalent_ids:
                         if eq_id in types and types[eq_id] == 'biolink:MolecularMixture':
-                            molecular_mixture_ids.append(eq_id)
+                            molecular_mixture_ids.add(eq_id)
                         else:
-                            all_other_ids.append(eq_id)
+                            all_other_ids.add(eq_id)
 
                     logging.info(
                         f"Found a clique that that contains PUBCHEM types " +
@@ -569,8 +569,8 @@ def create_typed_sets(eqsets, types):
                         f"into a biolink:MolecularMixture ({molecular_mixture_ids}) and " +
                         f"a biolink:SmallMolecule ({all_other_ids})"
                     )
-                    typed_sets['biolink:MolecularMixture'].add(molecular_mixture_ids)
-                    typed_sets['biolink:SmallMolecule'].add(all_other_ids)
+                    typed_sets['biolink:MolecularMixture'].add(frozenset(molecular_mixture_ids))
+                    typed_sets['biolink:SmallMolecule'].add(frozenset(all_other_ids))
                     found = True
                 else:
                     logging.warning(f"An unexpected number of PUBCHEM types found for {equivalent_ids} ({len(pctypes)}): {pctypes}")


### PR DESCRIPTION
This is a quick fix for #83 that splits cliques that contain both a PubChem MolecularMixture and SmallMolecule into two separate cliques, one containing all identifiers that have a type of MolecularMixture, while the other contains all remaining identifiers.

In most cases, only a single PubChem compound is separated, but some cliques have more than one identifiers, such as in the following example:

> WARNING:root:Found a clique that that contains PUBCHEM types ({'biolink:SmallMolecule', 'biolink:MolecularMixture'}). This clique will be split into a biolink:MolecularMixture ({'PUBCHEM.COMPOUND:11149677', 'PUBCHEM.COMPOUND:22836554', 'PUBCHEM.COMPOUND:4066245', 'PUBCHEM.COMPOUND:5373419'}) and a biolink:SmallMolecule ({'CAS:21679-31-2', 'UMLS:C0244965', 'CAS:17272-66-1', 'MESH:C049529', 'INCHIKEY:POILWHVDKZOXJZ-ARJAWSKDSA-M', 'PUBCHEM.COMPOUND:5460482'})