### PR TITLE
Minor fixes

### DIFF
--- a/scripts/babel-build.sh
+++ b/scripts/babel-build.sh
@@ -14,7 +14,7 @@ export CORES=5
 export DRY_RUN=1
 
 # Verbose: if set, produce verbose output.
-export VERBOSE=1
+export VERBOSE=
 
 # Keep going: if set, then keep going if one job errors out.
 export KEEP_GOING=1

--- a/src/snakefiles/reports.snakefile
+++ b/src/snakefiles/reports.snakefile
@@ -1,4 +1,4 @@
-from src.snakefiles.util import get_all_compendia, get_all_synonyms_with_drugchemicalconflated
+from src.snakefiles.util import get_all_compendia, get_all_synonyms
 import os
 
 from src.reports.compendia_per_file_reports import assert_files_in_directory, \
@@ -13,7 +13,7 @@ conflations_path = config['output_directory'] + '/conflation'
 compendia_files = get_all_compendia(config)
 
 # Expected synonym files.
-synonyms_files = get_all_synonyms_with_drugchemicalconflated(config)
+synonyms_files = get_all_synonyms(config)
 
 # Expected conflation files.
 conflation_files = config['geneprotein_outputs'] + config['drugchemical_outputs']

--- a/src/snakefiles/util.py
+++ b/src/snakefiles/util.py
@@ -14,8 +14,14 @@ def get_all_compendia(config):
             config['macromolecularcomplex_outputs'])
 
 
-# List of all the synonym files, except DrugChemicalConflated.
-def get_synonyms(config):
+def get_all_synonyms(config):
+    """
+    List of all the synonym files, including DrugChemicalConflated. Note that this duplicates synonyms: chemical output
+    synonyms will be in both the individual chemical outputs and the DrugChemicalConflated file.
+
+    :param config: The Babel config to use.
+    :return: A list of filenames expected in the `synonyms/` directory.
+    """
     return (
         config['anatomy_outputs'] +
         config['gene_outputs'] +
@@ -25,15 +31,41 @@ def get_synonyms(config):
         config['chemical_outputs'] +
         config['taxon_outputs'] +
         config['genefamily_outputs'] +
-        # config['drugchemicalconflated_synonym_outputs'] +
+        config['drugchemicalconflated_synonym_outputs'] +
         config['umls_outputs'] +
         config['macromolecularcomplex_outputs']
     )
 
 
-# List of all the synonym files including DrugChemicalConflated instead of the files it
-# duplicates.
+def get_all_synonyms_except_drugchemicalconflated(config):
+    """
+    List of all the synonym files, except DrugChemicalConflated.
+
+    :param config: The Babel config to use.
+    :return: A list of filenames expected in the `synonyms/` directory.
+    """
+    return (
+            config['anatomy_outputs'] +
+            config['gene_outputs'] +
+            config['protein_outputs'] +
+            config['disease_outputs'] +
+            config['process_outputs'] +
+            config['chemical_outputs'] +
+            config['taxon_outputs'] +
+            config['genefamily_outputs'] +
+            # config['drugchemicalconflated_synonym_outputs'] +
+            config['umls_outputs'] +
+            config['macromolecularcomplex_outputs']
+    )
+
+
 def get_all_synonyms_with_drugchemicalconflated(config):
+    """
+    List of all the synonym files including DrugChemicalConflated instead of the files it duplicates.
+
+    :param config: The Babel config to use.
+    :return: A list of filenames expected in the `synonyms/` directory.
+    """
     return (
             config['anatomy_outputs'] +
             config['gene_outputs'] +


### PR DESCRIPTION
This PR includes two minor fixes to Babel:
- We turn off verbose mode -- this didn't previously work, but now it does, and boy is it verbose.
- My plan to move drug-conflated synonyms into an alternate directory has failed (https://github.com/TranslatorSRI/Babel/pull/248), so this PR reverts the appropriate report and checks whether the duplicated synonym files are in the `synonyms/` directory.