### PR TITLE
Make synonym outputs explicit inputs to other rules in Snakemake

### DIFF
--- a/src/snakefiles/anatomy.snakefile
+++ b/src/snakefiles/anatomy.snakefile
@@ -113,6 +113,7 @@ rule check_cellular_component:
 rule anatomy:
     input:
         config['output_directory']+'/reports/anatomy_completeness.txt',
+        synonyms=expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['anatomy_outputs']),
         reports = expand("{od}/reports/{ap}",od=config['output_directory'], ap = config['anatomy_outputs'])
     output:
         x=config['output_directory']+'/reports/anatomy_done'

--- a/src/snakefiles/chemical.snakefile
+++ b/src/snakefiles/chemical.snakefile
@@ -262,6 +262,7 @@ rule check_chemical_mixture:
 rule chemical:
     input:
         config['output_directory']+'/reports/chemical_completeness.txt',
+        expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['chemical_outputs']),
         reports = expand("{od}/reports/{ap}",od=config['output_directory'], ap = config['chemical_outputs'])
     output:
         x=config['output_directory']+'/reports/chemicals_done'

--- a/src/snakefiles/diseasephenotype.snakefile
+++ b/src/snakefiles/diseasephenotype.snakefile
@@ -157,6 +157,7 @@ rule check_phenotypic_feature:
 rule disease:
     input:
         config['output_directory']+'/reports/disease_completeness.txt',
+        expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['disease_outputs']),
         reports = expand("{od}/reports/{ap}",od=config['output_directory'], ap = config['disease_outputs'])
     output:
         x=config['output_directory']+'/reports/disease_done'

--- a/src/snakefiles/gene.snakefile
+++ b/src/snakefiles/gene.snakefile
@@ -122,6 +122,7 @@ rule check_gene:
 rule gene:
     input:
         config['output_directory']+'/reports/gene_completeness.txt',
+        expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['gene_outputs']),
         reports = expand("{od}/reports/{ap}",od=config['output_directory'], ap = config['gene_outputs'])
     output:
         x=config['output_directory']+'/reports/gene_done'

--- a/src/snakefiles/genefamily.snakefile
+++ b/src/snakefiles/genefamily.snakefile
@@ -48,6 +48,7 @@ rule check_genefamily:
 rule genefamily:
     input:
         config['output_directory']+'/reports/genefamily_completeness.txt',
+        expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['genefamily_outputs']),
         reports = expand("{od}/reports/{ap}",od=config['output_directory'], ap = config['genefamily_outputs'])
     output:
         x=config['output_directory']+'/reports/genefamily_done'

--- a/src/snakefiles/macromolecular_complex.snakefile
+++ b/src/snakefiles/macromolecular_complex.snakefile
@@ -39,6 +39,7 @@ rule check_macromolecular_complex:
 rule macromolecular_complex:
     input:
         config['output_directory']+'/reports/macromolecular_complex_completeness.txt',
+        config['output_directory']+'/synonyms/MacromolecularComplex.txt',
         reports = config['output_directory']+'/reports/MacromolecularComplex.txt'
     output:
         x = config['output_directory']+'/reports/macromolecular_complex_done'

--- a/src/snakefiles/macromolecular_complex.snakefile
+++ b/src/snakefiles/macromolecular_complex.snakefile
@@ -7,7 +7,7 @@ rule macromolecular_complex_ids:
     output:
         outfile = config['intermediate_directory']+'/macromolecular_complex/ids/ComplexPortal'
     shell:
-        "awk '{{print $1\"\tbiolink:MacromolecularComplexMixin\"}}' {input.infile} > {output.outfile}"
+        "awk '{{print $1\"\tbiolink:MacromolecularComplex\"}}' {input.infile} > {output.outfile}"
 
 rule macromolecular_complex_compendia:
     input:
@@ -38,8 +38,8 @@ rule check_macromolecular_complex:
 
 rule macromolecular_complex:
     input:
-        config['output_directory']+'/reports/macromolecular_complex_completeness.txt',
         config['output_directory']+'/synonyms/MacromolecularComplex.txt',
+        config['output_directory']+'/reports/macromolecular_complex_completeness.txt',
         reports = config['output_directory']+'/reports/MacromolecularComplex.txt'
     output:
         x = config['output_directory']+'/reports/macromolecular_complex_done'

--- a/src/snakefiles/process.snakefile
+++ b/src/snakefiles/process.snakefile
@@ -113,6 +113,7 @@ rule check_pathway:
 rule process:
     input:
         config['output_directory']+'/reports/process_completeness.txt',
+        expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['process_outputs']),
         reports = expand("{od}/reports/{ap}",od=config['output_directory'], ap = config['process_outputs'])
     output:
         x=config['output_directory']+'/reports/process_done'

--- a/src/snakefiles/protein.snakefile
+++ b/src/snakefiles/protein.snakefile
@@ -94,6 +94,7 @@ rule check_protein:
 rule protein:
     input:
         config['output_directory']+'/reports/protein_completeness.txt',
+        expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['protein_outputs']),
         reports = expand("{od}/reports/{ap}",od=config['output_directory'], ap = config['protein_outputs'])
     output:
         x=config['output_directory']+'/reports/protein_done'

--- a/src/snakefiles/taxon.snakefile
+++ b/src/snakefiles/taxon.snakefile
@@ -72,6 +72,7 @@ rule check_taxon:
 rule taxon:
     input:
         config['output_directory']+'/reports/taxon_completeness.txt',
+        expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['taxon_outputs']),
         reports = expand("{od}/reports/{ap}",od=config['output_directory'], ap = config['taxon_outputs'])
     output:
         x=config['output_directory']+'/reports/taxon_done'


### PR DESCRIPTION
This PR adds the synonym files as inputs to the final completion task. This allows them to be regenerated simply by deleting them and re-running snakemake.

Should be merged after PR #130.