### PR TITLE
Download information content values for Ubergraph terms directly from Ubergraph

### DIFF
--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -1,3 +1,4 @@
+import logging
 from ftplib import FTP
 from io import BytesIO
 import gzip
@@ -202,7 +203,7 @@ def pull_via_urllib(url: str, in_file_name: str, decompress = True, subpath=None
     # return the filename to the caller
     return out_file_name
 
-def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[]):
+def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[],icrdf_filename=None):
     """
     :param synonym_list:
     :param ofname:
@@ -210,6 +211,11 @@ def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[]):
     :param labels:
     :param extra_prefixes: We default to only allowing the prefixes allowed for a particular type in Biolink.
         If you want to allow additional prefixes, list them here.
+    :param icrdf_filename: (REQUIRED) The file to read the information content from (icRDF.tsv). Although this is a
+        named parameter to make it easier to specify this when calling write_compendium(), it is REQUIRED, and
+        write_compendium() will throw a RuntimeError if it is not specified. This is to ensure that it has been
+        properly specified as a prerequisite in a Snakemake file, so that write_compendium() is not run until after
+        icRDF.tsv has been generated.
     :return:
     """
     config = get_config()
@@ -217,7 +223,13 @@ def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[]):
     biolink_version = config['biolink_version']
     node_factory = NodeFactory(make_local_name(''),biolink_version)
     synonym_factory = SynonymFactory(make_local_name(''))
-    ic_factory = InformationContentFactory(f'{get_config()["download_directory"]}/icRDF.tsv')
+
+    # Create an InformationContentFactory based on the specified icRDF.tsv file. Default to the one in the download
+    # directory.
+    if not icrdf_filename:
+        raise RuntimeError("No icrdf_filename parameter provided to write_compendium() -- this is required!")
+    ic_factory = InformationContentFactory(icrdf_filename)
+
     node_test = node_factory.create_node(input_identifiers=[],node_type=node_type,labels={},extra_prefixes = extra_prefixes)
     with jsonlines.open(os.path.join(cdir,'compendia',ofname),'w') as outf, jsonlines.open(os.path.join(cdir,'synonyms',ofname),'w') as sfile:
         for slist in synonym_list:

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -217,7 +217,7 @@ def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[]):
     biolink_version = config['biolink_version']
     node_factory = NodeFactory(make_local_name(''),biolink_version)
     synonym_factory = SynonymFactory(make_local_name(''))
-    ic_factory = InformationContentFactory(f'{get_config()["input_directory"]}/icRDF.tsv')
+    ic_factory = InformationContentFactory(f'{get_config()["download_directory"]}/icRDF.tsv')
     node_test = node_factory.create_node(input_identifiers=[],node_type=node_type,labels={},extra_prefixes = extra_prefixes)
     with jsonlines.open(os.path.join(cdir,'compendia',ofname),'w') as outf, jsonlines.open(os.path.join(cdir,'synonyms',ofname),'w') as sfile:
         for slist in synonym_list:

--- a/src/createcompendia/anatomy.py
+++ b/src/createcompendia/anatomy.py
@@ -99,7 +99,7 @@ def build_anatomy_obo_relationships(outdir):
 def build_anatomy_umls_relationships(idfile,outfile):
     umls.build_sets(idfile, outfile, {'SNOMEDCT_US':SNOMEDCT,'MSH': MESH, 'NCI': NCIT})
 
-def build_compendia(concordances, identifiers):
+def build_compendia(concordances, identifiers, icrdf_filename):
     """:concordances: a list of files from which to read relationships
        :identifiers: a list of files from which to read identifiers and optional categories"""
     dicts = {}
@@ -122,7 +122,7 @@ def build_compendia(concordances, identifiers):
     typed_sets = create_typed_sets(set([frozenset(x) for x in dicts.values()]),types)
     for biotype,sets in typed_sets.items():
         baretype = biotype.split(':')[-1]
