### PR TITLE
Read UNII file with Latin-1 character

### DIFF
--- a/src/datahandlers/unii.py
+++ b/src/datahandlers/unii.py
@@ -38,7 +38,7 @@ def make_labels_and_synonyms(inputfile,labelfile,synfile):
     syncol = 0
     wrotelabels = set()
     wrotesyns = set()
-    with open(inputfile,'r') as inf, open(labelfile,'w') as lf, open(synfile,'w') as sf:
+    with open(inputfile,'r', encoding='latin-1') as inf, open(labelfile,'w') as lf, open(synfile,'w') as sf:
         h = inf.readline()
         for line in inf:
             parts = line.strip().split('\t')


### PR DESCRIPTION
Line 62637 of the January 27, 2024 release reads:
> Alcolec Granules†	bn	1DI56QDM62	LECITHIN, SOYBEAN

This is encoded in Latin-1, not UTF-8, so we need to modify how we read this file.