### PR TITLE
Generate descriptions for all identifiers from UberGraph

### DIFF
--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -229,13 +229,12 @@ def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[]):
                 descs = description_factory.get_descriptions(node)
                 nw['identifiers'] = []
                 for nids in node['identifiers']:
-                    print(f"FOUND NIDS: {nids}")
                     id_info = {}
                     id_info['i'] = nids['identifier']
                     id_info['l'] = nids['label']
                     if id_info['i'] in descs:
                         # Sort from the shortest description to the longest.
-                        id_info['d'] = sorted(list(descs[id_info['i']]), key=lambda x: len(x))
+                        id_info['d'] = list(sorted(descs[id_info['i']], key=lambda x: len(x)))
                     nw['identifiers'].append(id_info)
 
                 outf.write( nw )

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -8,7 +8,7 @@ import requests
 import os
 import urllib
 import jsonlines
-from src.node import NodeFactory, SynonymFactory, InformationContentFactory
+from src.node import NodeFactory, SynonymFactory, DescriptionFactory, InformationContentFactory
 from src.util import Text
 from src.LabeledID import LabeledID
 from json import load
@@ -214,6 +214,7 @@ def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[]):
     biolink_version = config['biolink_version']
     node_factory = NodeFactory(make_local_name(''),biolink_version)
     synonym_factory = SynonymFactory(make_local_name(''))
+    description_factory = DescriptionFactory(make_local_name(''))
     ic_factory = InformationContentFactory(f'{get_config()["input_directory"]}/icRDF.tsv')
     node_test = node_factory.create_node(input_identifiers=[],node_type=node_type,labels={},extra_prefixes = extra_prefixes)
     with jsonlines.open(os.path.join(cdir,'compendia',ofname),'w') as outf, open(os.path.join(cdir,'synonyms',ofname),'w') as sfile:
@@ -225,6 +226,11 @@ def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[]):
                 if ic is not None:
                     nw['ic'] = ic
                 nw['identifiers'] = [ {k[0]:v for k,v in nids.items()} for nids in node['identifiers']]
+
+                descs = description_factory.get_descriptions(node)
+                if len(descs) > 0:
+                    nw['descriptions'] = descs
+
                 outf.write( nw )
                 synonyms = synonym_factory.get_synonyms(node)
                 if len(synonyms) > 0:

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -228,7 +228,7 @@ def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[]):
                 nw['identifiers'] = [ {k[0]:v for k,v in nids.items()} for nids in node['identifiers']]
 
                 descs = description_factory.get_descriptions(node)
-                if len(descs) > 0:
+                if descs:
                     nw['descriptions'] = descs
 
                 outf.write( nw )

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -225,11 +225,18 @@ def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[]):
                 ic = ic_factory.get_ic(node)
                 if ic is not None:
                     nw['ic'] = ic
-                nw['identifiers'] = [ {k[0]:v for k,v in nids.items()} for nids in node['identifiers']]
 
                 descs = description_factory.get_descriptions(node)
-                if descs:
-                    nw['descriptions'] = descs
+                nw['identifiers'] = []
+                for nids in node['identifiers']:
+                    print(f"FOUND NIDS: {nids}")
+                    id_info = {}
+                    id_info['i'] = nids['identifier']
+                    id_info['l'] = nids['label']
+                    if id_info['i'] in descs:
+                        # Sort from the shortest description to the longest.
+                        id_info['d'] = sorted(list(descs[id_info['i']]), key=lambda x: len(x))
+                    nw['identifiers'].append(id_info)
 
                 outf.write( nw )
                 synonyms = synonym_factory.get_synonyms(node)

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -229,12 +229,15 @@ def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[]):
                 descs = description_factory.get_descriptions(node)
                 nw['identifiers'] = []
                 for nids in node['identifiers']:
-                    id_info = {}
-                    id_info['i'] = nids['identifier']
-                    id_info['l'] = nids['label']
+                    id_info = {'i': nids['identifier']}
+
+                    if 'label' in nids:
+                        id_info['l'] = nids['label']
+
                     if id_info['i'] in descs:
                         # Sort from the shortest description to the longest.
                         id_info['d'] = list(sorted(descs[id_info['i']], key=lambda x: len(x)))
+
                     nw['identifiers'].append(id_info)
 
                 outf.write( nw )

--- a/src/datahandlers/obo.py
+++ b/src/datahandlers/obo.py
@@ -22,6 +22,22 @@ def pull_uber_labels(expected):
                 for unit in ldict[p]:
                     outf.write(f'{unit[0]}\t{unit[1]}\n')
 
