### PR TITLE
Improve conflation

### DIFF
--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -224,7 +224,7 @@ def build_pubchem_relationships(infile,outfile):
             for cid in cids:
                 outf.write(f"{RXCUI}:{rxnid}\tlinked\t{PUBCHEMCOMPOUND}:{cid}\n")
 
-def build_conflation(rxn_concord,pubchem_rxn_concord,drug_compendium,chemical_compendia,outfilename):
+def build_conflation(rxn_concord,umls_concord,pubchem_rxn_concord,drug_compendium,chemical_compendia,outfilename):
     """RXN_concord contains relationshps between rxcuis that can be used to conflate
     Now we don't want all of them.  We want the ones that are between drugs and chemicals,
     and the ones between drugs and drugs.
@@ -240,28 +240,29 @@ def build_conflation(rxn_concord,pubchem_rxn_concord,drug_compendium,chemical_co
         print(f"load {chemical_compendium}")
         chemical_rxcui_to_clique.update(load_cliques(chemical_compendium))
     pairs = []
-    with open(rxn_concord,"r") as infile:
-        for line in infile:
-            x = line.strip().split('\t')
-            subject = x[0]
-            object = x[2]
-            if subject in drug_rxcui_to_clique and object in chemical_rxcui_to_clique:
-                subject = drug_rxcui_to_clique[subject]
-                object = chemical_rxcui_to_clique[object]
-                pairs.append( (subject,object) )
-            elif subject in chemical_rxcui_to_clique and object in drug_rxcui_to_clique:
-                subject = chemical_rxcui_to_clique[subject]
-                object = drug_rxcui_to_clique[object]
-                pairs.append( (subject,object) )
-            # OK, this is possible, and it's OK, as long as we get real clique leaders
-            elif subject in drug_rxcui_to_clique and object in drug_rxcui_to_clique:
-                subject = drug_rxcui_to_clique[subject]
-                object = drug_rxcui_to_clique[object]
-                pairs.append( (subject,object) )
-            elif subject in chemical_rxcui_to_clique and object in chemical_rxcui_to_clique:
-                subject = chemical_rxcui_to_clique[subject]
-                object = chemical_rxcui_to_clique[object]
-                pairs.append( (subject,object) )
+    for concfile in [rxn_concord,umls_concord]:
+        with open(concfile,"r") as infile:
+            for line in infile:
+                x = line.strip().split('\t')
+                subject = x[0]
+                object = x[2]
+                if subject in drug_rxcui_to_clique and object in chemical_rxcui_to_clique:
+                    subject = drug_rxcui_to_clique[subject]
+                    object = chemical_rxcui_to_clique[object]
+                    pairs.append( (subject,object) )
+                elif subject in chemical_rxcui_to_clique and object in drug_rxcui_to_clique:
+                    subject = chemical_rxcui_to_clique[subject]
+                    object = drug_rxcui_to_clique[object]
+                    pairs.append( (subject,object) )
+                # OK, this is possible, and it's OK, as long as we get real clique leaders
+                elif subject in drug_rxcui_to_clique and object in drug_rxcui_to_clique:
+                    subject = drug_rxcui_to_clique[subject]
+                    object = drug_rxcui_to_clique[object]
+                    pairs.append( (subject,object) )
+                elif subject in chemical_rxcui_to_clique and object in chemical_rxcui_to_clique:
+                    subject = chemical_rxcui_to_clique[subject]
+                    object = chemical_rxcui_to_clique[object]
+                    pairs.append( (subject,object) )
     with open(pubchem_rxn_concord,"r") as infile:
         for line in infile:
             x = line.strip().split('\t')

--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -162,6 +162,7 @@ def build_rxnorm_relationships(conso, relfile, outfile):
         prefix = UMLS
     else:
         prefix = RXCUI
+    debug_entity = "C0724393"
     aui_to_cui, sdui_to_cui = get_aui_to_cui(conso)
     # relfile = os.path.join('input_data', 'private', "RXNREL.RRF")
     single_use_relations = {"has_active_ingredient": defaultdict(set),
@@ -185,24 +186,38 @@ def build_rxnorm_relationships(conso, relfile, outfile):
                 if subject == object:
                     continue
                 predicate = x[7]
+                if debug_entity in [subject,object]:
+                    print(f"{subject}\t{predicate}\t{object}")
                 if predicate in single_use_relations:
                     single_use_relations[predicate][subject].add(object)
                 elif predicate in one_to_one_relations:
                     one_to_one_relations[predicate]["subject"][subject].add(object)
                     one_to_one_relations[predicate]["object"][object].add(subject)
                 else:
+                    if debug_entity in [subject, object]:
+                        print(f" wrote")
                     outf.write(f"{prefix}:{subject}\t{predicate}\t{prefix}:{object}\n")
         for predicate in single_use_relations:
             for subject,objects in single_use_relations[predicate].items():
                 if len(objects) > 1:
+                    if debug_entity in [subject, object]:
+                        print(f" {predicate}: too many objects.")
                     continue
+                if debug_entity in [subject, object]:
+                    print(f" {predicate}: wrote.")
                 outf.write(f"{prefix}:{subject}\t{predicate}\t{prefix}:{next(iter(objects))}\n")
         for predicate in one_to_one_relations:
             for subject,objects in one_to_one_relations[predicate]["subject"].items():
                 if len(objects) > 1:
+                    if debug_entity in [subject, object]:
+                        print(f" {predicate}: too many objects.")
                     continue
                 if len(one_to_one_relations[predicate]["object"][next(iter(objects))]) > 1:
+                    if debug_entity in [subject, object]:
+                        print(f" {predicate}: too many subjects.")
                     continue
+                if debug_entity in [subject, object]:
+                    print(f" {predicate}: wrote.")
                 outf.write(f"{prefix}:{subject}\t{predicate}\t{prefix}:{next(iter(objects))}\n")
 
 

--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -112,7 +112,11 @@ def get_cui(x,indicator_column,cui_column,aui_column,aui_to_cui,sdui_to_cui):
         if x[indicator_column] == "CUI":
             return x[cui_column]
         elif x[indicator_column] == "AUI":
-            return aui_to_cui[x[aui_column]]
+            try:
+                return aui_to_cui[x[aui_column]]
+            except:
+                #this really shouldn't happen.  But it seems to occur for the UMLS files?
+                return None
         elif x[indicator_column] == "SDUI":
             cuis = sdui_to_cui[(x[source_column],x[aui_column])]
             if len(cuis) == 1:

--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -150,6 +150,11 @@ def build_rxnorm_relationships(conso, relfile, outfile):
     by the fact that auis and sduis are used in the file.  This happens when the effective triple comes from multiple
     sources. That's why the collections below need to be sets rather than lists
     """
