### PR TITLE
Fix UNII download

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ strong dependencies against the Babel code.
 
 ## Configuration
 
-Babel requires Python 3.11 or later.
-
 Before running, edit `config.json` and set the `babel_downloads` and `babel_output` directories.  Do not edit the
 remaining items, which are used to control the build process.
 

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -162,7 +162,7 @@ def write_drugbank_ids(infile,outfile):
     written = set()
     with open(infile,'r') as inf, open(outfile,'w') as outf:
         header_line = inf.readline()
-        assert(header_line == "UCI\tSRC_ID\tSRC_COMPOUND_ID\tASSIGNMENT\n", f"Incorrect header line in {infile}: {header_line}")
+        assert header_line == "UCI\tSRC_ID\tSRC_COMPOUND_ID\tASSIGNMENT\n", f"Incorrect header line in {infile}: {header_line}"
         for line in inf:
             x = line.rstrip().split('\t')
             if x[1] == drugbank_id:
@@ -229,11 +229,11 @@ def write_unichem_concords(structfile,reffile,outdir):
         concfiles[num] = open(concname,'w')
     with open(reffile,'rt') as inf:
         header_line = inf.readline()
-        assert(header_line == "UCI\tSRC_ID\tSRC_COMPOUND_ID\tASSIGNMENT\n", f"Incorrect header line in {reffile}: {header_line}")
+        assert header_line == "UCI\tSRC_ID\tSRC_COMPOUND_ID\tASSIGNMENT\n", f"Incorrect header line in {reffile}: {header_line}"
         for line in inf:
             x = line.rstrip().split('\t')
             outf = concfiles[x[1]]
-            assert(x[3] == '1') # Only '1' (current) assignments should be in this file
+            assert x[3] == '1'  # Only '1' (current) assignments should be in this file
                                 # (see https://chembl.gitbook.io/unichem/definitions/what-is-an-assignment).
             outf.write(f'{unichem_data_sources[x[1]]}:{x[2]}\toio:equivalent\t{inchikeys[x[0]]}\n')
     for outf in concfiles.values():
@@ -244,7 +244,7 @@ def read_inchikeys(struct_file):
     inchikeys = {}
     with gzip.open(struct_file, 'rt') as inf:
         header_line = inf.readline()
-        assert(header_line == "UCI\tSTANDARDINCHI\tSTANDARDINCHIKEY\n", f"Unexpected header line in {struct_file}: {header_line}")
+        assert header_line == "UCI\tSTANDARDINCHI\tSTANDARDINCHIKEY\n", f"Unexpected header line in {struct_file}: {header_line}"
         for sline in inf:
             line = sline.rstrip().split('\t')
             if len(line) == 0:

--- a/src/datahandlers/unii.py
+++ b/src/datahandlers/unii.py
@@ -20,7 +20,7 @@ def pull_unii():
             for chunk in response.iter_content(chunk_size=8192):
                 f.write(chunk)
         ddir = path.dirname(local_filename)
-        with ZipFile(dname, 'r') as zipObj:
+        with ZipFile(local_filename, 'r') as zipObj:
             zipObj.extractall(ddir)
         #this zip file unzips into a readme and a file named something like "UNII_Names_<date>.txt" and we need to rename it for make
         files = listdir(ddir)


### PR DESCRIPTION
This PR fixes two bugs in UNII downloads:
1. I accidentally used `assert(a == b)` in a few places. This is incorrect, since technically you are asserting a tuple `(a == b,)`. I've replaced it with the correct `assert a == b`.
2. I've been annoyed that we need Python 3.11 to get `pull_via_urllib()` to support HTTP 308 responses. This PR replaces that with a call to `requests.get()`, which can work on earlier Python versions.