-        write_compendium(sets,f'{baretype}.txt',biotype,{})
+        write_compendium(sets,f'{baretype}.txt',biotype,{}, icrdf_filename=icrdf_filename)
 
 def create_typed_sets(eqsets,types):
     """Given a set of sets of equivalent identifiers, we want to type each one into

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -499,7 +499,7 @@ def build_untyped_compendia(concordances, identifiers,unichem_partial, untyped_c
         for s in untyped_sets:
             outf.write(f'{set(s)}\n')
 
-def build_compendia(type_file,untyped_compendia_file):
+def build_compendia(type_file, untyped_compendia_file, icrdf_filename):
     types = {}
     with open(type_file,'r') as inf:
         for line in inf:
@@ -513,7 +513,7 @@ def build_compendia(type_file,untyped_compendia_file):
     typed_sets = create_typed_sets(untyped_sets, types)
     for biotype, sets in typed_sets.items():
         baretype = biotype.split(':')[-1]
-        write_compendium(sets, f'{baretype}.txt', biotype, {})
+        write_compendium(sets, f'{baretype}.txt', biotype, {}, icrdf_filename=icrdf_filename)
 
 def create_typed_sets(eqsets, types):
     """

--- a/src/createcompendia/diseasephenotype.py
+++ b/src/createcompendia/diseasephenotype.py
@@ -123,7 +123,7 @@ def build_disease_doid_relationships(idfile,outfile):
                                                       'SNOMEDCT_US_2020_03_01': SNOMEDCT, 'SNOMEDCT_US_2020_09_01': SNOMEDCT,
                                                       'UMLS_CUI': UMLS, 'KEGG': KEGGDISEASE})
 
-def build_compendium(concordances, identifiers, mondoclose, badxrefs):
+def build_compendium(concordances, identifiers, mondoclose, badxrefs, icrdf_filename):
     """:concordances: a list of files from which to read relationships
        :identifiers: a list of files from which to read identifiers and optional categories"""
     dicts = {}
@@ -171,7 +171,7 @@ def build_compendium(concordances, identifiers, mondoclose, badxrefs):
     typed_sets = create_typed_sets(set([frozenset(x) for x in dicts.values()]),types)
     for biotype,sets in typed_sets.items():
         baretype = biotype.split(':')[-1]