+    #This is maybe relying on convention a bit too much.
+    if outfile == "UMLS":
+        prefix = UMLS
+    else:
+        prefix = RXCUI
     aui_to_cui, sdui_to_cui = get_aui_to_cui(conso)
     # relfile = os.path.join('input_data', 'private', "RXNREL.RRF")
     single_use_relations = {"has_active_ingredient": defaultdict(set),
@@ -174,19 +179,19 @@ def build_rxnorm_relationships(conso, relfile, outfile):
                     one_to_one_relations[predicate]["subject"][subject].add(object)
                     one_to_one_relations[predicate]["object"][object].add(subject)
                 else:
-                    outf.write(f"{RXCUI}:{subject}\t{predicate}\t{RXCUI}:{object}\n")
+                    outf.write(f"{prefix}:{subject}\t{predicate}\t{prefix}:{object}\n")
         for predicate in single_use_relations:
             for subject,objects in single_use_relations[predicate].items():
                 if len(objects) > 1:
                     continue
-                outf.write(f"{RXCUI}:{subject}\t{predicate}\t{RXCUI}:{next(iter(objects))}\n")
+                outf.write(f"{prefix}:{subject}\t{predicate}\t{prefix}:{next(iter(objects))}\n")
         for predicate in one_to_one_relations:
             for subject,objects in one_to_one_relations[predicate]["subject"].items():
                 if len(objects) > 1:
                     continue
                 if len(one_to_one_relations[predicate]["object"][next(iter(objects))]) > 1:
                     continue
-                outf.write(f"{RXCUI}:{subject}\t{predicate}\t{RXCUI}:{next(iter(objects))}\n")
+                outf.write(f"{prefix}:{subject}\t{predicate}\t{prefix}:{next(iter(objects))}\n")
 
 
 def load_cliques(compendium):

--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -169,9 +169,11 @@ def build_rxnorm_relationships(conso, relfile, outfile):
                             "has_precise_active_ingredient": defaultdict(set),
                             "has_precise_ingredient": defaultdict(set),
                             "has_ingredient": defaultdict(set),
-                            "consists_of": defaultdict(set)}
-    one_to_one_relations = {"has_tradename": {"subject": defaultdict(set),
-                                              "object": defaultdict(set)}}
+                            "consists_of": defaultdict(set),
+                            "tradename_of": defaultdict(set)}
+    #one_to_one_relations = {"has_tradename": {"subject": defaultdict(set),
+    #                                          "object": defaultdict(set)}}
+    one_to_one_relations = {}
     with open(relfile, 'r') as inf, open(outfile, 'w') as outf:
         for line in inf:
             x = line.strip().split('|')

