### PR TITLE
Fix capitalization bug in SynonymFactory

### DIFF
--- a/src/node.py
+++ b/src/node.py
@@ -10,6 +10,7 @@ class SynonymFactory():
     def __init__(self,syndir):
         self.synonym_dir = syndir
         self.synonyms = {}
+        print(f"Created SynonymFactory for directory {syndir}")
 
     def load_synonyms(self,prefix):
         lbs = defaultdict(set)

--- a/src/node.py
+++ b/src/node.py
@@ -12,14 +12,17 @@ class SynonymFactory():
         self.synonyms = {}
 
     def load_synonyms(self,prefix):
-        print(f'Loading {prefix}')
         lbs = defaultdict(set)
         labelfname = os.path.join(self.synonym_dir, prefix, 'labels')
+        print(f'Loading synonyms for {prefix} from {labelfname}')
+        count_labels = 0
+        count_synonyms = 0
         if os.path.exists(labelfname):
             with open(labelfname, 'r') as inf:
                 for line in inf:
                     x = line.strip().split('\t')
                     lbs[x[0]].add( ('http://www.geneontology.org/formats/oboInOwl#hasExactSynonym',x[1]) )
+                    count_labels += 1
         synfname = os.path.join(self.synonym_dir, prefix, 'synonyms')
         if os.path.exists(synfname):
             with open(synfname, 'r') as inf:
@@ -28,8 +31,9 @@ class SynonymFactory():
                     if len(x) < 3:
                         continue
                     lbs[x[0]].add( (x[1], x[2]) )
+                    count_synonyms += 1
         self.synonyms[prefix] = lbs
-        print(f'Loaded')
+        print(f'Loaded {count_labels} labels and {count_synonyms} synonyms for {prefix} from {labelfname}')
 
     def get_synonyms(self,node):
         node_synonyms = set()

--- a/src/node.py
+++ b/src/node.py
@@ -40,7 +40,7 @@ class SynonymFactory():
         node_synonyms = set()
         for ident in node['identifiers']:
             thisid = ident['identifier']
-            pref = Text.get_curie(thisid)
+            pref = Text.get_prefix(thisid)
             if not pref in self.synonyms:
                 self.load_synonyms(pref)
             node_synonyms.update( self.synonyms[pref][thisid] )


### PR DESCRIPTION
SynonymFactory uses `Text.get_curie()` to retrieve the uppercased version of the prefix, which can cause a problem when attempting to access a folder for a prefix that isn't uppercased (such as `NCBIGene`, which the current code incorrectly looks up at `babel_downloads/NCBIGENE/synonyms`). This PR replaces that with a call to `Text.get_prefix()`, which does not uppercase the prefix, and so retrieves the synonyms correctly.

There is one outstanding question, which we can fix in this PR or file as a separate issue:
- [ ] `Text.get_curie()` does in fact return the (uppercased) CURIE prefix rather than the entire CURIE. Was that the intention? If so, can we rename this to `Text.get_prefix_uppercased()` or `Text.get_prefix_uc()`?

Closes #128.