-        write_compendium(sets,f'{baretype}.txt',biotype,{})
+        write_compendium(sets,f'{baretype}.txt',biotype,{}, icrdf_filename=icrdf_filename)
 
 def create_typed_sets(eqsets,types):
     """Given a set of sets of equivalent identifiers, we want to type each one into
@@ -228,7 +228,7 @@ def read_badxrefs(fn):
             morebad.add( (x[0],x[1]) )
     return morebad
 
-def load_diseases_and_phenotypes(concords,idlists,badhpos,badhpoxrefs):
+def load_diseases_and_phenotypes(concords,idlists,badhpos,badhpoxrefs, icrdf_filename):
     #print('disease/phenotype')
     #print('get and write hp sets')
     #bad_mappings = read_bad_hp_mappings(badhpos)
@@ -299,8 +299,8 @@ def load_diseases_and_phenotypes(concords,idlists,badhpos,badhpoxrefs):
     print('dump it')
     fs = set([frozenset(x) for x in dicts.values()])
     diseases,phenotypes = create_typed_sets(fs)
-    write_compendium(diseases,'disease.txt','biolink:Disease',labels)
-    write_compendium(phenotypes,'phenotypes.txt','biolink:PhenotypicFeature',labels)
+    write_compendium(diseases,'disease.txt','biolink:Disease',labels, icrdf_filename=icrdf_filename)
+    write_compendium(phenotypes,'phenotypes.txt','biolink:PhenotypicFeature',labels, icrdf_filename=icrdf_filename)
 
 if __name__ == '__main__':
     with open('crapfile','w') as crapfile:

--- a/src/createcompendia/gene.py
+++ b/src/createcompendia/gene.py
@@ -252,7 +252,7 @@ def build_gene_umls_hgnc_relationships(umls_idfile,outfile):
     #Could also add MESH, if that were a valid gene prefix
     umls.build_sets(umls_idfile, outfile, {'HGNC':HGNC})
 
-def build_gene_compendia(concordances, identifiers):
+def build_gene_compendia(concordances, identifiers, icrdf_filename):
     """:concordances: a list of files from which to read relationships
        :identifiers: a list of files from which to read identifiers and optional categories"""
     dicts = {}
@@ -274,5 +274,5 @@ def build_gene_compendia(concordances, identifiers):
         glom(dicts, pairs, unique_prefixes=uniques)
     gene_sets = set([frozenset(x) for x in dicts.values()])
     baretype = GENE.split(':')[-1]
-    write_compendium(gene_sets, f'{baretype}.txt', GENE, {})
+    write_compendium(gene_sets, f'{baretype}.txt', GENE, {}, icrdf_filename=icrdf_filename)
 

--- a/src/createcompendia/genefamily.py
+++ b/src/createcompendia/genefamily.py
@@ -2,7 +2,7 @@ from src.categories import GENE_FAMILY
 
 from src.babel_utils import read_identifier_file,glom,write_compendium
 
-def build_compendia(identifiers):
+def build_compendia(identifiers, icrdf_filename):
     """:concordances: a list of files from which to read relationships
        :identifiers: a list of files from which to read identifiers and optional categories"""
     dicts = {}
@@ -15,5 +15,5 @@ def build_compendia(identifiers):
         types.update(new_types)
     genefam_sets = set([frozenset(x) for x in dicts.values()])
     baretype = GENE_FAMILY.split(':')[-1]
-    write_compendium(genefam_sets, f'{baretype}.txt', GENE_FAMILY, {})
+    write_compendium(genefam_sets, f'{baretype}.txt', GENE_FAMILY, {}, icrdf_filename=icrdf_filename)
 

--- a/src/createcompendia/macromolecular_complex.py
+++ b/src/createcompendia/macromolecular_complex.py
@@ -4,7 +4,7 @@ from src.categories import MACROMOLECULAR_COMPLEX
 import src.datahandlers.complexportal as complexportal
 from src.babel_utils import read_identifier_file, glom, write_compendium
 
-def build_compendia(identifiers):
+def build_compendia(identifiers, icrdf_filename):
     """:concordances: a list of files from which to read relationships
        :identifiers: a list of files from which to read identifiers and optional categories"""
     dicts = {}
@@ -17,4 +17,4 @@ def build_compendia(identifiers):
         types.update(new_types)
     sets = set([frozenset(x) for x in dicts.values()])
     type = MACROMOLECULAR_COMPLEX.split(':')[-1]
-    write_compendium(sets, f'{type}.txt', MACROMOLECULAR_COMPLEX, {}, extra_prefixes=[COMPLEXPORTAL])
+    write_compendium(sets, f'{type}.txt', MACROMOLECULAR_COMPLEX, {}, extra_prefixes=[COMPLEXPORTAL], icrdf_filename=icrdf_filename)

--- a/src/createcompendia/processactivitypathway.py
+++ b/src/createcompendia/processactivitypathway.py
@@ -43,7 +43,7 @@ def build_process_rhea_relationships(outfile):
     rhea.make_concord(outfile)
 
 
-def build_compendia(concordances, identifiers):
+def build_compendia(concordances, identifiers, icrdf_filename):
     """:concordances: a list of files from which to read relationships
        :identifiers: a list of files from which to read identifiers and optional categories"""
     #These are concords that cause problems and are being special cased out.  In disease/process we put these in some
@@ -77,7 +77,7 @@ def build_compendia(concordances, identifiers):
     typed_sets = create_typed_sets(set([frozenset(x) for x in dicts.values()]),types)
     for biotype,sets in typed_sets.items():
         baretype = biotype.split(':')[-1]
-        write_compendium(sets,f'{baretype}.txt',biotype,{})
+        write_compendium(sets,f'{baretype}.txt',biotype,{}, icrdf_filename=icrdf_filename)
 
 def create_typed_sets(eqsets,types):
     """Given a set of sets of equivalent identifiers, we want to type each one into

--- a/src/createcompendia/protein.py
+++ b/src/createcompendia/protein.py
@@ -161,5 +161,5 @@ def build_protein_compendia(concordances, identifiers, icrdf_filename):
     # only then generate the compendium from those input files.
 
     baretype = PROTEIN.split(':')[-1]
-    write_compendium(gene_sets, f'{baretype}.txt', PROTEIN, {}, icrdf_filename)
+    write_compendium(gene_sets, f'{baretype}.txt', PROTEIN, {}, icrdf_filename=icrdf_filename)
 

