### PR TITLE
Add taxa to NCBIGene

### DIFF
--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -366,6 +366,9 @@ def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[],i
 
                     nw['identifiers'].append(id_info)
 
+                # Collect taxon names for this node.
+                nw['taxa'] = list(sorted(taxa.values(), key=get_curie_suffix))
+
                 outf.write( nw )
 
                 # get_synonyms() returns tuples in the form ('http://www.geneontology.org/formats/oboInOwl#hasExactSynonym', 'Caudal articular process of eighteenth thoracic vertebra')
@@ -445,7 +448,7 @@ def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[],i
                             pass
 
                     # Collect taxon names for this node.
-                    document['taxa'] = list(sorted(taxa[id_info['i']], key=get_curie_suffix))
+                    document['taxa'] = list(sorted(taxa.values(), key=get_curie_suffix))
 
                     sfile.write( document )
                 except Exception as ex:

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -295,6 +295,7 @@ def sort_identifiers_with_boosted_prefixes(identifiers, prefixes):
     )
 
 
+
 def get_curie_suffix(curie):
     curie_parts = curie.split(':', 1)
     if len(curie_parts) > 0:
@@ -367,7 +368,7 @@ def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[],i
                     nw['identifiers'].append(id_info)
 
                 # Collect taxon names for this node.
-                nw['taxa'] = list(sorted(taxa.values(), key=get_curie_suffix))
+                nw['taxa'] = list(sorted(set().union(*taxa.values()), key=get_curie_suffix))
 
                 outf.write( nw )
 
@@ -448,7 +449,7 @@ def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[],i
                             pass
 
                     # Collect taxon names for this node.
-                    document['taxa'] = list(sorted(taxa.values(), key=get_curie_suffix))
+                    document['taxa'] = list(sorted(set().union(*taxa.values()), key=get_curie_suffix))
 
                     sfile.write( document )
                 except Exception as ex:

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -306,6 +306,7 @@ def get_curie_suffix(curie):
             pass
     return None
 
+
 def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[],icrdf_filename=None):
     """
     :param synonym_list:

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -11,7 +11,7 @@ import requests
 import os
 import urllib
 import jsonlines
-from src.node import NodeFactory, SynonymFactory, DescriptionFactory, InformationContentFactory, get_config
+from src.node import NodeFactory, SynonymFactory, DescriptionFactory, InformationContentFactory, TaxonFactory, get_config
 from src.util import Text
 from src.LabeledID import LabeledID
 from collections import defaultdict
@@ -295,6 +295,16 @@ def sort_identifiers_with_boosted_prefixes(identifiers, prefixes):
     )
 
 
+def get_curie_suffix(curie):
+    curie_parts = curie.split(':', 1)
+    if len(curie_parts) > 0:
+        # Try to cast the CURIE suffix to an integer. If we get a ValueError, don't worry about it.
+        try:
+            return int(curie_parts[1])
+        except ValueError:
+            pass
+    return None
+
 def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[],icrdf_filename=None):
     """
     :param synonym_list:
@@ -327,6 +337,7 @@ def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[],i
     ic_factory = InformationContentFactory(icrdf_filename)
 
     description_factory = DescriptionFactory(make_local_name(''))
+    taxon_factory = TaxonFactory(make_local_name(''))
     node_test = node_factory.create_node(input_identifiers=[],node_type=node_type,labels={},extra_prefixes = extra_prefixes)
     with jsonlines.open(os.path.join(cdir,'compendia',ofname),'w') as outf, jsonlines.open(os.path.join(cdir,'synonyms',ofname),'w') as sfile:
         for slist in synonym_list:
@@ -338,6 +349,7 @@ def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[],i
                     nw['ic'] = ic
 
                 descs = description_factory.get_descriptions(node)
+                taxa = taxon_factory.get_taxa(node)
                 nw['identifiers'] = []
                 for nids in node['identifiers']:
                     id_info = {'i': nids['identifier']}
@@ -346,8 +358,11 @@ def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[],i
                         id_info['l'] = nids['label']
 
                     if id_info['i'] in descs:
-                        # Sort from the shortest description to the longest.
+                        # Sort descriptions from the shortest to the longest.
                         id_info['d'] = list(sorted(descs[id_info['i']], key=lambda x: len(x)))
+
+                        # Sort taxa by CURIE suffix.
+                        id_info['t'] = list(sorted(taxa[id_info['i']], key=get_curie_suffix))
 
                     nw['identifiers'].append(id_info)
 
@@ -428,6 +443,9 @@ def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[],i
                             document["curie_suffix"] = int(curie_parts[1])
                         except ValueError:
                             pass
