### PR TITLE
Increased storage on Babel

### DIFF
--- a/kubernetes/babel-downloads.k8s.yaml
+++ b/kubernetes/babel-downloads.k8s.yaml
@@ -13,5 +13,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 500Gi
+      storage: 600Gi
   storageClassName: basic

--- a/kubernetes/babel-outputs.k8s.yaml
+++ b/kubernetes/babel-outputs.k8s.yaml
@@ -15,5 +15,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 300Gi
+      storage: 400Gi
   storageClassName: basic


### PR DESCRIPTION
This PR increases storage on Kubernetes. This is probably not strictly necessary, especially if we could Gzip all output files (#125). But for now this is the quickest way forward.