### PR TITLE
Fix EFO labels and misc fixes

### DIFF
--- a/src/datahandlers/ec.py
+++ b/src/datahandlers/ec.py
@@ -25,7 +25,7 @@ class ECgraph:
         start = dt.now()
         self.m= pyoxigraph.MemoryStore()
         with open(ifname,'rb') as inf:
-            self.m.load(inf,'application/rdf+xml',base_iri='http://nihilism.com/')
+            self.m.load(inf,'application/rdf+xml',base_iri='http://example.org/')
         end = dt.now()
         print('loading complete')
         print(f'took {end-start}')

--- a/src/datahandlers/efo.py
+++ b/src/datahandlers/efo.py
@@ -25,7 +25,7 @@ class EFOgraph:
         start = dt.now()
         self.m= pyoxigraph.MemoryStore()
         with open(ifname,'rb') as inf:
-            self.m.load(inf,'application/rdf+xml',base_iri='http://nihilism.com/')
+            self.m.load(inf,'application/rdf+xml',base_iri='http://example.org/')
         end = dt.now()
         print('loading complete')
         print(f'took {end-start}')

--- a/src/datahandlers/efo.py
+++ b/src/datahandlers/efo.py
@@ -1,3 +1,5 @@
+import re
+
 from src.prefixes import EFO,ORPHANET
 from src.babel_utils import pull_via_urllib
 from src.babel_utils import make_local_name
@@ -44,7 +46,12 @@ class EFOgraph:
                     iterm = str(row['x'])
                     label = str(row['label'])
                     if label.startswith('"'):
-                        label=label[1:-1]
+                        # If the label ends with '"@[language code]", edit that out.
+                        pattern = re.compile(r"^\"(.*)\"@\w+$")
+                        if pattern.match(label):
+                            label = re.sub(pattern, r"\1", label)
+                        else:
+                            label = label[1:-1]
                     efoid = iterm[:-1].split('/')[-1]
                     if not efoid.startswith("EFO_"):
                         continue

--- a/src/datahandlers/kegg.py
+++ b/src/datahandlers/kegg.py
@@ -1,3 +1,5 @@
+import re
+
 import requests
 import traceback
 from more_itertools import chunked
@@ -150,7 +152,7 @@ def get_sequence(compound_id):
             raise (x)
     # OK, anything left should be a 3-letter AA string
     # remove parenthetical comments
-    regex = "\((.*?)\)"
+    regex = r"\((.*?)\)"
     xprime = re.sub(regex, "", x)
     # do a cleanup for things like Arg-NH2
     xps = xprime.split()


### PR DESCRIPTION
For EFO with language codes, edit them out of the labels. We currently ignore language codes, although in the future we might want to filter to English labels. Closes #271.

This PR also:
- replaces nihilism.com with example.org to make it clearer that it is intended as a stand-in.
- fixes an unrelated regex in KEGG that I noticed because of a warning.