### PR TITLE
Add manual concords for Disease to improve Opioid and Alcohol Use Disorder

### DIFF
--- a/config.json
+++ b/config.json
@@ -30,7 +30,7 @@
 
   "disease_labelsandsynonyms": ["MONDO","DOID","Orphanet","HP","MESH","NCIT","UMLS","SNOMEDCT","EFO"],
   "disease_ids": ["MONDO","DOID","Orphanet","HP","MESH","NCIT","UMLS","OMIM","EFO"],
-  "disease_concords": ["HP","MONDO","UMLS","DOID","EFO"],
+  "disease_concords": ["HP","MONDO","UMLS","DOID","EFO", "Manual"],
   "disease_outputs": ["Disease.txt", "PhenotypicFeature.txt"],
 
   "process_labels": ["GO","REACT","RHEA","EC","SMPDB","PANTHER.PATHWAY"],

--- a/input_data/manual_concords/disease.txt
+++ b/input_data/manual_concords/disease.txt
@@ -1,23 +1,23 @@
 # All lines starting with '#' will be removed from this file before being used as a
-# concord.
+# concord. All pipes ('|') will be converted into tab characters.
 #
 # OPIOID USE DISORDER
 #
 # As per https://github.com/TranslatorSRI/Babel/issues/265, we would like to combine
 # a bunch of opioid use order cliques.
 # Opioid abuse
-MONDO:0001225   xref    UMLS:C4237237
+MONDO:0001225|xref|UMLS:C4237237
 # Opioid dependence (which we combine incorrectly with opiate dependence following MONDO)
-MONDO:0005530   xref    UMLS:C4324621
+MONDO:0005530|xref|UMLS:C4324621
 # This combination is as per https://github.com/TranslatorSRI/Babel/issues/270
-UMLS:C4324621   xref    EFO:0010702
+UMLS:C4324621|xref|EFO:0010702
 # We also combine opioid dependence with both UMLS:C4237239 "Opioid use disorder, severe"
 # and UMLS:C4237238 "Opioid use disorder, moderate".
-MONDO:0005530   xref    UMLS:C4237238
-MONDO:0005530   xref    UMLS:C4237239
+MONDO:0005530|xref|UMLS:C4237238
+MONDO:0005530|xref|UMLS:C4237239
 
 #
 # ALCOHOL USE DISORDER
 #
-MONDO:0002046   xref    HP:0430037
-MONDO:0007079   xref    HP:0030955
+MONDO:0002046|xref|HP:0430037
+MONDO:0007079|xref|HP:0030955

--- a/input_data/manual_concords/disease.txt
+++ b/input_data/manual_concords/disease.txt
@@ -1,5 +1,5 @@
 # All lines starting with '#' will be removed from this file before being used as a
-# concord. All pipes ('|') will be converted into tab characters.
+# concord. All pipes ('	') will be converted into tab characters.
 #
 # OPIOID USE DISORDER
 #
@@ -7,42 +7,42 @@
 # a bunch of opioid use order cliques.
 
 # Opioid dependence (which we combine incorrectly with opiate dependence following MONDO)
-MONDO:0005530|xref|UMLS:C4324621
+MONDO:0005530	xref	UMLS:C4324621
 # This combination is as per https://github.com/TranslatorSRI/Babel/issues/270
-UMLS:C4324621|xref|EFO:0010702
+UMLS:C4324621	xref	EFO:0010702
 
 # For these UMLS terms, we rather imprecisely connect them with:
 # - mild -> MONDO:0001225 "opioid abuse" and UMLS:C4237237 "Opioid use disorder, mild"
-MONDO:0001225|oio:closeMatch|UMLS:C4237237
-UMLS:C4237237|oio:closeMatch|UMLS:C4268215
-UMLS:C4237237|oio:closeMatch|UMLS:C4509038
-UMLS:C4237237|oio:closeMatch|UMLS:C4509039
+MONDO:0001225	oio:closeMatch	UMLS:C4237237
+UMLS:C4237237	oio:closeMatch	UMLS:C4268215
+UMLS:C4237237	oio:closeMatch	UMLS:C4509038
+UMLS:C4237237	oio:closeMatch	UMLS:C4509039
 
 
 # There are some unclear UMLS terms re: opioid induced disorders. Let's stick them into
 # "opioid abuse" for now, but we might want to petition for a new MONDO term.
