### PR TITLE
Rename ncbi.nih.gov is now ncbi.nlm.nih.gov

### DIFF
--- a/src/datahandlers/ncbigene.py
+++ b/src/datahandlers/ncbigene.py
@@ -3,13 +3,13 @@ import gzip
 
 
 def pull_ncbigene(filenames):
-    remotedir = 'https://ftp.ncbi.nih.gov/gene/DATA/'
+    remotedir = 'https://ftp.ncbi.nlm.nih.gov/gene/DATA/'
     for fn in filenames:
-        pull_via_ftp('ftp.ncbi.nih.gov', '/gene/DATA', fn, decompress_data=False, outfilename=f'NCBIGene/{fn}')
+        pull_via_ftp('ftp.ncbi.nlm.nih.gov', '/gene/DATA', fn, decompress_data=False, outfilename=f'NCBIGene/{fn}')
 
 
 def pull_ncbigene_labels_synonyms_and_taxa():
-    # File format described here: https://ftp.ncbi.nih.gov/gene/DATA/README
+    # File format described here: https://ftp.ncbi.nlm.nih.gov/gene/DATA/README
     ifname = make_local_name('gene_info.gz', subpath='NCBIGene')
     labelname = make_local_name('labels', subpath='NCBIGene')
     synname = make_local_name('synonyms', subpath='NCBIGene')

--- a/src/datahandlers/ncbitaxon.py
+++ b/src/datahandlers/ncbitaxon.py
@@ -3,7 +3,7 @@ from src.prefixes import NCBITAXON
 import tarfile
 
 def pull_ncbitaxon():
-    pull_via_ftp('ftp.ncbi.nih.gov','/pub/taxonomy','taxdump.tar.gz',decompress_data=True,outfilename=f'{NCBITAXON}/taxdump.tar')
+    pull_via_ftp('ftp.ncbi.nlm.nih.gov','/pub/taxonomy','taxdump.tar.gz',decompress_data=True,outfilename=f'{NCBITAXON}/taxdump.tar')
 
 def make_labels_and_synonyms(infile,labelfile,synfile):
     taxtar = tarfile.open(infile,'r')


### PR DESCRIPTION
ncbi.nih.gov has changed to ncbi.nlm.nih.gov. This PR updates URLs in Babel.