+
+                    # Collect taxon names for this node.
+                    document['taxa'] = list(sorted(taxa[id_info['i']], key=get_curie_suffix))
 
                     sfile.write( document )
                 except Exception as ex:

--- a/src/datahandlers/ncbigene.py
+++ b/src/datahandlers/ncbigene.py
@@ -8,13 +8,17 @@ def pull_ncbigene(filenames):
         pull_via_ftp('ftp.ncbi.nih.gov', '/gene/DATA', fn, decompress_data=False, outfilename=f'NCBIGene/{fn}')
 
 
-def pull_ncbigene_labels_and_synonyms():
+def pull_ncbigene_labels_synonyms_and_taxa():
     # File format described here: https://ftp.ncbi.nih.gov/gene/DATA/README
     ifname = make_local_name('gene_info.gz', subpath='NCBIGene')
     labelname = make_local_name('labels', subpath='NCBIGene')
     synname = make_local_name('synonyms', subpath='NCBIGene')
+    taxaname = make_local_name('taxa', subpath='NCBIGene')
     bad_gene_types = set(['biological-region', 'other', 'unknown'])
-    with gzip.open(ifname, 'r') as inf, open(labelname, 'w') as labelfile, open(synname, 'w') as synfile:
+    with (gzip.open(ifname, 'r') as inf,
+          open(labelname, 'w') as labelfile,
+          open(synname, 'w') as synfile,
+          open(taxaname, 'w') as taxafile):
 
         # Make sure the gene_info.gz columns haven't changed from under us.
         header = inf.readline().decode('utf-8').strip().split("\t")
@@ -60,6 +64,8 @@ def pull_ncbigene_labels_and_synonyms():
             if gene_type in bad_gene_types:
                 continue
             labelfile.write(f'{gene_id}\t{symbol}\n')
+            taxafile.write(f'{gene_id}\t{get_field(row, "#tax_id")}\n')
+
             syns = set(get_field(row, "Synonyms").split('|'))
             syns.add(symbol)
             description = get_field(row, "description")

--- a/src/datahandlers/ncbigene.py
+++ b/src/datahandlers/ncbigene.py
@@ -64,7 +64,7 @@ def pull_ncbigene_labels_synonyms_and_taxa():
             if gene_type in bad_gene_types:
                 continue
             labelfile.write(f'{gene_id}\t{symbol}\n')
-            taxafile.write(f'{gene_id}\t{get_field(row, "#tax_id")}\n')
+            taxafile.write(f'{gene_id}\tNCBITaxon:{get_field(row, "#tax_id")}\n')
 
             syns = set(get_field(row, "Synonyms").split('|'))
             syns.add(symbol)

--- a/src/node.py
+++ b/src/node.py
@@ -134,7 +134,7 @@ class DescriptionFactory:
         node_descriptions = defaultdict(set)
         for ident in node['identifiers']:
             thisid = ident['identifier']
-            pref = Text.get_curie(thisid)
+            pref = thisid.split(':', 1)[0]
             if not pref in self.descriptions:
                 self.load_descriptions(pref)
             node_descriptions[thisid].update( self.descriptions[pref][thisid] )
@@ -167,7 +167,7 @@ class TaxonFactory:
         node_taxa = defaultdict(set)
         for ident in node['identifiers']:
             thisid = ident['identifier']
-            pref = Text.get_curie(thisid)
+            pref = thisid.split(':', 1)[0]
             if not pref in self.taxa:
                 self.load_taxa(pref)
             node_taxa[thisid].update(self.taxa[pref][thisid])

--- a/src/node.py
+++ b/src/node.py
@@ -141,6 +141,39 @@ class DescriptionFactory:
         return node_descriptions
 
 