-MONDO:0001225|oio:closeMatch|UMLS:C3647215
-MONDO:0001225|oio:closeMatch|UMLS:C4536271
-MONDO:0001225|oio:closeMatch|UMLS:C4237251
-MONDO:0001225|oio:closeMatch|UMLS:C4237242
-MONDO:0001225|oio:closeMatch|UMLS:C4237245
-MONDO:0001225|oio:closeMatch|UMLS:C2874460
-MONDO:0001225|oio:closeMatch|UMLS:C2874467
-MONDO:0001225|oio:closeMatch|UMLS:C2874468
-MONDO:0001225|oio:closeMatch|UMLS:C2874461
-MONDO:0001225|oio:closeMatch|UMLS:C2874469
+MONDO:0001225	oio:closeMatch	UMLS:C3647215
+MONDO:0001225	oio:closeMatch	UMLS:C4536271
+MONDO:0001225	oio:closeMatch	UMLS:C4237251
+MONDO:0001225	oio:closeMatch	UMLS:C4237242
+MONDO:0001225	oio:closeMatch	UMLS:C4237245
+MONDO:0001225	oio:closeMatch	UMLS:C2874460
+MONDO:0001225	oio:closeMatch	UMLS:C2874467
+MONDO:0001225	oio:closeMatch	UMLS:C2874468
+MONDO:0001225	oio:closeMatch	UMLS:C2874461
+MONDO:0001225	oio:closeMatch	UMLS:C2874469
 
 # For these UMLS terms, we rather imprecisely connect them with:
 # - moderate/severe -> MONDO:0005530 "opiate dependence",
 #   UMLS:C4237238 "Opioid use disorder, moderate" and UMLS:C4237239 "Opioid use disorder, severe"
-MONDO:0005530|oio:closeMatch|UMLS:C4237238
-UMLS:C4237238|oio:closeMatch|UMLS:C4268216
-UMLS:C4237238|oio:closeMatch|UMLS:C4509040
-UMLS:C4237238|oio:closeMatch|UMLS:C4509041
+MONDO:0005530	oio:closeMatch	UMLS:C4237238
+UMLS:C4237238	oio:closeMatch	UMLS:C4268216
+UMLS:C4237238	oio:closeMatch	UMLS:C4509040
+UMLS:C4237238	oio:closeMatch	UMLS:C4509041
 
-MONDO:0005530|oio:closeMatch|UMLS:C4237239
-UMLS:C4237239|oio:closeMatch|UMLS:C4509042
-UMLS:C4237239|oio:closeMatch|UMLS:C4509043
+MONDO:0005530	oio:closeMatch	UMLS:C4237239
+UMLS:C4237239	oio:closeMatch	UMLS:C4509042
+UMLS:C4237239	oio:closeMatch	UMLS:C4509043
 
 
 #
@@ -50,61 +50,61 @@ UMLS:C4237239|oio:closeMatch|UMLS:C4509043
 #
 # MONDO:0002046 "alcohol abuse" (http://purl.obolibrary.org/obo/MONDO_0002046)
 # - includes UMLS:C4236927 "Alcohol use disorder, mild"
