### PR TITLE
Move UNII out of private and back into Downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,5 +114,4 @@ These two directories should be set up as following:
 * `babel/input_data/private` is used to store some input files
   that you will need to download yourself:
     * `MRCONSO.RRF` and `MRSTY.RRF`: parts of the UMLS release, need to be downloaded from [the UMLS download website](https://www.nlm.nih.gov/research/umls/licensedcontent/umlsknowledgesources.html).
-    * `UNII/UNIIs.zip` and `UNII/UNII_Data.zip`: needs to be downloaded from [the FDA UNII download website](https://precision.fda.gov/uniisearch/archive).
 * `babel/babel_downloads` is used to store data files downloaded during Babel assembly.

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -162,9 +162,12 @@ def pull_via_urllib(url: str, in_file_name: str, decompress = True, subpath=None
     else:
         dl_file_name = os.path.join(download_dir,subpath,in_file_name)
 
+    # Add support for redirects
+    opener = urllib.request.build_opener(urllib.request.HTTPRedirectHandler())
+
     # get a handle to the ftp file
     print(url+in_file_name)
-    handle = urllib.request.urlopen(url + in_file_name)
+    handle = opener.open(url + in_file_name)
 
     # create the compressed file
     with open(dl_file_name, 'wb') as compressed_file:

--- a/src/datahandlers/unii.py
+++ b/src/datahandlers/unii.py
@@ -2,19 +2,13 @@ from zipfile import ZipFile
 from os import path,listdir,rename
 from src.prefixes import UNII
 from src.babel_utils import pull_via_urllib
-import shutil
 
-def pull_unii(download_dir):
+def pull_unii():
     for (pullfile,originalprefix,finalname) in [('UNIIs.zip','UNII_Names','Latest_UNII_Names.txt'),
                                                 ('UNII_Data.zip','UNII_Records','Latest_UNII_Records.txt')]:
-        # This should be downloadable from the web, but since this service moved to the FDA [1], there do not appear
-        # to be direct downloadable. Instead, the user will need to download these files manually from
-        # https://precision.fda.gov/uniisearch/archive and store them in `input_data/private/UNII`.
-        # [1] https://www.nlm.nih.gov/pubs/techbull/nd21/nd21_fda_srs.html
-        # dname = pull_via_urllib('https://fdasis.nlm.nih.gov/srs/download/srs/',pullfile,decompress=False,subpath='UNII')
-        # ddir = path.dirname(dname)
-        ddir = path.join('input_data', 'private', 'UNII')
-        dname = path.join(ddir, pullfile)
+        # Downloads also available from https://precision.fda.gov/uniisearch/archive
+        dname = pull_via_urllib('https://precision.fda.gov/uniisearch/archive/latest/',pullfile,decompress=False,subpath='UNII')
+        ddir = path.dirname(dname)
         with ZipFile(dname, 'r') as zipObj:
             zipObj.extractall(ddir)
         #this zip file unzips into a readme and a file named something like "UNII_Names_<date>.txt" and we need to rename it for make
@@ -24,9 +18,6 @@ def pull_unii(download_dir):
                 original = path.join(ddir,filename)
                 final = path.join(ddir,finalname)
                 rename(original,final)
-
-                # Also copy these files to the download directory.
-                shutil.copyfile(final, path.join(download_dir, finalname))
 
 
 def make_labels_and_synonyms(inputfile,labelfile,synfile):

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -411,7 +411,7 @@ rule get_unii:
         config['download_directory']+'/UNII/Latest_UNII_Names.txt',
         config['download_directory']+'/UNII/Latest_UNII_Records.txt'
     run:
-        unii.pull_unii(config['download_directory'] + '/UNII')
+        unii.pull_unii()
 
 rule unii_labels_and_synonyms:
     input:


### PR DESCRIPTION
This PR removes the UNII files from input_data/private/ and back into babel_downloads/.

Closes #76.

WIP: precision.fda.gov returns HTTP Error 308, which urllib.request doesn't seem to be supporting correctly although [this is documented](https://docs.python.org/3/library/urllib.request.html#httpredirecthandler-objects). Needs more diagnosis, or possibly we could use another HTTP request library Just This Once.