### PR TITLE
Export information content in synonym files

### DIFF
--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -278,6 +278,11 @@ def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[],i
                     if len(short_names) > 0:
                         logging.warning(f"CURIE {curie} has very short names: {short_names}")
 
+                    # The information content value may be useful in generating synonyms. Let's integrate
+                    # that into the synonym information.
+                    if 'ic' in node:
+                        document["ic"] = node["ic"]
+
                     # We previously used the shortest length of a name as a proxy for how good a match it is, i.e. given
                     # two concepts that both have the word "acetaminophen" in them, we assume that the shorter one is the
                     # more interesting one for users. I'm not sure if there's a better way to do that -- for instance,

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -280,8 +280,8 @@ def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[],i
 
                     # The information content value may be useful in generating synonyms. Let's integrate
                     # that into the synonym information.
-                    if 'ic' in node:
-                        document["ic"] = node["ic"]
+                    if ic is not None:
+                        document["ic"] = ic
 
                     # We previously used the shortest length of a name as a proxy for how good a match it is, i.e. given
                     # two concepts that both have the word "acetaminophen" in them, we assume that the shorter one is the


### PR DESCRIPTION
As per https://github.com/TranslatorSRI/NameResolution/issues/72#issue-1782935627, we should try to see if we can use the information content values for cliques to improve sorting. This PR adds the information content value to the synonym export.

Should be merged after PR #134.