-MONDO:0002046|xref|HP:0430037
-MONDO:0002046|oio:closeMatch|UMLS:C4236927
-MONDO:0002046|oio:closeMatch|UMLS:C4509032
-MONDO:0002046|oio:closeMatch|UMLS:C4509033
-MONDO:0002046|oio:closeMatch|UMLS:C4268203
-MONDO:0002046|oio:closeMatch|UMLS:C4268202
-MONDO:0002046|oio:closeMatch|UMLS:C4236955
-MONDO:0002046|oio:closeMatch|UMLS:C4236934
-MONDO:0002046|oio:closeMatch|UMLS:C4236949
-MONDO:0002046|oio:closeMatch|UMLS:C4236940
-MONDO:0002046|oio:closeMatch|UMLS:C4236926
-MONDO:0002046|oio:closeMatch|UMLS:C4236953
-MONDO:0002046|oio:closeMatch|UMLS:C4236932
-MONDO:0002046|oio:closeMatch|UMLS:C4236947
-MONDO:0002046|oio:closeMatch|UMLS:C4236938
-MONDO:0002046|oio:closeMatch|UMLS:C4236946
-MONDO:0002046|oio:closeMatch|UMLS:C4236924
-MONDO:0002046|oio:closeMatch|UMLS:C4236923
-MONDO:0002046|oio:closeMatch|UMLS:C2874409
-MONDO:0002046|oio:closeMatch|UMLS:C2874416
-MONDO:0002046|oio:closeMatch|UMLS:C2874418
-MONDO:0002046|oio:closeMatch|UMLS:C2874419
-MONDO:0002046|oio:closeMatch|UMLS:C2874410
-MONDO:0002046|oio:closeMatch|UMLS:C2874420
-MONDO:0002046|oio:closeMatch|UMLS:C4268214
-MONDO:0002046|oio:closeMatch|UMLS:C4236937
+MONDO:0002046	xref	HP:0430037
+MONDO:0002046	oio:closeMatch	UMLS:C4236927
+MONDO:0002046	oio:closeMatch	UMLS:C4509032
+MONDO:0002046	oio:closeMatch	UMLS:C4509033
+MONDO:0002046	oio:closeMatch	UMLS:C4268203
+MONDO:0002046	oio:closeMatch	UMLS:C4268202
+MONDO:0002046	oio:closeMatch	UMLS:C4236955
+MONDO:0002046	oio:closeMatch	UMLS:C4236934
+MONDO:0002046	oio:closeMatch	UMLS:C4236949
+MONDO:0002046	oio:closeMatch	UMLS:C4236940
+MONDO:0002046	oio:closeMatch	UMLS:C4236926
+MONDO:0002046	oio:closeMatch	UMLS:C4236953
+MONDO:0002046	oio:closeMatch	UMLS:C4236932
+MONDO:0002046	oio:closeMatch	UMLS:C4236947
+MONDO:0002046	oio:closeMatch	UMLS:C4236938
+MONDO:0002046	oio:closeMatch	UMLS:C4236946
+MONDO:0002046	oio:closeMatch	UMLS:C4236924
+MONDO:0002046	oio:closeMatch	UMLS:C4236923
+MONDO:0002046	oio:closeMatch	UMLS:C2874409
+MONDO:0002046	oio:closeMatch	UMLS:C2874416
+MONDO:0002046	oio:closeMatch	UMLS:C2874418
+MONDO:0002046	oio:closeMatch	UMLS:C2874419
+MONDO:0002046	oio:closeMatch	UMLS:C2874410
+MONDO:0002046	oio:closeMatch	UMLS:C2874420
+MONDO:0002046	oio:closeMatch	UMLS:C4268214
+MONDO:0002046	oio:closeMatch	UMLS:C4236937
 
 # MONDO:0007079 "alcohol dependence" (http://purl.obolibrary.org/obo/MONDO_0007079)
 # - includes UMLS:C0001956 "Alcohol Use Disorder"
 # - includes UMLS:C4236929 "Alcohol use disorder, severe"
 # - includes UMLS:C4236928 "Alcohol use disorder, moderate"