+def pull_uber_descriptions(expected):
+    uber = UberGraph()
+    labels = uber.get_all_descriptions()
+    ldict = defaultdict(set)
+    for unit in labels:
+        iri = unit['iri']
+        p = iri.split(':')[0]
+        ldict[p].add( ( unit['iri'], unit['description'] ) )
+    for p in ldict:
+        if p not in ['http','ro'] and not p.startswith('t') and not '#' in p:
+            fname = make_local_name('descriptions',subpath=p)
+            with open(fname,'w') as outf:
+                for unit in ldict[p]:
+                    outf.write(f'{unit[0]}\t{unit[1]}\n')
+
+
 def pull_uber_synonyms(expected):
     uber = UberGraph()
     labels = uber.get_all_synonyms()
@@ -41,6 +57,7 @@ def pull_uber_synonyms(expected):
 
 def pull_uber(expected_ontologies):
     pull_uber_labels(expected_ontologies)
+    pull_uber_descriptions(expected_ontologies)
     pull_uber_synonyms(expected_ontologies)
 
 

--- a/src/node.py
+++ b/src/node.py
@@ -52,25 +52,25 @@ class DescriptionFactory:
 
     def load_descriptions(self,prefix):
         print(f'Loading descriptions for {prefix}')
-        descs = defaultdict(list)
+        descs = defaultdict(set)
         descfname = os.path.join(self.root_dir, prefix, 'descriptions')
         if os.path.exists(descfname):
             with open(descfname, 'r') as inf:
                 for line in inf:
                     x = line.strip().split('\t')
-                    descs[x[0]].append("\t".join(x[1:]))
+                    descs[x[0]].add("\t".join(x[1:]))
         self.descriptions[prefix] = descs
         print(f'Loaded')
 
     def get_descriptions(self,node):
-        node_descriptions = list()
+        node_descriptions = set()
         for ident in node['identifiers']:
             thisid = ident['identifier']
             pref = Text.get_curie(thisid)
             if not pref in self.descriptions:
                 self.load_descriptions(pref)
             node_descriptions.update( self.descriptions[pref][thisid] )
-        return node_descriptions
+        return list(node_descriptions)
 
 class InformationContentFactory:
     def __init__(self,ic_file):

--- a/src/node.py
+++ b/src/node.py
@@ -41,6 +41,37 @@ class SynonymFactory():
             node_synonyms.update( self.synonyms[pref][thisid] )
         return node_synonyms
 
+
+class DescriptionFactory:
+    """ A factory for loading descriptions where available.
+    """
+
+    def __init__(self,rootdir):
+        self.root_dir = rootdir
+        self.descriptions = {}
+
+    def load_descriptions(self,prefix):
+        print(f'Loading descriptions for {prefix}')
+        descs = defaultdict(set)
+        descfname = os.path.join(self.root_dir, prefix, 'descriptions')
+        if os.path.exists(descfname):
+            with open(descfname, 'r') as inf:
+                for line in inf:
+                    x = line.strip().split('\t')
+                    descs[x[0]].add("\t".join(x[1:]))
+        self.descriptions[prefix] = descs
+        print(f'Loaded')
+
+    def get_descriptions(self,node):
+        node_descriptions = set()
+        for ident in node['identifiers']:
+            thisid = ident['identifier']
+            pref = Text.get_curie(thisid)
+            if not pref in self.descriptions:
+                self.load_descriptions(pref)
+            node_descriptions.update( self.descriptions[pref][thisid] )
+        return node_descriptions
+
 class InformationContentFactory:
     def __init__(self,ic_file):
         self.ic = {}

--- a/src/node.py
+++ b/src/node.py
@@ -54,13 +54,15 @@ class DescriptionFactory:
         print(f'Loading descriptions for {prefix}')
         descs = defaultdict(set)
         descfname = os.path.join(self.root_dir, prefix, 'descriptions')
+        desc_count = 0
         if os.path.exists(descfname):
             with open(descfname, 'r') as inf:
                 for line in inf:
                     x = line.strip().split('\t')
                     descs[x[0]].add("\t".join(x[1:]))
+                    desc_count += 1
         self.descriptions[prefix] = descs
-        print(f'Loaded')
+        print(f'Loaded {desc_count} descriptions for {prefix}')
 
     def get_descriptions(self,node):
         node_descriptions = defaultdict(set)

--- a/src/node.py
+++ b/src/node.py
@@ -52,18 +52,18 @@ class DescriptionFactory:
 
     def load_descriptions(self,prefix):
         print(f'Loading descriptions for {prefix}')
-        descs = defaultdict(set)
+        descs = defaultdict(list)
         descfname = os.path.join(self.root_dir, prefix, 'descriptions')
         if os.path.exists(descfname):
             with open(descfname, 'r') as inf:
                 for line in inf:
                     x = line.strip().split('\t')
