### PR TITLE
Move DrugChemical synonyms into subdirectory

### DIFF
--- a/src/reports/compendia_per_file_reports.py
+++ b/src/reports/compendia_per_file_reports.py
@@ -31,7 +31,7 @@ def assert_files_in_directory(dir, files, report_file):
     """
 
     logging.info(f"Expect files in directory {dir} to be equal to {files}")
-    file_list = os.listdir(dir)
+    file_list = [f for f in os.listdir(dir) if os.path.isfile(os.path.join(dir, f))]
     assert set(file_list) == set(files)
 
     # If we passed, write the output to the check_file.

--- a/src/snakefiles/chemical.snakefile
+++ b/src/snakefiles/chemical.snakefile
@@ -219,7 +219,7 @@ rule chemical_compendia:
         icrdf_filename = config['download_directory'] + '/icRDF.tsv',
     output:
         expand("{od}/compendia/{ap}", od = config['output_directory'], ap = config['chemical_outputs']),
-        expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['chemical_outputs'])
+        expand("{od}/synonyms/drugchemical/{ap}", od = config['output_directory'], ap = config['chemical_outputs'])
     run:
         chemicals.build_compendia(input.typesfile,input.untyped_file, input.icrdf_filename)
 
@@ -292,7 +292,7 @@ rule check_drug:
 rule chemical:
     input:
         config['output_directory']+'/reports/chemical_completeness.txt',
-        expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['chemical_outputs']),
+        expand("{od}/synonyms/drugchemical/{ap}", od = config['output_directory'], ap = config['chemical_outputs']),
         reports = expand("{od}/reports/{ap}",od=config['output_directory'], ap = config['chemical_outputs'])
     output:
         x=config['output_directory']+'/reports/chemicals_done'

--- a/src/snakefiles/drugchemical.snakefile
+++ b/src/snakefiles/drugchemical.snakefile
@@ -45,7 +45,7 @@ rule drugchemical_conflation:
 rule drugchemical_conflated_synonyms:
     input:
         drugchemical_conflation=[config['output_directory']+'/conflation/DrugChemical.txt'],
-        chemical_synonyms=expand("{do}/synonyms/{co}", do=config['output_directory'], co=config['chemical_outputs']),
+        chemical_synonyms=expand("{do}/synonyms/drugchemicals/{co}", do=config['output_directory'], co=config['chemical_outputs']),
     output:
         drugchemical_conflated=config['output_directory']+'/synonyms/DrugChemicalConflated.txt',
     run:


### PR DESCRIPTION
We currently create a DrugChemicalConflated.txt synonyms file using the DrugChemical conflation information to combine cliques. However, we still include synonym names for each individual chemical output (i.e. SmallMolecule.txt, Drug.txt, and so on). This PR moves those files into a subdirectory, so we still create those files, but they are in a separate directory so a user won't get confused and accidentally use both DrugChemicalConflated.txt and the redundant synonyms in the individual chemical output files.