### PR TITLE
Adds a `shortest_name_length` value to the synonyms file

### DIFF
--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -1,3 +1,4 @@
+import logging
 from ftplib import FTP
 from io import BytesIO
 import gzip
@@ -255,6 +256,19 @@ def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[]):
                                 "types": [ t[8:] for t in node_factory.get_ancestors(node["type"])]} #remove biolink:
                     if "label" in node["identifiers"][0]:
                         document["preferred_name"] = node["identifiers"][0]["label"]
+
+                    # We previously used the shortest length of a name as a proxy for how good a match it is, i.e. given
+                    # two concepts that both have the word "acetaminophen" in them, we assume that the shorter one is the
+                    # more interesting one for users. I'm not sure if there's a better way to do that -- for instance,
+                    # could we consider the information content values? -- but in the interests of getting something
+                    # working quickly, this code restores that previous method.
+
+                    # Since synonyms_list is sorted,
+                    if len(synonyms_list) == 0:
+                        logging.warning(f"Synonym list for {node} is empty: no valid name.")
+                    else:
+                        document["shortest_name_length"] = len(synonyms_list[0])
+
                     sfile.write( document )
                 except Exception as ex:
                     print(f"Exception thrown while write_compendium() was generating {ofname}: {ex}")


### PR DESCRIPTION
This restores the previously used sorting method as per https://github.com/TranslatorSRI/NameResolution/issues/65#issuecomment-1610056843.

WIP