### PR TITLE
Fix bug in HMDB metabolites with a single synonym

### DIFF
--- a/src/datahandlers/hmdb.py
+++ b/src/datahandlers/hmdb.py
@@ -16,7 +16,14 @@ def handle_metabolite(metabolite,lfile,synfile,smifile):
     lfile.write(f'{hmdbident}\t{label}\n')
     syns = metabolite['synonyms']
     if (syns is not None) and ('synonym' in syns):
-        for sname in syns['synonym']:
+
+        # In some cases, syns['synonym'] may be a single string.
+        # If so, we turn it into a single-element list.
+        synonyms_list = syns['synonym']
+        if not isinstance(synonyms_list, list):
+            synonyms_list = [synonyms_list]
+
+        for sname in synonyms_list:
             synfile.write(f'{hmdbident}\toio:exact\t{sname}\n')
     if 'smiles' in metabolite:
         smifile.write(f'{hmdbident}\t{metabolite["smiles"]}\n')


### PR DESCRIPTION
When an HMDB metabolite has a single synonym, a bug in the code caused each character from that synonym to be treated as a separate synonym (see #103). This PR fixes that by checking for that case and changing a single synonym into a one-element list.