### PR TITLE
Fix CURIEs used for information content

### DIFF
--- a/config.json
+++ b/config.json
@@ -58,5 +58,8 @@
   "genefamily_outputs": ["GeneFamily.txt"],
 
   "ubergraph_iri_stem_to_prefix_map": {
+    "https://identifiers.org/ncbigene/": "NCBIGene",
+    "http://www.genenames.org/cgi-bin/gene_symbol_report?hgnc_id=": "HGNC",
+    "http://www.informatics.jax.org/marker/MGI:": "MGI"
   }
 }

--- a/config.json
+++ b/config.json
@@ -59,6 +59,7 @@
 
   "ubergraph_iri_stem_to_prefix_map": {
     "https://identifiers.org/ncbigene/": "NCBIGene",
+    "http://www.ncbi.nlm.nih.gov/gene/": "NCBIGene",
     "http://www.genenames.org/cgi-bin/gene_symbol_report?hgnc_id=": "HGNC",
     "http://www.informatics.jax.org/marker/MGI:": "MGI"
   }

--- a/config.json
+++ b/config.json
@@ -55,5 +55,9 @@
 
   "genefamily_labels": ["PANTHER.FAMILY","HGNC.FAMILY"],
   "genefamily_ids": ["PANTHER.FAMILY","HGNC.FAMILY"],
-  "genefamily_outputs": ["GeneFamily.txt"]
+  "genefamily_outputs": ["GeneFamily.txt"],
+
+  "ubergraph_curie_to_iri_stem": {
+
+  }
 }

--- a/config.json
+++ b/config.json
@@ -57,7 +57,6 @@
   "genefamily_ids": ["PANTHER.FAMILY","HGNC.FAMILY"],
   "genefamily_outputs": ["GeneFamily.txt"],
 