--- a/src/createcompendia/protein.py
+++ b/src/createcompendia/protein.py
@@ -126,7 +126,7 @@ def build_ncit_uniprot_relationships(infile,outfile):
 def build_umls_ncit_relationships(idfile,outfile):
     umls.build_sets(idfile, outfile, {'NCI': NCIT})
 
-def build_protein_compendia(concordances, identifiers):
+def build_protein_compendia(concordances, identifiers, icrdf_filename):
     """:concordances: a list of files from which to read relationships
        :identifiers: a list of files from which to read identifiers and optional categories"""
     dicts = {}
@@ -161,5 +161,5 @@ def build_protein_compendia(concordances, identifiers):
     # only then generate the compendium from those input files.
 
     baretype = PROTEIN.split(':')[-1]
-    write_compendium(gene_sets, f'{baretype}.txt', PROTEIN, {})
+    write_compendium(gene_sets, f'{baretype}.txt', PROTEIN, {}, icrdf_filename)
 

--- a/src/createcompendia/taxon.py
+++ b/src/createcompendia/taxon.py
@@ -82,7 +82,7 @@ def build_relationships(outfile,mesh_ids):
 
 
 
-def build_compendia(concordances, identifiers):
+def build_compendia(concordances, identifiers, icrdf_filename):
     """:concordances: a list of files from which to read relationships
        :identifiers: a list of files from which to read identifiers and optional categories"""
     dicts = {}
@@ -106,5 +106,5 @@ def build_compendia(concordances, identifiers):
     baretype = ORGANISM_TAXON.split(':')[-1]
     # We need to use extra_prefixes since UMLS is not listed as an identifier prefix at
     # https://biolink.github.io/biolink-model/docs/OrganismTaxon.html
-    write_compendium(gene_sets, f'{baretype}.txt', ORGANISM_TAXON, {})
+    write_compendium(gene_sets, f'{baretype}.txt', ORGANISM_TAXON, {}, icrdf_filename=icrdf_filename)
 

--- a/src/datahandlers/obo.py
+++ b/src/datahandlers/obo.py
@@ -6,13 +6,12 @@ from json import loads,dumps
 
 from src.util import Text
 
-def pull_uber_icRDF():
+def pull_uber_icRDF(icrdf_filename):
     """
     Download the icRDF.tsv file that contains normalizedInformationContent for all the entities in UberGraph.
     """
     uber = UberGraph()
-    config = get_config()
-    _ = uber.write_normalized_information_content(os.path.join(config['download_directory'], 'icRDF.tsv'))
+    _ = uber.write_normalized_information_content(icrdf_filename)
 
 def pull_uber_labels(expected):
     uber = UberGraph()
@@ -46,8 +45,8 @@ def pull_uber_synonyms(expected):
                 for unit in ldict[p]:
                     outf.write(f'{unit[0]}\t{unit[1]}\t{unit[2]}\n')
 
-def pull_uber(expected_ontologies):
-    pull_uber_icRDF()
+def pull_uber(expected_ontologies, icrdf_filename):
+    pull_uber_icRDF(icrdf_filename)
     pull_uber_labels(expected_ontologies)
     pull_uber_synonyms(expected_ontologies)
 

--- a/src/datahandlers/obo.py
+++ b/src/datahandlers/obo.py
@@ -1,11 +1,18 @@
 from src.ubergraph import UberGraph
-from src.babel_utils import make_local_name, pull_via_ftp
+from src.babel_utils import make_local_name, pull_via_ftp, get_config
 from collections import defaultdict
 import os, gzip
 from json import loads,dumps
 
 from src.util import Text
 
+def pull_uber_icRDF():
+    """
+    Download the icRDF.tsv file that contains normalizedInformationContent for all the entities in UberGraph.
+    """
+    uber = UberGraph()
+    config = get_config()
+    _ = uber.write_normalized_information_content(os.path.join(config['download_directory'], 'icRDF.tsv'))
 
 def pull_uber_labels(expected):
     uber = UberGraph()
