### PR TITLE
Fix GtoPdb ligands.tsv header

### DIFF
--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -196,7 +196,12 @@ def parse_smifile(infile,outfile,smicol,idcol,pref,stripquotes=False):
                 continue
             if line.startswith('"Ligand ID"'):
                 # Header line! Check, then skip.
-                assert line == '"Ligand ID"	"Name"	"Species"	"Type"	"Approved"	"Withdrawn"	"Labelled"Radioactive"	"PubChem SID"	"PubChem CID"	"UniProt ID"	"Ensembl ID"	"Ligand Subunit IDs"	"Ligand Subunit Name"	"Ligand Subunit UniProt IDs"	"Ligand Subunit Ensembl IDs"	"IUPAC name"	"INN"	"Synonyms"	"SMILES"	"InChIKey"	"InChI"	"GtoImmuPdb"	"GtoMPdb"	"Antibacterial"'
+                assert line.strip() == '"Ligand ID"	"Name"	"Species"	"Type"	"Approved"	"Withdrawn"	' \
+                                       '"Labelled"Radioactive"	"PubChem SID"	"PubChem CID"	"UniProt ID"	' \
+                                       '"Ensembl ID"	"Ligand Subunit IDs"	"Ligand Subunit Name"	"Ligand ' \
+                                       'Subunit UniProt IDs"	"Ligand Subunit Ensembl IDs"	"IUPAC name"	' \
+                                       '"INN"	"Synonyms"	"SMILES"	"InChIKey"	"InChI"	"GtoImmuPdb"	' \
+                                       '"GtoMPdb"	"Antibacterial"'
                 continue
             x = line.split('\t')
             if stripquotes:

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -197,7 +197,7 @@ def parse_smifile(infile,outfile,smicol,idcol,pref,stripquotes=False):
             if line.startswith('"Ligand ID"'):
                 # Header line! Check, then skip.
                 header = line.strip().split('\t')
-                print("header: ", header)
+                # print("header: ", header)
                 assert header == [
                     '"Ligand ID"', '"Name"', '"Species"', '"Type"', '"Approved"', '"Withdrawn"',
                     '"Labelled"', '"Radioactive"', '"PubChem SID"', '"PubChem CID"', '"UniProt ID"',

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -196,12 +196,15 @@ def parse_smifile(infile,outfile,smicol,idcol,pref,stripquotes=False):
                 continue
             if line.startswith('"Ligand ID"'):
                 # Header line! Check, then skip.
-                assert line.strip() == '"Ligand ID"	"Name"	"Species"	"Type"	"Approved"	"Withdrawn"	' \
-                                       '"Labelled"Radioactive"	"PubChem SID"	"PubChem CID"	"UniProt ID"	' \
-                                       '"Ensembl ID"	"Ligand Subunit IDs"	"Ligand Subunit Name"	"Ligand ' \
-                                       'Subunit UniProt IDs"	"Ligand Subunit Ensembl IDs"	"IUPAC name"	' \
-                                       '"INN"	"Synonyms"	"SMILES"	"InChIKey"	"InChI"	"GtoImmuPdb"	' \
-                                       '"GtoMPdb"	"Antibacterial"'
+                header = line.strip().split('\t')
+                print("header: ", header)
+                assert header == [
+                    '"Ligand ID"', '"Name"', '"Species"', '"Type"', '"Approved"', '"Withdrawn"',
+                    '"Labelled"Radioactive"', '"PubChem SID"', '"PubChem CID"', '"UniProt ID"',
+                    '"Ensembl ID"', '"Ligand Subunit IDs"', '"Ligand Subunit Name"',
+                    '"Ligand Subunit UniProt IDs"', '"Ligand Subunit Ensembl IDs"', '"IUPAC name"',
+                    '"INN"', '"Synonyms"', '"SMILES"', '"InChIKey"', '"InChI"', '"GtoImmuPdb"',
+                    '"GtoMPdb"', '"Antibacterial"']
                 continue
             x = line.split('\t')
             if stripquotes:

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -200,7 +200,7 @@ def parse_smifile(infile,outfile,smicol,idcol,pref,stripquotes=False):
                 print("header: ", header)
                 assert header == [
                     '"Ligand ID"', '"Name"', '"Species"', '"Type"', '"Approved"', '"Withdrawn"',
-                    '"Labelled"Radioactive"', '"PubChem SID"', '"PubChem CID"', '"UniProt ID"',
+                    '"Labelled"', '"Radioactive"', '"PubChem SID"', '"PubChem CID"', '"UniProt ID"',
                     '"Ensembl ID"', '"Ligand Subunit IDs"', '"Ligand Subunit Name"',
                     '"Ligand Subunit UniProt IDs"', '"Ligand Subunit Ensembl IDs"', '"IUPAC name"',
                     '"INN"', '"Synonyms"', '"SMILES"', '"InChIKey"', '"InChI"', '"GtoImmuPdb"',

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -355,7 +355,7 @@ def make_gtopdb_relations(infile,outfile):
     with open(infile,'r') as inf, open(outfile,'w') as outf:
         h = inf.readline()
         # We might have a header/version line. If so, skip to the next line.
-        if h.startswith('"## GtoPdb Version'):
+        if h.startswith('"# GtoPdb Version'):
             h = inf.readline()
         h = h.strip().split('\t')
         gid_index = h.index('"Ligand ID"')

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -191,7 +191,7 @@ def write_chemical_ids_from_labels_and_smiles(labelfile,smifile,outfile):
 def parse_smifile(infile,outfile,smicol,idcol,pref,stripquotes=False):
     with open(infile,'r') as inf, open(outfile,'w') as outf:
         for line in inf:
-            if line.startswith('"## GtoPdb Version'):
+            if line.startswith('"# GtoPdb Version'):
                 # Header line! Ignore.
                 continue
             x = line.split('\t')

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -192,7 +192,11 @@ def parse_smifile(infile,outfile,smicol,idcol,pref,stripquotes=False):
     with open(infile,'r') as inf, open(outfile,'w') as outf:
         for line in inf:
             if line.startswith('"# GtoPdb Version'):
-                # Header line! Ignore.
+                # Version line! Skip.
+                continue
+            if line.startswith('"Ligand ID"'):
+                # Header line! Check, then skip.
+                assert line == '"Ligand ID"	"Name"	"Species"	"Type"	"Approved"	"Withdrawn"	"Labelled"Radioactive"	"PubChem SID"	"PubChem CID"	"UniProt ID"	"Ensembl ID"	"Ligand Subunit IDs"	"Ligand Subunit Name"	"Ligand Subunit UniProt IDs"	"Ligand Subunit Ensembl IDs"	"IUPAC name"	"INN"	"Synonyms"	"SMILES"	"InChIKey"	"InChI"	"GtoImmuPdb"	"GtoMPdb"	"Antibacterial"'
                 continue
             x = line.split('\t')
             if stripquotes:


### PR DESCRIPTION
This PR fixes the GtoPdb ligands.tsv header, and adds an assertion to ensure that the GtoPdb ligands.tsv columns haven't changed.