### PR TITLE
Skip writing synonyms that have no valid name

### DIFF
--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -282,7 +282,8 @@ def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[],i
 
                     # Since synonyms_list is sorted,
                     if len(synonyms_list) == 0:
-                        logging.warning(f"Synonym list for {node} is empty: no valid name.")
+                        logging.warning(f"Synonym list for {node} is empty: no valid name. Skipping.")
+                        continue
                     else:
                         document["shortest_name_length"] = len(synonyms_list[0])
 

--- a/src/createcompendia/leftover_umls.py
+++ b/src/createcompendia/leftover_umls.py
@@ -227,7 +227,8 @@ def write_leftover_umls(compendia, mrconso, mrsty, synonyms, umls_compendium, um
 
                 # Since synonyms_list is sorted,
                 if len(synonyms_list) == 0:
-                    logging.warning(f"Synonym list for UMLS entry {id} is empty: no valid name.")
+                    logging.warning(f"Synonym list for UMLS entry {id} is empty: no valid name. Skipping.")
+                    continue
                 else:
                     document["shortest_name_length"] = len(synonyms_list[0])
 


### PR DESCRIPTION
I'd been previously been keeping identifiers in the synonyms file that have no actual synonyms because I was hoping to implement a feature that would allow people to search by concept identifiers directly in NameRes. But until that functionality exists, we don't need to make the NameRes synonym files larger than they need to be.