@@ -40,6 +47,7 @@ def pull_uber_synonyms(expected):
                     outf.write(f'{unit[0]}\t{unit[1]}\t{unit[2]}\n')
 
 def pull_uber(expected_ontologies):
+    pull_uber_icRDF()
     pull_uber_labels(expected_ontologies)
     pull_uber_synonyms(expected_ontologies)
 

--- a/src/node.py
+++ b/src/node.py
@@ -52,8 +52,8 @@ class InformationContentFactory:
         with open(ic_file, 'r') as inf:
             for line in inf:
                 x = line.strip().split('\t')
-                node_id = Text.obo_to_curie(x[0][:-1]) # -1 takes off the >
-                ic = x[2]
+                node_id = Text.obo_to_curie(x[0])
+                ic = x[1]
                 self.ic[node_id] = ic
             print(f"Loaded {len(self.ic)} InformationContent values")
 

--- a/src/snakefiles/anatomy.snakefile
+++ b/src/snakefiles/anatomy.snakefile
@@ -64,11 +64,12 @@ rule anatomy_compendia:
         synonyms=expand("{dd}/{ap}/synonyms",dd=config['download_directory'],ap=config['anatomy_prefixes']),
         concords=expand("{dd}/anatomy/concords/{ap}",dd=config['intermediate_directory'],ap=config['anatomy_concords']),
         idlists=expand("{dd}/anatomy/ids/{ap}",dd=config['intermediate_directory'],ap=config['anatomy_ids']),
+        icrdf_filename=config['download_directory']+'/icRDF.tsv',
     output:
         expand("{od}/compendia/{ap}", od = config['output_directory'], ap = config['anatomy_outputs']),
         expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['anatomy_outputs'])
     run:
-        anatomy.build_compendia(input.concords,input.idlists)
+        anatomy.build_compendia(input.concords, input.idlists, input.icrdf_filename)
 
 rule check_anatomy_completeness:
     input:

--- a/src/snakefiles/chemical.snakefile
+++ b/src/snakefiles/chemical.snakefile
@@ -196,11 +196,12 @@ rule chemical_compendia:
     input:
         typesfile    = config['intermediate_directory'] + '/chemicals/partials/types',
         untyped_file = config['intermediate_directory'] + '/chemicals/partials/untyped_compendium',
+        icrdf_filename = config['download_directory'] + '/icRDF.tsv',
     output:
         expand("{od}/compendia/{ap}", od = config['output_directory'], ap = config['chemical_outputs']),
         expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['chemical_outputs'])
     run:
-        chemicals.build_compendia(input.typesfile,input.untyped_file)
+        chemicals.build_compendia(input.typesfile,input.untyped_file, input.icrdf_filename)
 
 rule check_chemical_completeness:
     input:

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -147,7 +147,8 @@ rule get_umls_labels_and_synonyms:
 rule get_ontology_labels_and_synonyms:
     output:
         expand("{download_directory}/{onto}/labels", download_directory = config['download_directory'], onto = config['ubergraph_ontologies']),
-        expand("{download_directory}/{onto}/synonyms", download_directory = config['download_directory'], onto = config['ubergraph_ontologies'])
+        expand("{download_directory}/{onto}/synonyms", download_directory = config['download_directory'], onto = config['ubergraph_ontologies']),
+        config['download_directory']+'/icRDF.tsv'
     run:
         obo.pull_uber(config['ubergraph_ontologies'])
 

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -150,7 +150,7 @@ rule get_ontology_labels_and_synonyms:
         expand("{download_directory}/{onto}/synonyms", download_directory = config['download_directory'], onto = config['ubergraph_ontologies']),
         icrdf_filename = config['download_directory']+'/icRDF.tsv'
     run:
-        obo.pull_uber(config['ubergraph_ontologies'], icrdf_filename)
+        obo.pull_uber(config['ubergraph_ontologies'], output.icrdf_filename)
 
 ### NCBIGene
 

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -148,9 +148,9 @@ rule get_ontology_labels_and_synonyms:
     output:
         expand("{download_directory}/{onto}/labels", download_directory = config['download_directory'], onto = config['ubergraph_ontologies']),
         expand("{download_directory}/{onto}/synonyms", download_directory = config['download_directory'], onto = config['ubergraph_ontologies']),