--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -169,11 +169,9 @@ def build_rxnorm_relationships(conso, relfile, outfile):
                             "has_precise_active_ingredient": defaultdict(set),
                             "has_precise_ingredient": defaultdict(set),
                             "has_ingredient": defaultdict(set),
-                            "consists_of": defaultdict(set),
-                            "tradename_of": defaultdict(set)}
-    #one_to_one_relations = {"has_tradename": {"subject": defaultdict(set),
-    #                                          "object": defaultdict(set)}}
-    one_to_one_relations = {}
+                            "consists_of": defaultdict(set)}
+    one_to_one_relations = {"has_tradename": {"subject": defaultdict(set),
+                                              "object": defaultdict(set)}}
     with open(relfile, 'r') as inf, open(outfile, 'w') as outf:
         for line in inf:
             x = line.strip().split('|')

--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -174,8 +174,13 @@ def build_rxnorm_relationships(conso, relfile, outfile):
     with open(relfile, 'r') as inf, open(outfile, 'w') as outf:
         for line in inf:
             x = line.strip().split('|')
-            object = get_cui(x,2,0,1,aui_to_cui,sdui_to_cui)
-            subject = get_cui(x,6,4,5,aui_to_cui,sdui_to_cui)
+            #UMLS always has the CUI in it, while RXNORM does not.
+            if outfile == "UMLS":
+                object = x[0]
+                subject = x[4]
+            else:
+                object = get_cui(x,2,0,1,aui_to_cui,sdui_to_cui)
+                subject = get_cui(x,6,4,5,aui_to_cui,sdui_to_cui)
             if (subject is not None) and (object is not None):
                 if subject == object:
                     continue

--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -121,6 +121,9 @@ def get_cui(x,indicator_column,cui_column,aui_column,aui_to_cui,sdui_to_cui):
             print(x)
             print(cuis)
             exit()
+        elif x[indicator_column] == "SCUI":
+            #SCUI is source cui, i.e. what the source calls it.  We might be able to pull this out of CONSO if we have to.
+            return None
         print("cmon man")
         print(x)
         exit()
@@ -169,7 +172,7 @@ def build_rxnorm_relationships(conso, relfile, outfile):
             x = line.strip().split('|')
             object = get_cui(x,2,0,1,aui_to_cui,sdui_to_cui)
             subject = get_cui(x,6,4,5,aui_to_cui,sdui_to_cui)
-            if subject is not None:
+            if (subject is not None) and (object is not None):
                 if subject == object:
                     continue
                 predicate = x[7]

--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -162,7 +162,6 @@ def build_rxnorm_relationships(conso, relfile, outfile):
         prefix = UMLS
     else:
         prefix = RXCUI
