### PR TITLE
Removed unique prefix for COMPLEXPORTAL since it is no longer needed

### DIFF
--- a/src/createcompendia/macromolecular_complex.py
+++ b/src/createcompendia/macromolecular_complex.py
@@ -9,11 +9,10 @@ def build_compendia(identifiers, icrdf_filename):
        :identifiers: a list of files from which to read identifiers and optional categories"""
     dicts = {}
     types = {}
-    uniques = [COMPLEXPORTAL]
     for ifile in identifiers:
         print('loading ', ifile)
         new_identifiers, new_types = read_identifier_file(ifile)
-        glom(dicts, new_identifiers, unique_prefixes=uniques)
+        glom(dicts, new_identifiers)
         types.update(new_types)
     sets = set([frozenset(x) for x in dicts.values()])
     type = MACROMOLECULAR_COMPLEX.split(':')[-1]


### PR DESCRIPTION
I [added a unique prefix override](
https://github.com/TranslatorSRI/Babel/blob/e838712d1e8d9ccae091634eabd768b1c7e0c2c0/src/createcompendia/macromolecular_complex.py#L7-L20) to allow the COMPLEXPORTAL prefix to be written out as part of the MacromolecularComplex compendium. Now that this has been added to the BiolinkModel (https://github.com/biolink/biolink-model/issues/1088), this should no longer be needed. This PR removes that prefix override.

Closes #54.