+class TaxonFactory:
+    """ A factory for loading taxa for CURIEs where available.
+    """
+
+    def __init__(self,rootdir):
+        self.root_dir = rootdir
+        self.taxa = {}
+
+    def load_taxa(self, prefix):
+        print(f'Loading taxa for {prefix}')
+        taxa_per_prefix = defaultdict(set)
+        taxafilename = os.path.join(self.root_dir, prefix, 'taxa')
+        taxon_count = 0
+        if os.path.exists(taxafilename):
+            with open(taxafilename, 'r') as inf:
+                for line in inf:
+                    x = line.strip().split('\t')
+                    taxa_per_prefix[x[0]].add("\t".join(x[1:]))
+                    taxon_count += 1
+        self.taxa[prefix] = taxa_per_prefix
+        print(f'Loaded {taxon_count} taxon-CURIE mappings for {prefix}')
+
+    def get_taxa(self, node):
+        node_taxa = defaultdict(set)
+        for ident in node['identifiers']:
+            thisid = ident['identifier']
+            pref = Text.get_curie(thisid)
+            if not pref in self.taxa:
+                self.load_taxa(pref)
+            node_taxa[thisid].update(self.taxa[pref][thisid])
+        return node_taxa
+
+
 class InformationContentFactory:
     """
 

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -183,14 +183,15 @@ rule get_ncbigene:
     run:
         ncbigene.pull_ncbigene(config['ncbi_files'])
 
-rule get_ncbigene_labels_and_synonyms:
+rule get_ncbigene_labels_synonyms_and_taxa:
     output:
         config['download_directory']+'/NCBIGene/labels',
-        config['download_directory']+'/NCBIGene/synonyms'
+        config['download_directory']+'/NCBIGene/synonyms',
+        config['download_directory']+'/NCBIGene/taxa'
     input:
         config['download_directory']+'/NCBIGene/gene_info.gz'
     run:
-        ncbigene.pull_ncbigene_labels_and_synonyms()
+        ncbigene.pull_ncbigene_labels_synonyms_and_taxa()
 
 ### ENSEMBL
 


### PR DESCRIPTION
This PR will add taxonomic identifiers to NCBIGene so we can differentiate human and other model organism genes from other cliques.

This PR adds support for extracting NCBI Taxon identifiers from the `NCBIGene/gene_info.gz`, storing it into `NCBIGene/taxa` in a simple tab-delimited format (`CURIE for NCBIGene\tCURIE for NCBITaxon`), adds a TaxonFactory for reading `taxa` files, and adds instructions for writing taxon information into compendium and synonym files.

Should help with TranslatorSRI/NameResolution#92.

In the current Babel run, we don't appear to have any genes with multiple taxa. We have 3,434,997 genes without any taxon information and 49,002,680 genes with one taxon. In compendia files, taxon information is stored per-identifier and per-clique. For example:

```json
{
  "type": "biolink:Gene",
  "identifiers": [
    {
      "i": "NCBIGene:1956",
      "l": "EGFR",
      "d": [],
      "t": [
        "NCBITaxon:9606"
      ]
    },
    {
      "i": "ENSEMBL:ENSG00000146648",
      "d": [],
      "t": []
    },
    {
      "i": "HGNC:3236",
      "l": "EGFR",
      "d": [],
      "t": []
    },
    {
      "i": "OMIM:131550",
      "d": [],
      "t": []
    },
    {
      "i": "UMLS:C1414313",
      "l": "EGFR gene",
      "d": [],
      "t": []
    }
  ],
  "taxa": [
    "NCBITaxon:9606"
  ]
}
```

In synonym files, taxon information is only stored per-clique:

```json
{
  "curie": "NCBIGene:1956",
  "names": [
    "SA7",
    "mENA",
    "ERRP",
    "EGFR",
    "ERBB",
    "HER1",
    "PIG61",
    "ERBB1",
    "NISBD2",
    "EGFR vIII",
    "EGFR gene",
    "EGFR Gene",
    "ONCOGENE ERBB",
    "SPECIES ANTIGEN 7",
    "proto-oncogene c-ErbB-1",
    "EPIDERMAL GROWTH FACTOR RECEPTOR",
    "epidermal growth factor receptor",
    "cell growth inhibiting protein 40",
    "erb-b2 receptor tyrosine kinase 1",
    "Epidermal Growth Factor Receptor Gene",
    "cell proliferation-inducing protein 61",
    "receptor tyrosine-protein kinase erbB-1",
    "epidermal growth factor receptor tyrosine kinase domain",
    "V-ERB-B AVIAN ERYTHROBLASTIC LEUKEMIA VIRAL ONCOGENE HOMOLOG",
    "avian erythroblastic leukemia viral (v-erb-b) oncogene homolog",
    "erythroblastic leukemia viral (v-erb-b) oncogene homolog (avian)",
    "epidermal growth factor receptor (avian erythroblastic leukemia viral (v-erb-b) oncogene homolog)"
  ],
  "types": [
    "Gene",
    "GeneOrGeneProduct",
    "GenomicEntity",
    "ChemicalEntityOrGeneOrGeneProduct",
    "PhysicalEssence",
    "OntologyClass",
    "BiologicalEntity",
    "ThingWithTaxon",
    "NamedThing",
    "Entity",
    "PhysicalEssenceOrOccurrent",
    "MacromolecularMachineMixin"
  ],
  "preferred_name": "EGFR",
  "shortest_name_length": 3,
  "curie_suffix": 1956,
  "taxa": [
    "NCBITaxon:9606"
  ]
}
```

Should be merged after PR #201.