### PR TITLE
Add clique identifier count to synonyms

### DIFF
--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -435,12 +435,16 @@ def write_compendium(synonym_list,ofname,node_type,labels={},extra_prefixes=[],i
                     # could we consider the information content values? -- but in the interests of getting something
                     # working quickly, this code restores that previous method.
 
-                    # Since synonyms_list is sorted,
+                    # Since synonyms_list is sorted, we can use the length of the first term as the synonym.
                     if len(synonyms_list) == 0:
                         logging.debug(f"Synonym list for {node} is empty: no valid name. Skipping.")
                         continue
                     else:
                         document["shortest_name_length"] = len(synonyms_list[0])
+
+                    # Cliques with more identifiers might be better than cliques with smaller identifiers.
+                    # So let's try to incorporate that here.
+                    document["clique_identifier_count"] = len(node["identifiers"])
 
                     # We want to see if we can use the CURIE suffix to sort concepts with similar identifiers.
                     # We want to sort this numerically, so we only do this if the CURIE suffix is numerical.

--- a/src/synonyms/synonymconflation.py
+++ b/src/synonyms/synonymconflation.py
@@ -155,8 +155,31 @@ def conflate_synonyms(synonym_files, conflation_file, output):
                             final_conflation['types'].append(typ)
                             types_included.add(typ)
 
-                    # Since we no longer use shortest_name_length, I'm just not going to bother writing it
-                    # into the final conflations.
+                    # Handle shortest_name_length.
+                    if 'shortest_name_length' in synonym:
+                        # If we don't have a shortest_name_length in final_conflation OR if
+                        # it is smaller than synonym['shortest_name_length'], use that instead.
+                        if 'shortest_name_length' not in final_conflation or \
+                                synonym['shortest_name_length'] < final_conflation['shortest_name_length']:
+                            final_conflation['shortest_name_length'] = synonym['shortest_name_length']
+
+                    # Handle clique_identifier_count.
+                    if 'clique_identifier_count' in synonym:
+                        if 'clique_identifier_count' not in final_conflation:
+                            # If we don't have a clique_identifier_count in final_conflation, set it to zero.
+                            final_conflation['clique_identifier_count'] = 0
+
+                        # If we do have a clique_identifier_count in final_conflation, add the count from this synonym.
+                        final_conflation['clique_identifier_count'] += synonym['clique_identifier_count']
+
+                    # Handle taxa.
+                    if 'taxa' in synonym:
+                        if 'taxa' not in final_conflation:
+                            final_conflation['taxa'] = set()
+                        final_conflation.update(synonym['taxa'])
+
+            # Convert the taxa into a list.
+            final_conflation['taxa'] = sorted(final_conflation['taxa'])
 
             # Checks
             ## assert final_conflation['curie'] == curie


### PR DESCRIPTION
We discussed that we might be able to improve how we use UMLS by incorporating the clique count into the search, i.e. if multiple synonyms have the same score, the one with the higher clique count should be sorted higher up. This PR modifies Babel to include the clique identifier count (as `clique_identifier_count`) in synonym files. It also fixes a minor bug in which conflated synonym files did not get the correct taxon information set on them.