### PR TITLE
Fix synonym uniquification

### DIFF
--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -261,7 +261,10 @@ def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[],i
                 # But we're only interested in the synonyms themselves, so we can skip the relationship for now.
                 curie = node["identifiers"][0]["identifier"]
                 synonyms = [result[1] for result in synonym_factory.get_synonyms(node)]
-                synonyms_list = sorted(synonyms,key=lambda x:len(x))
+                # Why are we running the synonym list through set() again? Because get_synonyms returns unique pairs of (relation, synonym).
+                # So multiple identical synonyms may be returned as long they have a different relation. But since we don't care about the
+                # relation, we should get rid of any duplicated synonyms here.
+                synonyms_list = sorted(set(synonyms), key=lambda x:len(x))
                 try:
                     document = {"curie": curie,
                                 "names": synonyms_list,


### PR DESCRIPTION
We sometimes get duplicate synonyms in the output, which I've realized is because `synonym_factory.get_synonyms()` only ensures that `(relation, synonym)` tuples are unique. I've added a `set()` to ensure that the actual synonyms are unique, too. (Split off from PR #165).

Should be merged after PR #166.