### PR TITLE
Added a test to warn on short names

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,6 @@
 {
+  "warn_on_short_names": 3,
+
   "input_directory": "input_data",
   "download_directory": "babel_downloads",
   "intermediate_directory": "babel_outputs/intermediate",

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -261,7 +261,10 @@ def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[],i
                 # But we're only interested in the synonyms themselves, so we can skip the relationship for now.
                 curie = node["identifiers"][0]["identifier"]
                 synonyms = [result[1] for result in synonym_factory.get_synonyms(node)]
-                synonyms_list = sorted(synonyms,key=lambda x:len(x))
+                # Why are we running the synonym list through set() again? Because get_synonyms returns unique pairs of (relation, synonym).
+                # So multiple identical synonyms may be returned as long they have a different relation. But since we don't care about the
+                # relation, we should get rid of any duplicated synonyms here.
+                synonyms_list = sorted(set(synonyms), key=lambda x:len(x))
                 try:
                     document = {"curie": curie,
                                 "names": synonyms_list,

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -259,15 +259,21 @@ def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[],i
 
                 # get_synonyms() returns tuples in the form ('http://www.geneontology.org/formats/oboInOwl#hasExactSynonym', 'Caudal articular process of eighteenth thoracic vertebra')
                 # But we're only interested in the synonyms themselves, so we can skip the relationship for now.
+                curie = node["identifiers"][0]["identifier"]
                 synonyms = [result[1] for result in synonym_factory.get_synonyms(node)]
                 synonyms_list = sorted(synonyms,key=lambda x:len(x))
                 try:
-                    document = {"curie": node["identifiers"][0]["identifier"],
+                    document = {"curie": curie,
                                 "names": synonyms_list,
                                 "types": [ t[8:] for t in node_factory.get_ancestors(node["type"])]} #remove biolink:
 
                     if "label" in node["identifiers"][0]:
                         document["preferred_name"] = node["identifiers"][0]["label"]
+
+                    # Warn about very short names.
+                    short_names = list(filter(lambda s: len(s) <= config['warn_on_short_names'], synonyms_list))
+                    if len(short_names) > 0:
+                        logging.warning(f"CURIE {curie} has very short names: {short_names}")
 
                     # We previously used the shortest length of a name as a proxy for how good a match it is, i.e. given
                     # two concepts that both have the word "acetaminophen" in them, we assume that the shorter one is the


### PR DESCRIPTION
This PR adds a warning for short names in the list of synonyms for a CURIE, as this could be a sign of incorrect synonyms being included in Babel. Also: we sometimes get duplicate synonyms, which I've just realized is because `synonym_factory.get_synonyms()` only ensures that `(relation, synonym)` tuples are unique. I've added a `set()` to ensure that the actual synonyms are unique, too.