-MONDO:0007079|xref|HP:0030955
-MONDO:0007079|xref|UMLS:C0001956
-MONDO:0007079|oio:closeMatch|UMLS:C0679288
-MONDO:0007079|oio:closeMatch|UMLS:C4236929
-MONDO:0007079|oio:closeMatch|UMLS:C4236928
-MONDO:0007079|oio:closeMatch|UMLS:C0679289
-MONDO:0007079|oio:closeMatch|EFO:0009458
-MONDO:0007079|oio:closeMatch|UMLS:C0679290
-MONDO:0007079|oio:closeMatch|UMLS:C0841000
-MONDO:0007079|oio:closeMatch|UMLS:C0679287
-MONDO:0007079|oio:closeMatch|UMLS:C4509036
-MONDO:0007079|oio:closeMatch|UMLS:C4509034
-MONDO:0007079|oio:closeMatch|UMLS:C4509037
-MONDO:0007079|oio:closeMatch|UMLS:C4509035
-MONDO:0007079|oio:closeMatch|UMLS:C4268207
-MONDO:0007079|oio:closeMatch|UMLS:C4268205
-MONDO:0007079|oio:closeMatch|UMLS:C4268213
-MONDO:0007079|oio:closeMatch|UMLS:C4268212
-MONDO:0007079|oio:closeMatch|UMLS:C4268206
-MONDO:0007079|oio:closeMatch|UMLS:C4268204
-MONDO:0007079|oio:closeMatch|UMLS:C4268209
-MONDO:0007079|oio:closeMatch|UMLS:C4268208
-MONDO:0007079|oio:closeMatch|UMLS:C4268211
-MONDO:0007079|oio:closeMatch|UMLS:C4268210
-MONDO:0007079|oio:closeMatch|UMLS:C3650363
-MONDO:0007079|oio:closeMatch|UMLS:C4536264
+MONDO:0007079	xref	HP:0030955
+MONDO:0007079	xref	UMLS:C0001956
+MONDO:0007079	oio:closeMatch	UMLS:C0679288
+MONDO:0007079	oio:closeMatch	UMLS:C4236929
+MONDO:0007079	oio:closeMatch	UMLS:C4236928
+MONDO:0007079	oio:closeMatch	UMLS:C0679289
+MONDO:0007079	oio:closeMatch	EFO:0009458
+MONDO:0007079	oio:closeMatch	UMLS:C0679290
+MONDO:0007079	oio:closeMatch	UMLS:C0841000
+MONDO:0007079	oio:closeMatch	UMLS:C0679287
+MONDO:0007079	oio:closeMatch	UMLS:C4509036
+MONDO:0007079	oio:closeMatch	UMLS:C4509034
+MONDO:0007079	oio:closeMatch	UMLS:C4509037
+MONDO:0007079	oio:closeMatch	UMLS:C4509035
+MONDO:0007079	oio:closeMatch	UMLS:C4268207
+MONDO:0007079	oio:closeMatch	UMLS:C4268205
+MONDO:0007079	oio:closeMatch	UMLS:C4268213
+MONDO:0007079	oio:closeMatch	UMLS:C4268212
+MONDO:0007079	oio:closeMatch	UMLS:C4268206
+MONDO:0007079	oio:closeMatch	UMLS:C4268204
+MONDO:0007079	oio:closeMatch	UMLS:C4268209
+MONDO:0007079	oio:closeMatch	UMLS:C4268208
+MONDO:0007079	oio:closeMatch	UMLS:C4268211
+MONDO:0007079	oio:closeMatch	UMLS:C4268210
+MONDO:0007079	oio:closeMatch	UMLS:C3650363
+MONDO:0007079	oio:closeMatch	UMLS:C4536264
 

--- a/input_data/manual_concords/disease.txt
+++ b/input_data/manual_concords/disease.txt
@@ -1,0 +1,23 @@
+# All lines starting with '#' will be removed from this file before being used as a
+# concord.
+#
+# OPIOID USE DISORDER
+#
+# As per https://github.com/TranslatorSRI/Babel/issues/265, we would like to combine
+# a bunch of opioid use order cliques.
+# Opioid abuse
+MONDO:0001225   xref    UMLS:C4237237
+# Opioid dependence (which we combine incorrectly with opiate dependence following MONDO)
+MONDO:0005530   xref    UMLS:C4324621
+# This combination is as per https://github.com/TranslatorSRI/Babel/issues/270
+UMLS:C4324621   xref    EFO:0010702
+# We also combine opioid dependence with both UMLS:C4237239 "Opioid use disorder, severe"
+# and UMLS:C4237238 "Opioid use disorder, moderate".
+MONDO:0005530   xref    UMLS:C4237238
+MONDO:0005530   xref    UMLS:C4237239
+
+#
+# ALCOHOL USE DISORDER
+#
+MONDO:0002046   xref    HP:0430037
+MONDO:0007079   xref    HP:0030955

--- a/input_data/manual_concords/disease.txt
+++ b/input_data/manual_concords/disease.txt
@@ -5,19 +5,106 @@
 #
 # As per https://github.com/TranslatorSRI/Babel/issues/265, we would like to combine
 # a bunch of opioid use order cliques.
