### PR TITLE
Improve UniProtKB downloads

### DIFF
--- a/src/datahandlers/uniprotkb.py
+++ b/src/datahandlers/uniprotkb.py
@@ -1,7 +1,5 @@
 from src.babel_utils import pull_via_urllib, make_local_name
 
-def pull_one_uniprotkb(which):
-    pull_via_urllib('ftp://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/complete/',f'uniprot_{which}.fasta.gz',subpath='UniProtKB')
 
 def readlabels(which):
     swissname = make_local_name(f'UniProtKB/uniprot_{which}.fasta')
@@ -16,11 +14,6 @@ def readlabels(which):
                 name = x[2].split(' OS=')[0]
                 swissprot_labels[uniprotid] = f'{name} ({which})'
     return swissprot_labels
-
-def pull_uniprotkb():
-    pull_via_urllib('https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/idmapping/',f'idmapping.dat.gz',subpath='UniProtKB')
-    for which in ['sprot','trembl']:
-        pull_via_urllib('https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/complete/',f'uniprot_{which}.fasta.gz',subpath='UniProtKB')
 
 def pull_uniprot_labels(sprotfile,tremblfile,fname):
     slabels = readlabels('sprot')

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -91,13 +91,20 @@ rule get_mods_labels:
 
 ### UniProtKB
 
-rule get_uniprotkb:
+rule get_uniprotkb_idmapping:
     output:
-        config['download_directory']+'/UniProtKB/uniprot_sprot.fasta',
-        config['download_directory']+'/UniProtKB/uniprot_trembl.fasta',
-        config['download_directory']+'/UniProtKB/idmapping.dat'
-    run:
-        uniprotkb.pull_uniprotkb()
+        idmapping = config['download_directory']+'/UniProtKB/idmapping.dat'
+    shell: """wget --continue --tries=10 "https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/idmapping/idmapping.dat.gz" -O {output.idmapping}.gz && gunzip {output.idmapping}.gz"""
+
+rule get_uniprotkb_sprot:
+    output:
+        uniprot_sprot = config['download_directory']+'/UniProtKB/uniprot_sprot.fasta'
+    shell: """wget --continue --tries=10 "https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/complete/uniprot_sprot.fasta.gz" -O {output.uniprot_sprot}.gz && gunzip {output.uniprot_sprot}.gz"""
+
+rule get_uniprotkb_trembl:
+    output:
+        uniprot_trembl = config['download_directory']+'/UniProtKB/uniprot_trembl.fasta'
+    shell: """wget --continue --tries=10 "https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/complete/uniprot_trembl.fasta.gz" -O {output.uniprot_trembl}.gz && gunzip {output.uniprot_trembl}.gz"""
 
 rule get_uniprotkb_labels:
     input:

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -94,17 +94,17 @@ rule get_mods_labels:
 rule get_uniprotkb_idmapping:
     output:
         idmapping = config['download_directory']+'/UniProtKB/idmapping.dat'
-    shell: """wget --continue --tries=10 "https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/idmapping/idmapping.dat.gz" -O {output.idmapping}.gz && gunzip {output.idmapping}.gz"""
+    shell: """wget --continue --progress=dot --tries=10 "https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/idmapping/idmapping.dat.gz" -O {output.idmapping}.gz && gunzip {output.idmapping}.gz"""
 
 rule get_uniprotkb_sprot:
     output:
         uniprot_sprot = config['download_directory']+'/UniProtKB/uniprot_sprot.fasta'
-    shell: """wget --continue --tries=10 "https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/complete/uniprot_sprot.fasta.gz" -O {output.uniprot_sprot}.gz && gunzip {output.uniprot_sprot}.gz"""
+    shell: """wget --continue --progress=dot --tries=10 "https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/complete/uniprot_sprot.fasta.gz" -O {output.uniprot_sprot}.gz && gunzip {output.uniprot_sprot}.gz"""
 
 rule get_uniprotkb_trembl:
     output:
         uniprot_trembl = config['download_directory']+'/UniProtKB/uniprot_trembl.fasta'
-    shell: """wget --continue --tries=10 "https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/complete/uniprot_trembl.fasta.gz" -O {output.uniprot_trembl}.gz && gunzip {output.uniprot_trembl}.gz"""
+    shell: """wget --continue --progress=dot --tries=10 "https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/complete/uniprot_trembl.fasta.gz" -O {output.uniprot_trembl}.gz && gunzip {output.uniprot_trembl}.gz"""
 
 rule get_uniprotkb_labels:
     input:


### PR DESCRIPTION
UniProtKB downloads have gotten really slow lately. Rather than relying on the built-in `pull_via_urllib()` method, this PR switches that over to using `wget --continue` so that we get progress updates and resume incomplete downloads. This is a pretty hacky way of implementing this, but it's quicker than the two alternatives:
1. Rewriting `pull_via_urllib()` so that it can resume an incomplete download.
2. Writing a `pull_via_wget()` method that can either be a plug-in replacement for `pull_via_urllib()` or can be inserted into Snakemake.

Breaking up the downloads in Snakemake has the advantage that the files can be downloaded simultaneously.

WIP: after writing all this down, I think I should write a `pull_via_wget()` method to clean this up a bit before merging it.