### PR TITLE
Fix conflation bug

### DIFF
--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -279,14 +279,22 @@ def build_conflation(rxn_concord,umls_concord,pubchem_rxn_concord,drug_compendiu
             elif subject in chemical_rxcui_to_clique:
                 subject = chemical_rxcui_to_clique[subject]
             else:
-                raise RuntimeError(f"Unknown identifier in drugchemical conflation as subject: {subject}")
+                logging.warning(
+                    f"Skipping subject-object pair ({subject}, {object}) because the subject isn't mapped to a RxCUI"
+                )
+                continue
+                # raise RuntimeError(f"Unknown identifier in drugchemical conflation as subject: {subject}")
 
             if object in drug_rxcui_to_clique:
                 object = drug_rxcui_to_clique[object]
             elif object in chemical_rxcui_to_clique:
                 object = chemical_rxcui_to_clique[object]
             else:
-                raise RuntimeError(f"Unknown identifier in drugchemical conflation as object: {object}")
+                logging.warning(
+                    f"Skipping subject-object pair ({subject}, {object}) because the object isn't mapped to a RxCUI"
+                )
+                continue
+                # raise RuntimeError(f"Unknown identifier in drugchemical conflation as object: {object}")
 
             pairs.append((subject, object))
     print("glom")

--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -279,11 +279,7 @@ def build_conflation(rxn_concord,umls_concord,pubchem_rxn_concord,drug_compendiu
             elif subject in chemical_rxcui_to_clique:
                 subject = chemical_rxcui_to_clique[subject]
             else:
-                logging.warning(
-                    f"Skipping subject-object pair ({subject}, {object}) because the subject isn't mapped to a RxCUI"
-                )
-                continue
-                # raise RuntimeError(f"Unknown identifier in drugchemical conflation as subject: {subject}")
+                raise RuntimeError(f"Unknown identifier in drugchemical conflation as subject: {subject}")
 
             if object in drug_rxcui_to_clique:
                 object = drug_rxcui_to_clique[object]

--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -273,11 +273,21 @@ def build_conflation(rxn_concord,umls_concord,pubchem_rxn_concord,drug_compendiu
             x = line.strip().split('\t')
             subject = x[0]
             object = x[2]
-            #object is a PUBCHEM.  It's by definition a clique_leader.
+
             if subject in drug_rxcui_to_clique:
                 subject = drug_rxcui_to_clique[subject]
             elif subject in chemical_rxcui_to_clique:
                 subject = chemical_rxcui_to_clique[subject]
+            else:
+                raise RuntimeError(f"Unknown identifier in drugchemical conflation as subject: {subject}")
+
+            if object in drug_rxcui_to_clique:
+                object = drug_rxcui_to_clique[object]
+            elif object in chemical_rxcui_to_clique:
+                object = chemical_rxcui_to_clique[object]
+            else:
+                raise RuntimeError(f"Unknown identifier in drugchemical conflation as object: {object}")
+
             pairs.append((subject, object))
     print("glom")
     gloms = {}


### PR DESCRIPTION
This PR fixes the DrugChemical conflation bug (https://github.com/TranslatorSRI/NodeNormalization/issues/221) in a simple way that is probably the best we can do in the short term. The conflation code assumes that every identifier in the clique has a type, but that is not currently in the case for the drug-chemical conflation, which generates identifiers that aren't clique leaders. We can remove those by ensuring that every object must be in either `drug_rxcui_to_clique` or `chemical_rxcui_to_clique` -- if not, that object is skipped from the conflation. This gives us smaller conflations than we would otherwise get, but ensures that every identifier is a clique leader.

This has already been incorporated into PR #201, so if we decide not to go this route, we will need to remove it from that PR.