-# Opioid abuse
-MONDO:0001225|xref|UMLS:C4237237
+
 # Opioid dependence (which we combine incorrectly with opiate dependence following MONDO)
 MONDO:0005530|xref|UMLS:C4324621
 # This combination is as per https://github.com/TranslatorSRI/Babel/issues/270
 UMLS:C4324621|xref|EFO:0010702
-# We also combine opioid dependence with both UMLS:C4237239 "Opioid use disorder, severe"
-# and UMLS:C4237238 "Opioid use disorder, moderate".
-MONDO:0005530|xref|UMLS:C4237238
-MONDO:0005530|xref|UMLS:C4237239
+
+# For these UMLS terms, we rather imprecisely connect them with:
+# - mild -> MONDO:0001225 "opioid abuse" and UMLS:C4237237 "Opioid use disorder, mild"
+MONDO:0001225|oio:closeMatch|UMLS:C4237237
+UMLS:C4237237|oio:closeMatch|UMLS:C4268215
+UMLS:C4237237|oio:closeMatch|UMLS:C4509038
+UMLS:C4237237|oio:closeMatch|UMLS:C4509039
+
+
+# There are some unclear UMLS terms re: opioid induced disorders. Let's stick them into
+# "opioid abuse" for now, but we might want to petition for a new MONDO term.
+MONDO:0001225|oio:closeMatch|UMLS:C3647215
+MONDO:0001225|oio:closeMatch|UMLS:C4536271
+MONDO:0001225|oio:closeMatch|UMLS:C4237251
+MONDO:0001225|oio:closeMatch|UMLS:C4237242
+MONDO:0001225|oio:closeMatch|UMLS:C4237245
+MONDO:0001225|oio:closeMatch|UMLS:C2874460
+MONDO:0001225|oio:closeMatch|UMLS:C2874467
+MONDO:0001225|oio:closeMatch|UMLS:C2874468
+MONDO:0001225|oio:closeMatch|UMLS:C2874461
+MONDO:0001225|oio:closeMatch|UMLS:C2874469
+
+# For these UMLS terms, we rather imprecisely connect them with:
+# - moderate/severe -> MONDO:0005530 "opiate dependence",
+#   UMLS:C4237238 "Opioid use disorder, moderate" and UMLS:C4237239 "Opioid use disorder, severe"
+MONDO:0005530|oio:closeMatch|UMLS:C4237238
+UMLS:C4237238|oio:closeMatch|UMLS:C4268216
+UMLS:C4237238|oio:closeMatch|UMLS:C4509040
+UMLS:C4237238|oio:closeMatch|UMLS:C4509041
+
+MONDO:0005530|oio:closeMatch|UMLS:C4237239
+UMLS:C4237239|oio:closeMatch|UMLS:C4509042
+UMLS:C4237239|oio:closeMatch|UMLS:C4509043
+
 
 #
 # ALCOHOL USE DISORDER
 #
+# MONDO:0002046 "alcohol abuse" (http://purl.obolibrary.org/obo/MONDO_0002046)
+# - includes UMLS:C4236927 "Alcohol use disorder, mild"
 MONDO:0002046|xref|HP:0430037
+MONDO:0002046|oio:closeMatch|UMLS:C4236927
+MONDO:0002046|oio:closeMatch|UMLS:C4509032
+MONDO:0002046|oio:closeMatch|UMLS:C4509033
+MONDO:0002046|oio:closeMatch|UMLS:C4268203
+MONDO:0002046|oio:closeMatch|UMLS:C4268202
+MONDO:0002046|oio:closeMatch|UMLS:C4236955
+MONDO:0002046|oio:closeMatch|UMLS:C4236934
+MONDO:0002046|oio:closeMatch|UMLS:C4236949
+MONDO:0002046|oio:closeMatch|UMLS:C4236940
+MONDO:0002046|oio:closeMatch|UMLS:C4236926
+MONDO:0002046|oio:closeMatch|UMLS:C4236953
+MONDO:0002046|oio:closeMatch|UMLS:C4236932
+MONDO:0002046|oio:closeMatch|UMLS:C4236947
+MONDO:0002046|oio:closeMatch|UMLS:C4236938
+MONDO:0002046|oio:closeMatch|UMLS:C4236946
+MONDO:0002046|oio:closeMatch|UMLS:C4236924
+MONDO:0002046|oio:closeMatch|UMLS:C4236923
+MONDO:0002046|oio:closeMatch|UMLS:C2874409
+MONDO:0002046|oio:closeMatch|UMLS:C2874416
+MONDO:0002046|oio:closeMatch|UMLS:C2874418
+MONDO:0002046|oio:closeMatch|UMLS:C2874419
+MONDO:0002046|oio:closeMatch|UMLS:C2874410
+MONDO:0002046|oio:closeMatch|UMLS:C2874420
+MONDO:0002046|oio:closeMatch|UMLS:C4268214
+MONDO:0002046|oio:closeMatch|UMLS:C4236937
+
+# MONDO:0007079 "alcohol dependence" (http://purl.obolibrary.org/obo/MONDO_0007079)
+# - includes UMLS:C0001956 "Alcohol Use Disorder"
+# - includes UMLS:C4236929 "Alcohol use disorder, severe"
+# - includes UMLS:C4236928 "Alcohol use disorder, moderate"
 MONDO:0007079|xref|HP:0030955