-        config['download_directory']+'/icRDF.tsv'
+        icrdf_filename = config['download_directory']+'/icRDF.tsv'
     run:
-        obo.pull_uber(config['ubergraph_ontologies'])
+        obo.pull_uber(config['ubergraph_ontologies'], icrdf_filename)
 
 ### NCBIGene
 

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -148,7 +148,7 @@ rule get_ontology_labels_and_synonyms:
     output:
         expand("{download_directory}/{onto}/labels", download_directory = config['download_directory'], onto = config['ubergraph_ontologies']),
         expand("{download_directory}/{onto}/synonyms", download_directory = config['download_directory'], onto = config['ubergraph_ontologies']),
-        icrdf_filename = config['download_directory']+'/icRDF.tsv'
+        icrdf_filename = config['download_directory']+'/icRDF.tsv',
     run:
         obo.pull_uber(config['ubergraph_ontologies'], output.icrdf_filename)
 

--- a/src/snakefiles/diseasephenotype.snakefile
+++ b/src/snakefiles/diseasephenotype.snakefile
@@ -122,13 +122,14 @@ rule disease_compendia:
         synonyms=expand("{dd}/{ap}/synonyms",dd=config['download_directory'],ap=config['disease_labelsandsynonyms']),
         concords=expand("{dd}/disease/concords/{ap}",dd=config['intermediate_directory'],ap=config['disease_concords']),
         idlists=expand("{dd}/disease/ids/{ap}",dd=config['intermediate_directory'],ap=config['disease_ids']),
+        icrdf_filename = config['download_directory'] + '/icRDF.tsv',
     output:
         expand("{od}/compendia/{ap}", od = config['output_directory'], ap = config['disease_outputs']),
         expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['disease_outputs'])
     run:
         diseasephenotype.build_compendium(input.concords,input.idlists,input.close_matches,{'HP':input.bad_hpo_xrefs,
                                                                         'MONDO':input.bad_mondo_xrefs,
-                                                                        'UMLS':input.bad_umls_xrefs} )
+                                                                        'UMLS':input.bad_umls_xrefs}, input.icrdf_filename )
 
 rule check_disease_completeness:
     input:

--- a/src/snakefiles/gene.snakefile
+++ b/src/snakefiles/gene.snakefile
@@ -97,11 +97,12 @@ rule gene_compendia:
         synonyms=expand("{dd}/{ap}/synonyms",dd=config['download_directory'],ap=config['gene_labels']),
         concords=expand("{dd}/gene/concords/{ap}",dd=config['intermediate_directory'],ap=config['gene_concords']),
         idlists=expand("{dd}/gene/ids/{ap}",dd=config['intermediate_directory'],ap=config['gene_ids']),
+        icrdf_filename=config['download_directory']+'/icRDF.tsv',
     output:
         expand("{od}/compendia/{ap}", od = config['output_directory'], ap = config['gene_outputs']),
         expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['gene_outputs'])
     run:
-        gene.build_gene_compendia(input.concords,input.idlists)
+        gene.build_gene_compendia(input.concords,input.idlists, input.icrdf_filename)
 
 rule check_gene_completeness:
     input:

--- a/src/snakefiles/genefamily.snakefile
+++ b/src/snakefiles/genefamily.snakefile
@@ -23,11 +23,12 @@ rule genefamily_compendia:
     input:
         labels=expand("{dd}/{ap}/labels",dd=config['download_directory'],ap=config['genefamily_labels']),
         idlists=expand("{dd}/genefamily/ids/{ap}",dd=config['intermediate_directory'],ap=config['genefamily_ids']),
+        icrdf_filename=config['download_directory'] + '/icRDF.tsv',
     output:
         expand("{od}/compendia/{ap}", od = config['output_directory'], ap = config['genefamily_outputs']),
         expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['genefamily_outputs'])
     run:
-        genefamily.build_compendia(input.idlists)
+        genefamily.build_compendia(input.idlists, input.icrdf_filename)
 
 rule check_genefamily_completeness:
     input:

--- a/src/snakefiles/macromolecular_complex.snakefile
+++ b/src/snakefiles/macromolecular_complex.snakefile
@@ -14,11 +14,12 @@ rule macromolecular_complex_compendia:
         labels = config['download_directory']+'/ComplexPortal/559292_labels.tsv',
         synonyms = config['download_directory']+'/ComplexPortal/559292_synonyms.tsv',
         idlists = config['intermediate_directory']+'/macromolecular_complex/ids/ComplexPortal',
+        icrdf_filename = config['download_directory'] + '/icRDF.tsv',
     output:
         config['output_directory']+'/compendia/MacromolecularComplex.txt',
         config['output_directory']+'/synonyms/MacromolecularComplex.txt'
     run:
-        macromolecular_complex.build_compendia([input.idlists])
+        macromolecular_complex.build_compendia([input.idlists], icrdf_filename=icrdf_filename)
 
 rule check_macromolecular_complex_completeness:
     input:

--- a/src/snakefiles/macromolecular_complex.snakefile
+++ b/src/snakefiles/macromolecular_complex.snakefile
@@ -19,7 +19,7 @@ rule macromolecular_complex_compendia:
         config['output_directory']+'/compendia/MacromolecularComplex.txt',
         config['output_directory']+'/synonyms/MacromolecularComplex.txt'
     run:
-        macromolecular_complex.build_compendia([input.idlists], icrdf_filename=icrdf_filename)
+        macromolecular_complex.build_compendia([input.idlists], icrdf_filename=input.icrdf_filename)
 
 rule check_macromolecular_complex_completeness:
     input:

--- a/src/snakefiles/process.snakefile
+++ b/src/snakefiles/process.snakefile
@@ -72,11 +72,12 @@ rule process_compendia:
         #synonyms=expand("{dd}/{ap}/synonyms",dd=config['download_directory'],ap=config['process_labelsandsynonyms']),
         concords=expand("{dd}/process/concords/{ap}",dd=config['intermediate_directory'],ap=config['process_concords']),
         idlists=expand("{dd}/process/ids/{ap}",dd=config['intermediate_directory'],ap=config['process_ids']),
+        icrdf_filename=config['download_directory']+'/icRDF.tsv',
     output:
         expand("{od}/compendia/{ap}", od = config['output_directory'], ap = config['process_outputs']),
         expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['process_outputs'])
     run:
-        pap.build_compendia(input.concords,input.idlists)
+        pap.build_compendia(input.concords,input.idlists,input.icrdf_filename)
 
 rule check_process_completeness:
     input:

--- a/src/snakefiles/protein.snakefile
+++ b/src/snakefiles/protein.snakefile
@@ -69,11 +69,12 @@ rule protein_compendia:
         synonyms=expand("{dd}/{ap}/synonyms",dd=config['download_directory'],ap=config['protein_synonyms']),
         concords=expand("{dd}/protein/concords/{ap}",dd=config['intermediate_directory'],ap=config['protein_concords']),
         idlists=expand("{dd}/protein/ids/{ap}",dd=config['intermediate_directory'],ap=config['protein_ids']),
+        icrdf_filename=config['download_directory'] + '/icRDF.tsv',
     output:
         expand("{od}/compendia/{ap}", od = config['output_directory'], ap = config['protein_outputs']),
         expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['protein_outputs'])
     run:
-        protein.build_protein_compendia(input.concords,input.idlists)
+        protein.build_protein_compendia(input.concords,input.idlists, input.icrdf_filename)
 
 rule check_protein_completeness:
     input:

--- a/src/snakefiles/taxon.snakefile
+++ b/src/snakefiles/taxon.snakefile
@@ -47,11 +47,12 @@ rule taxon_compendia:
         synonyms=expand("{dd}/{ap}/synonyms",dd=config['download_directory'],ap=config['taxon_synonyms']),
         concords=expand("{dd}/taxon/concords/{ap}",dd=config['intermediate_directory'],ap=config['taxon_concords']),
         idlists=expand("{dd}/taxon/ids/{ap}",dd=config['intermediate_directory'],ap=config['taxon_ids']),
+        icrdf_filename=config['download_directory'] + '/icRDF.tsv',
     output:
         expand("{od}/compendia/{ap}", od = config['output_directory'], ap = config['taxon_outputs']),
         expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['taxon_outputs'])
     run:
-        taxon.build_compendia(input.concords,input.idlists)
+        taxon.build_compendia(input.concords,input.idlists, input.icrdf_filename)
 
 rule check_taxon_completeness:
     input:

--- a/src/ubergraph.py
+++ b/src/ubergraph.py
@@ -350,6 +350,22 @@ class UberGraph:
             results[k] = list(filter(lambda x: ':' in x, v))
         return results
 
+    def write_normalized_information_content(self, filename):
+        """
+        Download the normalized information content and write it to the specified filename.
+
+        :param filename: The filename to write the normalized information content to -- we write them as `IRI\tNIC`.
+        :return: The number of normalized information content entries downloaded.
+        """
+        query = "SELECT * WHERE { ?iri <http://reasoner.renci.org/vocab/normalizedInformationContent> ?nic }"
+        resultmap = self.triplestore.query(query, ['iri', 'nic'])
+
+        with open(filename, "w") as ftsv:
+            for row in resultmap:
+                ftsv.write(f"{row['iri']}\t{row['nic']}\n")
+
+        print(f"Wrote {len(resultmap)} information content values into {filename}.")
+        return len(resultmap)
 
 def build_sets(iri, concordfiles, set_type, ignore_list = [], other_prefixes={}, hop_ontologies=False ):
     """Given an IRI create a list of sets.  Each set is a set of equivalent LabeledIDs, and there
@@ -376,6 +392,7 @@ def build_sets(iri, concordfiles, set_type, ignore_list = [], other_prefixes={},
                 p = Text.get_curie(k)
                 if p in concordfiles:
                     concordfiles[p].write(f'{k}\t{types2relations[set_type]}\t{x}\n')
+
 
 if __name__ == '__main__':
     ug = UberGraph()

--- a/src/ubergraph.py
+++ b/src/ubergraph.py
@@ -357,15 +357,28 @@ class UberGraph:
         :param filename: The filename to write the normalized information content to -- we write them as `IRI\tNIC`.
         :return: The number of normalized information content entries downloaded.
         """
-        query = "SELECT * WHERE { ?iri <http://reasoner.renci.org/vocab/normalizedInformationContent> ?nic }"
-        resultmap = self.triplestore.query(query, ['iri', 'nic'])
+        count_query = "SELECT (COUNT(*) AS ?count) WHERE { ?iri <http://reasoner.renci.org/vocab/normalizedInformationContent> ?nic }"
+        count_result = self.triplestore.query(count_query, ['count'])
+        total_count = int(count_result[0]['count'])
 
+        assert total_count > 0
+
+        write_count = 0
         with open(filename, "w") as ftsv:
-            for row in resultmap:
-                ftsv.write(f"{row['iri']}\t{row['nic']}\n")
+            for start in range(0, total_count, UberGraph.QUERY_BATCH_SIZE):
+                print(f"Querying write_normalized_information_content() offset {start} limit {UberGraph.QUERY_BATCH_SIZE} (total count: {total_count})")
 
-        print(f"Wrote {len(resultmap)} information content values into {filename}.")
-        return len(resultmap)
+                query = "SELECT ?iri ?nic WHERE " \
+                        "{ ?iri <http://reasoner.renci.org/vocab/normalizedInformationContent> ?nic }" \
+                        f"ORDER BY ASC(?iri) OFFSET {start} LIMIT {UberGraph.QUERY_BATCH_SIZE}"
+                results = self.triplestore.query(query, ['iri', 'nic'])
+
+                for row in results:
+                    ftsv.write(f"{row['iri']}\t{row['nic']}\n")
+                    write_count += 1
+
+        print(f"Wrote {write_count} information content values into {filename}.")
+        return write_count
 
 def build_sets(iri, concordfiles, set_type, ignore_list = [], other_prefixes={}, hop_ontologies=False ):
     """Given an IRI create a list of sets.  Each set is a set of equivalent LabeledIDs, and there


### PR DESCRIPTION
We previously had a local copy of this download -- the `input_data/icRDF.tsv` file -- which had to be updated manually. This PR generates a new version of this file -- at `babel_downloads/icRDF.tsv` by downloading all the values from Ubergraph and then uses them as needed during compendium writing.

Closes #123.