-  "ubergraph_curie_to_iri_stem": {
-
+  "ubergraph_iri_stem_to_prefix_map": {
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,5 @@ wheel
 oaklib~=0.5.1
 # Added by Gaurav, Sep 2023
 beautifulsoup4
+# Added by Gaurav, Dec 2023
+curies

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -9,6 +9,7 @@ import requests
 import os
 import urllib
 import jsonlines
+import curies
 from src.node import NodeFactory, SynonymFactory, DescriptionFactory, InformationContentFactory
 from src.util import Text
 from src.LabeledID import LabeledID
@@ -27,6 +28,29 @@ def make_local_name(fname,subpath=None):
     except:
         pass
     return os.path.join(odir,fname)
+
+
+def get_biolink_prefix_map():
+    """
+    Return a [CURIE converter](https://pypi.org/project/curies/) for the configured Biolink version.
+    """
+    config = get_config()
+    biolink_version = config['biolink_version']
+    if biolink_version.startswith('1.') or biolink_version.startswith('2.'):
+        raise RuntimeError(f"Biolink version {biolink_version} is not supported.")
+    elif biolink_version.startswith('3.'):
+        # biolink-model v3.* releases keeps the prefix map in a different place.
+        return curies.load_prefix_map(
+            'https://raw.githubusercontent.com/biolink/biolink-model/v' + biolink_version +
+            '/prefix-map/biolink-model-prefix-map.json'
+        )
+    else:
+        # biolink-model v4.0.0 and beyond is in the /project directory.
+        return curies.load_prefix_map(
+            f'https://raw.githubusercontent.com/biolink/biolink-model/v' + biolink_version +
+            '/project/prefixmap/biolink_model_prefix_map.json'
+        )
+
 
 class StateDB():
     def __init__(self,fname):

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -9,11 +9,9 @@ import requests
 import os
 import urllib
 import jsonlines
-import curies
-from src.node import NodeFactory, SynonymFactory, DescriptionFactory, InformationContentFactory
+from src.node import NodeFactory, SynonymFactory, DescriptionFactory, InformationContentFactory, get_config
 from src.util import Text
 from src.LabeledID import LabeledID
-from json import load
 from collections import defaultdict
 import sqlite3
 from typing import List, Tuple
@@ -28,28 +26,6 @@ def make_local_name(fname,subpath=None):
     except:
         pass
     return os.path.join(odir,fname)
-
-
-def get_biolink_prefix_map():
-    """
-    Return a [CURIE converter](https://pypi.org/project/curies/) for the configured Biolink version.
-    """
-    config = get_config()
-    biolink_version = config['biolink_version']
-    if biolink_version.startswith('1.') or biolink_version.startswith('2.'):
-        raise RuntimeError(f"Biolink version {biolink_version} is not supported.")
-    elif biolink_version.startswith('3.'):
-        # biolink-model v3.* releases keeps the prefix map in a different place.
-        return curies.load_prefix_map(
-            'https://raw.githubusercontent.com/biolink/biolink-model/v' + biolink_version +
-            '/prefix-map/biolink-model-prefix-map.json'
-        )
-    else:
-        # biolink-model v4.0.0 and beyond is in the /project directory.
-        return curies.load_prefix_map(
-            f'https://raw.githubusercontent.com/biolink/biolink-model/v' + biolink_version +
-            '/project/prefixmap/biolink_model_prefix_map.json'
-        )
 
 
 class StateDB():

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -457,11 +457,6 @@ def get_prefixes(idlist):
             prefs[Text.get_curie(ident)].append(ident)
     return prefs
 
-def get_config():
-    cname = os.path.join(os.path.dirname(__file__),'..', 'config.json')
-    with open(cname,'r') as json_file:
-        data = load(json_file)
-    return data
 
 def clean_sets(result_dict):
     """The keys for this are unique and unmergable: Don't merge GO!

--- a/src/datahandlers/obo.py
+++ b/src/datahandlers/obo.py
@@ -1,5 +1,6 @@
 from src.ubergraph import UberGraph
-from src.babel_utils import make_local_name, pull_via_ftp, get_config
+from src.babel_utils import make_local_name, pull_via_ftp
+from src.node import get_config
 from collections import defaultdict
 import os, gzip
 from json import loads,dumps

--- a/src/datahandlers/unii.py
+++ b/src/datahandlers/unii.py
@@ -4,7 +4,8 @@ from os import path,listdir,rename
 import requests
 
 from src.prefixes import UNII
-from src.babel_utils import pull_via_urllib, get_config
+from src.babel_utils import pull_via_urllib
+from src.node import get_config
 
 
 def pull_unii():

--- a/src/node.py
+++ b/src/node.py
@@ -178,7 +178,7 @@ class InformationContentFactory:
 
         unmapped_urls = []
         biolink_prefix_map = get_biolink_prefix_map()
-        ubergraph_curie_to_iri_stem_prefix_map = curies.Converter.from_reverse_prefix_map(config['ubergraph_curie_to_iri_stem'])
+        ubergraph_iri_stem_to_prefix_map = curies.Converter.from_reverse_prefix_map(config['ubergraph_iri_stem_to_prefix_map'])
 
         count_by_prefix = defaultdict(int)
         with open(ic_file, 'r') as inf:
@@ -188,8 +188,8 @@ class InformationContentFactory:
                 # prefix map to convert between them.
                 node_id = biolink_prefix_map.compress(x[0])
                 if node_id is None:
-                    # Try the ubergraph_curie_to_iri_stem_prefix_map
-                    node_id = ubergraph_curie_to_iri_stem_prefix_map.compress(x[0])
+                    # Try the ubergraph_iri_stem_to_prefix_map
+                    node_id = ubergraph_iri_stem_to_prefix_map.compress(x[0])
 
                 # If None, log this URL as unmapped.
                 if node_id is None:

--- a/src/node.py
+++ b/src/node.py
@@ -1,3 +1,4 @@
+import json
 from json import load
 import os
 from collections import defaultdict
@@ -116,6 +117,7 @@ class InformationContentFactory:
     def __init__(self,ic_file):
         self.ic = {}
         biolink_prefix_map = get_biolink_prefix_map()
+        count_by_prefix = defaultdict(int)
         with open(ic_file, 'r') as inf:
             for line in inf:
                 x = line.strip().split('\t')
@@ -124,7 +126,23 @@ class InformationContentFactory:
                 node_id = biolink_prefix_map.compress(x[0])
                 ic = x[1]
                 self.ic[node_id] = ic
-            print(f"Loaded {len(self.ic)} InformationContent values")
+
+                # Track IC values by prefix.
+                if isinstance(node_id, str):
+                    prefix = node_id.split(':')[0]
+                else:
+                    # Probably None, but we'll collect everything.
+                    prefix = str(node_id)
+                count_by_prefix[prefix] += 1
+
+        # Sort the dictionary items by value in descending order
+        sorted_by_prefix = sorted(count_by_prefix.items(), key=lambda item: item[1], reverse=True)
+
+        print(f"Loaded {len(self.ic)} InformationContent values from {len(count_by_prefix.keys())} prefixes:")
+        # Now you can print the sorted items
+        for key, value in sorted_by_prefix:
+            print(f'- {key}: {value}')
+
 
     def get_ic(self, node):
         ICs = []

--- a/src/node.py
+++ b/src/node.py
@@ -226,8 +226,8 @@ class InformationContentFactory:
             # Print them in reverse count order.
             print(f"Found {len(unmapped_urls)} unmapped URLs:")
             netlocs_by_count = sorted(unmapped_urls_by_netloc.items(), key=lambda item: len(item[1]), reverse=True)
-            for netloc, urls in netlocs_by_count.items():
-                print(f" - {netloc}: {len(urls)}")
+            for netloc, urls in netlocs_by_count:
+                print(f" - {netloc} [{len(urls)}]")
                 for url in sorted(urls):
                     print(f"   - {url}")
 

--- a/src/node.py
+++ b/src/node.py
@@ -4,6 +4,7 @@ from src.LabeledID import LabeledID
 from collections import defaultdict
 import os
 from bmt import Toolkit
+import curies
 from src.prefixes import PUBCHEMCOMPOUND
 
 class SynonymFactory():
@@ -83,6 +84,10 @@ class DescriptionFactory:
 class InformationContentFactory:
     def __init__(self,ic_file):
         self.ic = {}
+
+        # Load the prefix map for this version of Biolink
+        self.prefix_map =
+
         with open(ic_file, 'r') as inf:
             for line in inf:
                 x = line.strip().split('\t')

--- a/src/node.py
+++ b/src/node.py
@@ -11,6 +11,11 @@ from src.prefixes import PUBCHEMCOMPOUND
 
 
 def get_config():
+    """
+    Retrieve the configuration data from the 'config.json' file.
+
+    :return: The configuration data loaded from the 'config.json' file.
+    """
     cname = os.path.join(os.path.dirname(__file__),'..', 'config.json')
     with open(cname,'r') as json_file:
         data = load(json_file)
@@ -19,7 +24,10 @@ def get_config():
 
 def get_biolink_prefix_map():
     """
-    Return a [CURIE converter](https://pypi.org/project/curies/) for the configured Biolink version.
+    Get the prefix map for the BioLink Model.
+
+    :return: The prefix map for the BioLink Model.
+    :raises RuntimeError: If the BioLink version is not supported.
     """
     config = get_config()
     biolink_version = config['biolink_version']
@@ -40,6 +48,25 @@ def get_biolink_prefix_map():
 
 
 class SynonymFactory:
+    """
+    A class used to load and retrieve synonyms for given node identifiers
+
+    Attributes:
+        synonym_dir (str): The directory where the synonym files are located
+        synonyms (dict): A dictionary to store the loaded synonyms
+
+    Methods:
+        __init__(syndir)
+            Initializes the SynonymFactory with the specified directory
+
+        load_synonyms(prefix)
+            Loads the synonyms for a given prefix from the corresponding files
+
+        get_synonyms(node)
+            Retrieves the synonyms for a given node from the loaded synonyms
+
+    """
+
     def __init__(self,syndir):
         self.synonym_dir = syndir
         self.synonyms = {}
@@ -81,7 +108,8 @@ class SynonymFactory:
 
 
 class DescriptionFactory:
-    """ A factory for loading descriptions where available.
+    """
+    Class to handle loading and retrieving descriptions for nodes.
     """
 
     def __init__(self,rootdir):
@@ -114,6 +142,34 @@ class DescriptionFactory:
 
 
 class InformationContentFactory:
+    """
+
+    InformationContentFactory
+
+    A class for creating and using information content objects.
+
+    Attributes:
+        ic (dict): A dictionary containing information content values for different nodes.
+
+    Methods:
+        __init__(ic_file)
+            Initializes an InformationContentFactory object by loading information content values from a file.
+            The information content values are stored in the 'ic' attribute of the object.
+
+            Parameters:
+                ic_file (str): The path to the file containing the information content values.
+
+        get_ic(node)
+            Returns the minimum information content value for a given node.
+
+            Parameters:
+                node (dict): The node for which to retrieve the information content value.
+
+            Returns:
+                float or None: The minimum information content value for the node,
+                               or None if no information content value is found.
+    """
+
     def __init__(self,ic_file):
         self.ic = {}
         biolink_prefix_map = get_biolink_prefix_map()

--- a/src/node.py
+++ b/src/node.py
@@ -1,10 +1,11 @@
 import requests
+
+from src.babel_utils import get_biolink_prefix_map
 from src.util import Text
 from src.LabeledID import LabeledID
 from collections import defaultdict
 import os
 from bmt import Toolkit
-import curies
 from src.prefixes import PUBCHEMCOMPOUND
 
 class SynonymFactory():
@@ -84,14 +85,13 @@ class DescriptionFactory:
 class InformationContentFactory:
     def __init__(self,ic_file):
         self.ic = {}
-
-        # Load the prefix map for this version of Biolink
-        self.prefix_map =
-
+        biolink_prefix_map = get_biolink_prefix_map()
         with open(ic_file, 'r') as inf:
             for line in inf:
                 x = line.strip().split('\t')
-                node_id = Text.obo_to_curie(x[0])
+                # We talk in CURIEs, but the infores download is in URLs. We can use the Biolink
+                # prefix map to convert between them.
+                node_id = biolink_prefix_map.compress(x[0])
                 ic = x[1]
                 self.ic[node_id] = ic
             print(f"Loaded {len(self.ic)} InformationContent values")

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -1,3 +1,4 @@
+import src.node as node
 import src.datahandlers.mesh as mesh
 import src.datahandlers.obo as obo
 import src.datahandlers.umls as umls
@@ -163,6 +164,9 @@ rule get_ontology_labels_descriptions_and_synonyms:
         # expand("{download_directory}/{onto}/descriptions", download_directory = config['download_directory'], onto = config['ubergraph_ontologies']),
     run:
         obo.pull_uber(config['ubergraph_ontologies'], output.icrdf_filename)
+
+        # Try to load the icRDF.tsv file (this will produce an error if the file can't be read).
+        node.InformationContentFactory(output.icrdf_filename)
 
 ### NCBIGene
 


### PR DESCRIPTION
We previously used `Text.obo_to_curie()` to translate the URLs in the information content values we got back from UberGraph into CURIEs. This doesn't work for complex CURIEs such as NCBIGene:4522, which is `https://identifiers.org/ncbigene/4522` (see https://github.com/TranslatorSRI/NodeNormalization/issues/182). This PR provides a warning and an immediate solution, but #226 covers a more long-term tracking option.

This PR uses the [curies](https://github.com/cthoyt/curies) package to translate URLs into CURIEs for us to use. There will still be issues (where Biolink Model and Ubergraph disagree on HTTP vs HTTPS URLs, see https://github.com/biolink/biolink-model/issues/1431), but this should help improve our information content coverage. Since this code needs `get_config()`, which set up a circular dependency, I also moved `get_config()` into node.py.

Some of these identifiers can't be mapped to CURIEs using the Biolink model -- in most cases this is because UberGraph covers concepts that we don't have in Babel (such as the Hymenoptera Anatomy Ontology), while in others it's because of slight differences in URLs, such as http-vs-https (https://github.com/biolink/biolink-model/issues/1431). Tracking and fixing this in the long term is covered by #226.

I added prefixes for a bunch of URLs to the config.json file:

```
  "ubergraph_iri_stem_to_prefix_map": {
    "https://identifiers.org/ncbigene/": "NCBIGene",
    "http://www.ncbi.nlm.nih.gov/gene/": "NCBIGene",
    "http://www.genenames.org/cgi-bin/gene_symbol_report?hgnc_id=": "HGNC",
    "http://www.informatics.jax.org/marker/MGI:": "MGI"
  }
```

We end up with 129,856 identifiers that can't be mapped:

```
Loaded 3637041 InformationContent values from 63 prefixes:
- NCBITaxon: 2544587
- PR: 232379
- CHEBI: 216255
- NCIT: 187148
- None: 129856
- ENSEMBL: 90375
- NCBIGene: 85209
- GO: 51304
- MONDO: 27730
- FOODON: 25348
- HGNC: 23230
- FBbt: 20110
- HP: 18049
- MGI: 16956
- UBERON: 15837
- MP: 14369
- EMAPA: 8757
- FYPO: 8250
- WBbt: 7555
- dictyBase: 4555
- ENVO: 4292
- OBI: 3979
- MA: 3257
- ZFA: 3217
- CL: 2987
- ECTO: 2887
- PATO: 2860
- WBPhenotype: 2698
- SO: 2632
- ECO: 2077
- PO: 1993
- MAXO: 1848
- TO: 1691
- MI: 1635
- FBcv: 1361
- NBO: 934
- WBls: 779
- APO: 342
- FBdv: 212
- IAO: 208
- BSPO: 140
- MPATH: 96
- PCO: 72
- CARO: 56
- ZFS: 54
- BFO: 35
- FAO: 18
- HsapDv: 12
- CLO: 6
- ExO: 6
- OGMS: 6
- RO: 5
- BTO: 3
- DDANAT: 3
- IDO: 3
- GENEPIO: 2
- SEPIO: 1
- STATO: 1
- UPHENO: 1
- XAO: 1
- schema: 1
- oboInOwl: 1
- foaf: 1
```

Here is the source summary. In this summary, I've tried to group identifiers with similar IRI stems: the number in the first column tells you how many identifiers have each IRI stem. The actual full identifiers are available in [the list of all unmapped URLs](https://github.com/TranslatorSRI/Babel/files/13936061/unmapped-urls-full.txt).

```
   1 Found 129856 unmapped URLs:
   1  - purl.obolibrary.org [76768]
 586    - http://purl.obolibrary.org/obo/AISM_
   6    - http://purl.obolibrary.org/obo/APOLLO_SV_
   1    - http://purl.obolibrary.org/obo/BCO_
  97    - http://purl.obolibrary.org/obo/BS_
   3    - http://purl.obolibrary.org/obo/CDNO_
   4    - http://purl.obolibrary.org/obo/CHMO_
 203    - http://purl.obolibrary.org/obo/CHR_
1516    - http://purl.obolibrary.org/obo/CLAO_
  74    - http://purl.obolibrary.org/obo/COB_
 214    - http://purl.obolibrary.org/obo/COLAO_
   9    - http://purl.obolibrary.org/obo/CP_
   1    - http://purl.obolibrary.org/obo/D96882F1-8709-49AB-BCA9-772A67EA6C33
   1    - http://purl.obolibrary.org/obo/DRON_
   2    - http://purl.obolibrary.org/obo/ECOCORE_
   1    - http://purl.obolibrary.org/obo/Ensembl#_BCE_
   2    - http://purl.obolibrary.org/obo/Ensembl#_BruAb1_
   2    - http://purl.obolibrary.org/obo/Ensembl#_BruAb2_
   1    - http://purl.obolibrary.org/obo/Ensembl#_HI_
   1    - http://purl.obolibrary.org/obo/Ensembl#_MG_
   9    - http://purl.obolibrary.org/obo/Ensembl#_MJ_
   7    - http://purl.obolibrary.org/obo/Ensembl#_MPN_
   2    - http://purl.obolibrary.org/obo/Ensembl#_NIES39_
   2    - http://purl.obolibrary.org/obo/Ensembl#_Nos7524_
   1    - http://purl.obolibrary.org/obo/Ensembl#_SP_
   1    - http://purl.obolibrary.org/obo/Ensembl#_SYNPCC7002_
  47    - http://purl.obolibrary.org/obo/EnsemblBacteria#_BAB1_
  23    - http://purl.obolibrary.org/obo/EnsemblBacteria#_BAB2_
  32    - http://purl.obolibrary.org/obo/EnsemblBacteria#_BCAN_
  28    - http://purl.obolibrary.org/obo/EnsemblBacteria#_BMEA_
   5    - http://purl.obolibrary.org/obo/EnsemblBacteria#_BMI_
  33    - http://purl.obolibrary.org/obo/EnsemblBacteria#_BOV_
  33    - http://purl.obolibrary.org/obo/EnsemblBacteria#_BSUIS_
  40    - http://purl.obolibrary.org/obo/EnsemblBacteria#_BruAb1_
  31    - http://purl.obolibrary.org/obo/EnsemblBacteria#_BruAb2_
   2    - http://purl.obolibrary.org/obo/EnsemblBacteria#_KOX_
  12    - http://purl.obolibrary.org/obo/EnsemblBacteria#_NWMN_
   4    - http://purl.obolibrary.org/obo/EnsemblBacteria#_SAHV_
 659    - http://purl.obolibrary.org/obo/EnsemblBacteria#_SAOUHSC_
   5    - http://purl.obolibrary.org/obo/EnsemblBacteria#_SAUSA300_
  24    - http://purl.obolibrary.org/obo/EnsemblBacteria#_SE_
   1    - http://purl.obolibrary.org/obo/EnsemblBacteria#_Saro_
   2    - http://purl.obolibrary.org/obo/EnsemblBacteria#_SaurJH1_
   1    - http://purl.obolibrary.org/obo/EnsemblBacteria#_SaurJH9_
   2    - http://purl.obolibrary.org/obo/EnsemblBacteria#_USA300HOU_
   4    - http://purl.obolibrary.org/obo/FLOPO_
  10    - http://purl.obolibrary.org/obo/GAZ_
   1    - http://purl.obolibrary.org/obo/GEO_
 913    - http://purl.obolibrary.org/obo/GNO_
  40    - http://purl.obolibrary.org/obo/GOCHE_
2596    - http://purl.obolibrary.org/obo/HAO_
 144    - http://purl.obolibrary.org/obo/LEPAO_
   6    - http://purl.obolibrary.org/obo/MFOMD_
   4    - http://purl.obolibrary.org/obo/MF_
 862    - http://purl.obolibrary.org/obo/MMO_
 109    - http://purl.obolibrary.org/obo/MOD_
   1    - http://purl.obolibrary.org/obo/MOP_
51289    - http://purl.obolibrary.org/obo/MRO_
 178    - http://purl.obolibrary.org/obo/MmusDv_
   2    - http://purl.obolibrary.org/obo/NCBITaxon#_species_
   1    - http://purl.obolibrary.org/obo/NCBITaxon#_taxonomic_
 307    - http://purl.obolibrary.org/obo/OARCS_
13364    - http://purl.obolibrary.org/obo/OBA_
  11    - http://purl.obolibrary.org/obo/OGG_
   1    - http://purl.obolibrary.org/obo/OMIABIS_
   6    - http://purl.obolibrary.org/obo/OPL_
   1    - http://purl.obolibrary.org/obo/OPMI_
2312    - http://purl.obolibrary.org/obo/PCL_
 574    - http://purl.obolibrary.org/obo/PECO_
 254    - http://purl.obolibrary.org/obo/PPO_
   2    - http://purl.obolibrary.org/obo/REO_
   1    - http://purl.obolibrary.org/obo/RnorDv_
  29    - http://purl.obolibrary.org/obo/TS_
   6    - http://purl.obolibrary.org/obo/UO_
   1    - http://purl.obolibrary.org/obo/emapa#Tmp_new_
   1    - http://purl.obolibrary.org/obo/emapa#group_
   1    - http://purl.obolibrary.org/obo/pco.owl/PCO_
   7    - https://purl.obolibrary.org/obo/PCO_
   1  - bar.utoronto.ca [16248]
16248    - https://bar.utoronto.ca/thalemine/portal.do?externalids=
   1  - rgd.mcw.edu [8198]
8198    - http://rgd.mcw.edu/rgdweb/report/gene/main.html?id=
   1  - www.yeastgenome.org [5950]
5950    - http://www.yeastgenome.org/locus/
   1  - www.pombase.org [5121]
5121    - http://www.pombase.org/spombe/result/
   1  - www.wormbase.org [4779]
4779    - http://www.wormbase.org/species/c_
   1  - flybase.org [4112]
4112    - http://flybase.org/reports/
   1  - www.ecogene.org [4042]
4042    - http://www.ecogene.org/gene/
   1  - zfin.org [3432]
3432    - http://zfin.org/action/marker/view/ZDB-GENE-
   1  - birdgenenames.org [544]
 544    - http://birdgenenames.org/cgnc/GeneReport?id=
   1  - www.ensemblgenomes.org [279]
 279    - http://www.ensemblgenomes.org/id/
   1  - www.ensembl.org [184]
 184    - http://www.ensembl.org/id/
   1  - swisslipids.org [100]
 100    - https://swisslipids.org/rdf/SLM_
   1  - www.jcvi.org [95]
   7    - http://www.jcvi.org/framework/nsf2_full_mtg#CL_
   1    - http://www.jcvi.org/framework/nsf2_full_mtg#UBERON_
  87    - http://www.jcvi.org/framework/nsf2_full_mtg#pCL_
   1  - bioregistry.io [3]
   3    - https://bioregistry.io/lipidmaps:
   1  - purl.brain-bican.org [1]
   1    - https://purl.brain-bican.org/ontology/hbao/HBA_

```