+MONDO:0007079|xref|UMLS:C0001956
+MONDO:0007079|oio:closeMatch|UMLS:C0679288
+MONDO:0007079|oio:closeMatch|UMLS:C4236929
+MONDO:0007079|oio:closeMatch|UMLS:C4236928
+MONDO:0007079|oio:closeMatch|UMLS:C0679289
+MONDO:0007079|oio:closeMatch|EFO:0009458
+MONDO:0007079|oio:closeMatch|UMLS:C0679290
+MONDO:0007079|oio:closeMatch|UMLS:C0841000
+MONDO:0007079|oio:closeMatch|UMLS:C0679287
+MONDO:0007079|oio:closeMatch|UMLS:C4509036
+MONDO:0007079|oio:closeMatch|UMLS:C4509034
+MONDO:0007079|oio:closeMatch|UMLS:C4509037
+MONDO:0007079|oio:closeMatch|UMLS:C4509035
+MONDO:0007079|oio:closeMatch|UMLS:C4268207
+MONDO:0007079|oio:closeMatch|UMLS:C4268205
+MONDO:0007079|oio:closeMatch|UMLS:C4268213
+MONDO:0007079|oio:closeMatch|UMLS:C4268212
+MONDO:0007079|oio:closeMatch|UMLS:C4268206
+MONDO:0007079|oio:closeMatch|UMLS:C4268204
+MONDO:0007079|oio:closeMatch|UMLS:C4268209
+MONDO:0007079|oio:closeMatch|UMLS:C4268208
+MONDO:0007079|oio:closeMatch|UMLS:C4268211
+MONDO:0007079|oio:closeMatch|UMLS:C4268210
+MONDO:0007079|oio:closeMatch|UMLS:C3650363
+MONDO:0007079|oio:closeMatch|UMLS:C4536264
+

