### PR TITLE
Switched Dockerfile to Python 3.12

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,7 @@
 name: 'Release a new version to Github Packages'
 
 on:
+  push:
   release:
     types: [published]
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,6 @@
 name: 'Release a new version to Github Packages'
 
 on:
-  push:
   release:
     types: [published]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,11 @@
 # Use the RENCI Python image to make it easier to work with other
 # RENCI Docker packages and to make sure we have an up to date image.
 # (https://github.com/TranslatorSRI/RENCI-Python-image)
-FROM renciorg/renci-python-image:latest
+# FROM renciorg/renci-python-image:latest
+#
+# This is still at Python 3.9, so I'm going to use Python Latest, which
+# should give us a Debian with Python 3.12+.
+FROM python:latest
 
 # Configuration options:
 # - ${ROOT} is where Babel source code will be copied.

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ RUN apt-get install -y vim
 RUN apt-get install -y rsync
 RUN apt-get install -y jq
 
+# Create a non-root-user.
+RUN adduser --home ${ROOT} --uid 1000 nru
+
 # Copy directory into Docker.
 COPY --chown=nru . ${ROOT}
 

--- a/config.json
+++ b/config.json
@@ -4,9 +4,9 @@
   "intermediate_directory": "babel_outputs/intermediate",
   "output_directory": "babel_outputs",
 
-  "biolink_version": "3.6.0",
+  "biolink_version": "4.1.6",
   "umls_version": "2023AB",
-  "rxnorm_version": "01022024",
+  "rxnorm_version": "03042024",
 
   "ncbi_files": ["gene2ensembl.gz", "gene_info.gz", "gene_orthologs.gz", "gene_refseq_uniprotkb_collab.gz", "mim2gene_medgen"],
   "ubergraph_ontologies": ["UBERON", "CL", "GO", "NCIT", "ECO", "ECTO", "ENVO", "HP", "UPHENO","BFO","BSPO","CARO","CHEBI","CP","GOREL","IAO","MAXO","MONDO","PATO","PR","RO","UBPROP"],


### PR DESCRIPTION
Babel used to use renciorg/renci-python-image:latest, but this is still on Python 3.9, which is causing issues with one of our dependencies. This PR upgrades that to [python:latest](https://hub.docker.com/_/python), which should give up Python 3.12+.

This PR also updates Biolink Model to 4.1.6 and RxNorm to 03042024.