-                    descs[x[0]].add("\t".join(x[1:]))
+                    descs[x[0]].append("\t".join(x[1:]))
         self.descriptions[prefix] = descs
         print(f'Loaded')
 
     def get_descriptions(self,node):
-        node_descriptions = set()
+        node_descriptions = list()
         for ident in node['identifiers']:
             thisid = ident['identifier']
             pref = Text.get_curie(thisid)

--- a/src/node.py
+++ b/src/node.py
@@ -63,14 +63,14 @@ class DescriptionFactory:
         print(f'Loaded')
 
     def get_descriptions(self,node):
-        node_descriptions = set()
+        node_descriptions = defaultdict(set)
         for ident in node['identifiers']:
             thisid = ident['identifier']
             pref = Text.get_curie(thisid)
             if not pref in self.descriptions:
                 self.load_descriptions(pref)
-            node_descriptions.update( self.descriptions[pref][thisid] )
-        return list(node_descriptions)
+            node_descriptions[thisid].update( self.descriptions[pref][thisid] )
+        return node_descriptions
 
 class InformationContentFactory:
     def __init__(self,ic_file):

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -130,7 +130,8 @@ rule get_ontology_labels_descriptions_and_synonyms:
     output:
         expand("{download_directory}/{onto}/labels", download_directory = config['download_directory'], onto = config['ubergraph_ontologies']),
         expand("{download_directory}/{onto}/synonyms", download_directory = config['download_directory'], onto = config['ubergraph_ontologies']),
-        expand("{download_directory}/{onto}/descriptions", download_directory = config['download_directory'], onto = config['ubergraph_ontologies']),
+        # This would make sense if we had descriptions for every ontology, but since we don't, we can't make these outputs explicit.
+        # expand("{download_directory}/{onto}/descriptions", download_directory = config['download_directory'], onto = config['ubergraph_ontologies']),
     run:
         obo.pull_uber(config['ubergraph_ontologies'])
 

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -126,7 +126,7 @@ rule get_umls_labels_and_synonyms:
 
 ### OBO Ontologies
 
-rule get_ontology_labels_and_synonyms:
+rule get_ontology_labels_descriptions_and_synonyms:
     output:
         expand("{download_directory}/{onto}/labels", download_directory = config['download_directory'], onto = config['ubergraph_ontologies']),
         expand("{download_directory}/{onto}/synonyms", download_directory = config['download_directory'], onto = config['ubergraph_ontologies']),

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -129,7 +129,8 @@ rule get_umls_labels_and_synonyms:
 rule get_ontology_labels_and_synonyms:
     output:
         expand("{download_directory}/{onto}/labels", download_directory = config['download_directory'], onto = config['ubergraph_ontologies']),
-        expand("{download_directory}/{onto}/synonyms", download_directory = config['download_directory'], onto = config['ubergraph_ontologies'])
+        expand("{download_directory}/{onto}/synonyms", download_directory = config['download_directory'], onto = config['ubergraph_ontologies']),
+        expand("{download_directory}/{onto}/descriptions", download_directory = config['download_directory'], onto = config['ubergraph_ontologies']),
     run:
         obo.pull_uber(config['ubergraph_ontologies'])
 


### PR DESCRIPTION
This PR adds code to retrieve descriptions from UberGraph and incorporate them into the compendia being generated.

It generates descriptions in the format:

```json
{
  "type": "biolink:Disease",
  "ic": "100",
  "identifiers": [{"i": "UMLS:C5235953", "l": "Locally Advanced Ewing Sarcoma"}, {"i": "NCIT:C164080", "l": "Locally Advanced Ewing Sarcoma"}],
  "descriptions": ["Ewing sarcoma that has spread from its original site of growth to nearby tissues or lymph nodes."]
}
{
  "type": "biolink:Disease",
  "ic": "100",
  "identifiers": [{"i": "MONDO:0011613", "l": "autosomal recessive early-onset Parkinson disease 6"}, {"i": "DOID:0060369", "l": "Parkinson's disease 6"}, {"i": "OMIM:605909"}, {"i": "UMLS:C1853833", "l": "Parkinson Disease 6, Autosomal Recessive Early-Onset"}, {"i": "UMLS:C1970035", "l": "PARKINSON DISEASE 6, LATE-ONSET, SUSCEPTIBILITY TO"}, {"i": "MESH:C565276", "l": "Parkinson Disease 6, Autosomal Recessive Early-Onset"}, {"i": "NCIT:C184990", "l": "Parkinson Disease 6, Early Onset"}],
  "descriptions": [
    "An autosomal recessive subtype of Parkinson disease, caused by mutation(s) in the PINK1 gene, encoding serine/threonine-protein kinase PINK1, mitochondrial.",
    "Any Parkinson disease in which the cause of the disease is a mutation in the PINK1 gene."
  ]
}
```

Closes #109