### PR TITLE
Fix ChemicalEntity identifier prefix order bug

### DIFF
--- a/src/node.py
+++ b/src/node.py
@@ -98,15 +98,20 @@ class NodeFactory:
         elif input_type == 'biolink:ChemicalEntity':
             #This just has to be here for now
             prefs = prefs + self.get_prefixes('biolink:SmallMolecule')
-        #The pref are in a particular order, but apparently it can have dups (ugh)
-        # The particular dups are gone now, but the code remains in case they come back...
-        newprefs = ['']
+        # The pref are in a particular order, but apparently they can have dups (ugh)
+        # We de-duplicate those here.
+        prefixes_already_included = set()
+        prefixes_deduplicated = list()
         for pref in prefs:
-            if not pref  == newprefs[-1]:
-                newprefs.append(pref)
-        prefs = newprefs[1:]
-        self.prefix_map[input_type] = prefs
-        return prefs
+            # Don't add a prefix that we've already added.
+            if pref in prefixes_already_included:
+                continue
+
+            prefixes_deduplicated.append(pref)
+            prefixes_already_included.add(pref)
+
+        self.prefix_map[input_type] = prefixes_deduplicated
+        return prefixes_deduplicated
 
     def make_json_id(self,input):
         if isinstance(input,LabeledID):

--- a/src/node.py
+++ b/src/node.py
@@ -94,10 +94,10 @@ class NodeFactory:
             print('no prefixes for', input_type, 'Using small molecules')
             prefs = self.get_prefixes("biolink:SmallMolecule")
         elif input_type == 'biolink:Polypeptide':
-            prefs = list(set(prefs + self.get_prefixes('biolink:SmallMolecule')))
+            prefs = prefs + self.get_prefixes('biolink:SmallMolecule')
         elif input_type == 'biolink:ChemicalEntity':
             #This just has to be here for now
-            prefs = list(set(prefs + self.get_prefixes('biolink:SmallMolecule')))
+            prefs = prefs + self.get_prefixes('biolink:SmallMolecule')
         #The pref are in a particular order, but apparently it can have dups (ugh)
         # The particular dups are gone now, but the code remains in case they come back...
         newprefs = ['']


### PR DESCRIPTION
Because of a bug in our prefix list generation code, the order of identifier prefixes in both Polypeptides and ChemicalEntities are being de-duplicated by using `set()`, which may eliminate the order of these prefixes:

https://github.com/TranslatorSRI/Babel/blob/7536b2593bba01e007af9f5e1c1156460c1415fd/src/node.py#L96-L100

This leads to situations like [PUBCHEM.COMPOUND:148951136](https://nodenormalization-dev.apps.renci.org/get_normalized_nodes?curie=PUBCHEM.COMPOUND:148951136&conflate=false) (a.k.a. [AKOS012811781](https://pubchem.ncbi.nlm.nih.gov/substance/148951136)), which has a primary identifier of an INCHIKEY rather than the PUBCHEM.COMPOUND identifier.

This PR fixes that by removing the `set()` and by improving the deduplication logic so it can handle cases where the duplicates are not next to each other.

Fixes #68.