### PR TITLE
Added relation from UMLS/synonyms into synonyms/umls.txt

### DIFF
--- a/src/createcompendia/leftover_umls.py
+++ b/src/createcompendia/leftover_umls.py
@@ -186,11 +186,10 @@ def write_leftover_umls(compendia, mrconso, mrsty, synonyms, umls_compendium, um
         with open(synonyms, 'r') as synonymsf, open(umls_synonyms, 'w') as umls_synonymsf:
             for line in synonymsf:
                 id, relation, synonym = line.rstrip().split('\t')
-                # TODO: we ignore the relation for now, since UMLS only uses oboInOwl:hasExactSynonym
                 if id in umls_ids_in_this_compendium:
                     synonym_ids.add(id)
                     count_synonyms += 1
-                    umls_synonymsf.write(f"{id}\t{synonym}\n")
+                    umls_synonymsf.write(f"{id}\t{relation}\t{synonym}\n")
 
         logging.info(f"Wrote {count_synonyms} synonyms for {len(synonym_ids)} UMLS IDs into the leftover UMLS synonyms file.")
         reportf.write(f"Wrote {count_synonyms} synonyms for {len(synonym_ids)} UMLS IDs into the leftover UMLS synonyms file.\n")


### PR DESCRIPTION
The previous PR accidentally left out the relation when generating synonyms/umls.txt. This PR restores that.

Fixes #82.