-    debug_entity = "C0724393"
     aui_to_cui, sdui_to_cui = get_aui_to_cui(conso)
     # relfile = os.path.join('input_data', 'private', "RXNREL.RRF")
     single_use_relations = {"has_active_ingredient": defaultdict(set),
@@ -186,37 +185,23 @@ def build_rxnorm_relationships(conso, relfile, outfile):
                 if subject == object:
                     continue
                 predicate = x[7]
-                if debug_entity in [subject,object]:
-                    print(f"{subject}\t{predicate}\t{object}")
                 if predicate in single_use_relations:
-                    if debug_entity in [subject, object]:
-                        print(f" Added to single use")
                     single_use_relations[predicate][subject].add(object)
                 elif predicate in one_to_one_relations:
-                    if debug_entity in [subject, object]:
-                        print(f" Added to one to one")
                     one_to_one_relations[predicate]["subject"][subject].add(object)
                     one_to_one_relations[predicate]["object"][object].add(subject)
                 else:
-                    if debug_entity in [subject, object]:
-                        print(f" wrote")
                     outf.write(f"{prefix}:{subject}\t{predicate}\t{prefix}:{object}\n")
         for predicate in single_use_relations:
             for subject,objects in single_use_relations[predicate].items():
                 if len(objects) > 1:
-                    if (debug_entity == subject) or (debug_entity in objects):
-                        print(f" {predicate}: too many objects.")
                     continue
                 outf.write(f"{prefix}:{subject}\t{predicate}\t{prefix}:{next(iter(objects))}\n")
         for predicate in one_to_one_relations:
             for subject,objects in one_to_one_relations[predicate]["subject"].items():
                 if len(objects) > 1:
-                    if (debug_entity == subject) or (debug_entity in objects):
-                        print(f" {predicate}: too many objects.")
                     continue
                 if len(one_to_one_relations[predicate]["object"][next(iter(objects))]) > 1:
-                    if (debug_entity in one_to_one_relations[predicate]["object"][next(iter(objects))]) or (debug_entity == object):
-                        print(f" {predicate}: too many subjects.")
                     continue
                 outf.write(f"{prefix}:{subject}\t{predicate}\t{prefix}:{next(iter(objects))}\n")
 

--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -189,8 +189,12 @@ def build_rxnorm_relationships(conso, relfile, outfile):
                 if debug_entity in [subject,object]:
                     print(f"{subject}\t{predicate}\t{object}")
                 if predicate in single_use_relations:
+                    if debug_entity in [subject, object]:
+                        print(f" Added to single use")
                     single_use_relations[predicate][subject].add(object)
                 elif predicate in one_to_one_relations:
+                    if debug_entity in [subject, object]:
+                        print(f" Added to one to one")
                     one_to_one_relations[predicate]["subject"][subject].add(object)
                     one_to_one_relations[predicate]["object"][object].add(subject)
                 else:
@@ -200,24 +204,20 @@ def build_rxnorm_relationships(conso, relfile, outfile):
         for predicate in single_use_relations:
             for subject,objects in single_use_relations[predicate].items():
                 if len(objects) > 1:
-                    if debug_entity in [subject, object]:
+                    if (debug_entity == subject) or (debug_entity in objects):
                         print(f" {predicate}: too many objects.")
                     continue
-                if debug_entity in [subject, object]:
-                    print(f" {predicate}: wrote.")
                 outf.write(f"{prefix}:{subject}\t{predicate}\t{prefix}:{next(iter(objects))}\n")
         for predicate in one_to_one_relations:
             for subject,objects in one_to_one_relations[predicate]["subject"].items():
                 if len(objects) > 1:
-                    if debug_entity in [subject, object]:
+                    if (debug_entity == subject) or (debug_entity in objects):
                         print(f" {predicate}: too many objects.")
                     continue
                 if len(one_to_one_relations[predicate]["object"][next(iter(objects))]) > 1:
-                    if debug_entity in [subject, object]:
+                    if (debug_entity in one_to_one_relations[predicate]["object"][next(iter(objects))]) or (debug_entity == object):
                         print(f" {predicate}: too many subjects.")
                     continue
-                if debug_entity in [subject, object]:
-                    print(f" {predicate}: wrote.")
                 outf.write(f"{prefix}:{subject}\t{predicate}\t{prefix}:{next(iter(objects))}\n")
 
 

--- a/src/datahandlers/umls.py
+++ b/src/datahandlers/umls.py
@@ -250,6 +250,8 @@ def download_umls(umls_version, download_dir):
     shutil.copy2(os.path.join(download_dir, umls_version, 'META', 'MRCONSO.RRF'), download_dir)
     # - MRSTY.RRF
     shutil.copy2(os.path.join(download_dir, umls_version, 'META', 'MRSTY.RRF'), download_dir)
+    # - MRREL.RRF
+    shutil.copy2(os.path.join(download_dir, umls_version, 'META', 'MRREL.RRF'), download_dir)
 
 
 def download_rxnorm(rxnorm_version, download_dir):

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -137,6 +137,7 @@ rule download_umls:
     output:
         config['download_directory']+'/UMLS/MRCONSO.RRF',
         config['download_directory']+'/UMLS/MRSTY.RRF',
+        config['download_directory']+'/UMLS/MRREL.RRF',
     run:
         umls.download_umls(config['umls_version'], config['download_directory'] + '/UMLS')
 

--- a/src/snakefiles/drugchemical.snakefile
+++ b/src/snakefiles/drugchemical.snakefile
@@ -12,6 +12,15 @@ rule rxnorm_relationships:
     run:
         drugchemical.build_rxnorm_relationships(input.rxnconso, input.rxnrel, output.outfile_concords)
 
+rule umls_relationships:
+    input:
+        umlsconso = config['download_directory'] + "/UMLS/RXNCONSO.RRF",
+        umlsrel = config['download_directory'] + "/UMLS/RXNREL.RRF",
+    output:
+        outfile_concords = config['intermediate_directory'] + '/drugchemical/concords/UMLS'
+    run:
+        drugchemical.build_rxnorm_relationships(input.umlsconso, input.umlsrel, output.outfile_concords)
+
 rule pubchem_rxnorm_relationships:
     input:
         infile = config['download_directory'] + '/PUBCHEM.COMPOUND/RXNORM.json',
@@ -25,11 +34,12 @@ rule drugchemical_conflation:
         drug_compendium=config['output_directory']+'/compendia/'+'Drug.txt',
         chemical_compendia=expand("{do}/compendia/{co}", do=config['output_directory'], co=config['chemical_outputs']),
         rxnorm_concord=config['intermediate_directory']+'/drugchemical/concords/RXNORM',
+        umls_concord=config['intermediate_directory']+'/drugchemical/concords/UMLS',
         pubchem_concord=config['intermediate_directory']+'/drugchemical/concords/PUBCHEM_RXNORM'
     output:
         outfile=config['output_directory']+'/conflation/DrugChemical.txt'
     run:
-        drugchemical.build_conflation(input.rxnorm_concord,input.pubchem_concord,input.drug_compendium,input.chemical_compendia,output.outfile)
+        drugchemical.build_conflation(input.rxnorm_concord,input.umls_concord,input.pubchem_concord,input.drug_compendium,input.chemical_compendia,output.outfile)
 
 rule drugchemical:
     input:

--- a/src/snakefiles/drugchemical.snakefile
+++ b/src/snakefiles/drugchemical.snakefile
@@ -14,8 +14,8 @@ rule rxnorm_relationships:
 
 rule umls_relationships:
     input:
-        umlsconso = config['download_directory'] + "/UMLS/RXNCONSO.RRF",
-        umlsrel = config['download_directory'] + "/UMLS/RXNREL.RRF",
+        umlsconso = config['download_directory'] + "/UMLS/MRCONSO.RRF",
+        umlsrel = config['download_directory'] + "/UMLS/MRREL.RRF",
     output:
         outfile_concords = config['intermediate_directory'] + '/drugchemical/concords/UMLS'
     run:


### PR DESCRIPTION
I have identified 2 problems:

1. When we build the RXNORM conflation relations, we have some checks to make sure that we're not e.g. merging acetaminophen and caffeine because they are both ingredients in excedrin.  This takes the form of checking that a particular list has only a single element.  But it turns out that RXNREL can contain essentially the same triple multiple times. So that list should really be a set.   This PR fixes this issue.

2. There are some UMLS entities like "wellbutrin SR" that don't merge with anything in RXNORM or anywhere else.  My original hope was that we could use the UMLS REL file to connect these terms to other relevant terms.  However, the problem is that the only relatinons are "has_ingredient" and "has_tradename" relations that are subject to the rules mentioned above.  Because of the structure, these aren't able to merge in (there are MxN type has_ingredients edges, relaxing the constraints leads to everything is everything).  I'm not sure quite what to do with these.   I'm tempted to say that maybe NR should just not include e.g. drugs or chemicals that are a single UMLS term not merged with anything, but that's probably too draconian.