--- a/src/createcompendia/diseasephenotype.py
+++ b/src/createcompendia/diseasephenotype.py
@@ -153,10 +153,10 @@ def build_compendium(concordances, identifiers, mondoclose, badxrefs, icrdf_file
         with open(infile,'r') as inf:
             for line in inf:
                 stuff = line.strip().split('\t')
-                x = tuple( [stuff[0], stuff[2]] )
-                if len(x) != 2:
-                    print(x)
+                if len(stuff) != 2:
+                    print('Line "', line, '" is not a valid concord: ', stuff)
                     exit()
+                x = tuple([stuff[0].strip(), stuff[2].strip()])
                 if x not in bad_pairs:
                     pairs.append( x )
         if pref in ['MONDO','HP','EFO']:

--- a/src/createcompendia/diseasephenotype.py
+++ b/src/createcompendia/diseasephenotype.py
@@ -154,8 +154,7 @@ def build_compendium(concordances, identifiers, mondoclose, badxrefs, icrdf_file
             for line in inf:
                 stuff = line.strip().split('\t')
                 if len(stuff) != 3:
-                    print('Line "', line.strip(), '" is not a valid concord: ', stuff)
-                    exit()
+                    raise RuntimeError('Line "', line.strip(), '" is not a valid concord: ', stuff)
                 x = tuple([stuff[0].strip(), stuff[2].strip()])
                 if x not in bad_pairs:
                     pairs.append( x )

--- a/src/createcompendia/diseasephenotype.py
+++ b/src/createcompendia/diseasephenotype.py
@@ -153,8 +153,8 @@ def build_compendium(concordances, identifiers, mondoclose, badxrefs, icrdf_file
         with open(infile,'r') as inf:
             for line in inf:
                 stuff = line.strip().split('\t')
-                if len(stuff) != 2:
-                    print('Line "', line, '" is not a valid concord: ', stuff)
+                if len(stuff) != 3:
+                    print('Line "', line.strip(), '" is not a valid concord: ', stuff)
                     exit()
                 x = tuple([stuff[0].strip(), stuff[2].strip()])
                 if x not in bad_pairs:

--- a/src/snakefiles/diseasephenotype.snakefile
+++ b/src/snakefiles/diseasephenotype.snakefile
@@ -129,7 +129,7 @@ rule disease_manual_concord:
                     continue
                 if '|' in lstripped_line:
                     lstripped_line = "\t".join(lstripped_line.split('|'))
-                outp.writelines([line])
+                outp.writelines([lstripped_line])
 
 rule disease_compendia:
     input:

--- a/src/snakefiles/diseasephenotype.snakefile
+++ b/src/snakefiles/diseasephenotype.snakefile
@@ -127,8 +127,6 @@ rule disease_manual_concord:
                 lstripped_line = line.lstrip()
                 if lstripped_line == '' or lstripped_line.startswith('#'):
                     continue
-                if '|' in lstripped_line:
-                    lstripped_line = "\t".join(lstripped_line.split('|'))
                 outp.writelines([lstripped_line])
 
 rule disease_compendia:

--- a/src/snakefiles/diseasephenotype.snakefile
+++ b/src/snakefiles/diseasephenotype.snakefile
@@ -1,3 +1,5 @@
+import shutil
+
 import src.createcompendia.diseasephenotype as diseasephenotype
 import src.assess_compendia as assessments
 
@@ -112,6 +114,20 @@ rule get_disease_doid_relationships:
         outfile=config['intermediate_directory']+'/disease/concords/DOID',
     run:
         diseasephenotype.build_disease_doid_relationships(input.infile,output.outfile)
+
+rule disease_manual_concord:
+    input:
+        infile = 'input_data/manual_concords/disease.txt'
+    output:
+        outfile = config['intermediate_directory']+'/disease/concords/Manual'
+    run:
+        with open(input.infile, 'r') as inp, open(output.outfile, 'w') as outp:
+            for line in inp:
+                # Remove any lines starting with '#', which we treat as comments.
+                lstripped_line = line.lstrip()
+                if lstripped_line == '' or lstripped_line.startswith('#'):
+                    continue
+                outp.writelines([line])
 
 rule disease_compendia:
     input:

--- a/src/snakefiles/diseasephenotype.snakefile
+++ b/src/snakefiles/diseasephenotype.snakefile
@@ -127,6 +127,8 @@ rule disease_manual_concord:
                 lstripped_line = line.lstrip()
                 if lstripped_line == '' or lstripped_line.startswith('#'):
                     continue
+                if '|' in lstripped_line:
+                    lstripped_line = "\t".join(lstripped_line.split('|'))
                 outp.writelines([line])
 
 rule disease_compendia:


### PR DESCRIPTION
Searching for both "opioid use disorder" and "alcohol use disorder" would result in a long list of UMLS identifiers for many fine gradations of these concepts. This PR adds some manually-written concords for Disease and PhenotypicFeature to collect some of these identifiers into larger cliques. With these changes, "opioid use disorder" returns [MONDO:0005530 "opiate dependence"](http://purl.obolibrary.org/obo/MONDO_0005530) and "alcohol use disorder" returns [MONDO:0007079 "alcohol dependence"](http://purl.obolibrary.org/obo/MONDO_0007079).

The manual concords are written in a file that is similar to the other concords files, but with support for treating lines starting with `[any whitespace]*#` as comments. I'm not going to put much thought into this at the moment but if we need to do a lot more of this we might want to come up with a YAML representation so we're not reliant on a custom format. If its used in any other concords, it would also be a good idea to make a Python function for working with these concords-with-comments files.

Closes #265.