### PR TITLE
Add a manual concord for DrugChemicalConflation

### DIFF
--- a/input_data/manual_concords/drugchemical.tsv
+++ b/input_data/manual_concords/drugchemical.tsv
@@ -1,0 +1,14 @@
+subject	predicate	object	notes	url
+CHEMBL.COMPOUND:CHEMBL2108505	skos:relatedMatch	MESH:D043322	"Not exactly the same thing (MESH:D043322 is in the same clique as Tilactase, which is a synthetic lactase), but close enough."	https://github.com/NCATSTranslator/Feedback/issues/833
+UNII:E211KPY694	skos:closeMatch	UMLS:C0006050	“botulinum toxin type A” in UMLS	https://github.com/NCATSTranslator/Feedback/issues/395#issuecomment-2225798922
+UNII:E211KPY694	skos:closeMatch	UMLS:C5235582	“Botulinum Toxin Type A1” in UMLS	https://github.com/NCATSTranslator/Feedback/issues/395#issuecomment-2225798922
+UNII:E211KPY694	skos:closeMatch	UMLS:C5235583	“Botulinum Toxin Type A3” in UMLS	https://github.com/NCATSTranslator/Feedback/issues/395#issuecomment-2225798922
+UNII:E211KPY694	skos:closeMatch	UMLS:C5235584	“Botulinum Toxin Type A4” in UMLS	https://github.com/NCATSTranslator/Feedback/issues/395#issuecomment-2225798922
+UNII:E211KPY694	skos:closeMatch	UMLS:C5235585	“Botulinum Toxin Type A5” in UMLS	https://github.com/NCATSTranslator/Feedback/issues/395#issuecomment-2225798922
+UNII:E211KPY694	skos:closeMatch	UMLS:C5235586	“Botulinum Toxin Type A6” in UMLS	https://github.com/NCATSTranslator/Feedback/issues/395#issuecomment-2225798922
+UNII:E211KPY694	skos:closeMatch	UMLS:C5235587	“Botulinum Toxin Type A7” in UMLS	https://github.com/NCATSTranslator/Feedback/issues/395#issuecomment-2225798922
+UNII:P188ANX8CK	skos:exactMatch	CHEMBL.COMPOUND:CHEMBL1201585	"They should be combined, but they’re not — we can temporarily fix it in DrugChemical conflation, but we should figure out a comprehensive solution to this."	https://github.com/TranslatorSRI/Babel/issues/223
+MESH:D007252	skos:exactMatch	CHEMBL.COMPOUND:CHEMBL2109042	"They should be combined, but they’re not — we can temporarily fix it in DrugChemical conflation, but we should figure out a comprehensive solution to this."	https://github.com/NCATSTranslator/Feedback/issues/612||https://github.com/TranslatorSRI/Babel/issues/234
+MESH:C415772	skos:exactMatch	CHEMBL.COMPOUND:CHEMBL2108230	"They should be combined, but they’re not — we can temporarily fix it in DrugChemical conflation, but we should figure out a comprehensive solution to this."	https://github.com/TranslatorSRI/NodeNormalization/issues/224
+UNII:A1ED6W905I	skos:exactMatch	CHEMBL.COMPOUND:CHEMBL2108230	"They should be combined, but they’re not — we can temporarily fix it in DrugChemical conflation, but we should figure out a comprehensive solution to this."	https://github.com/TranslatorSRI/NodeNormalization/issues/224
+UNII:XX73205DH5	skos:exactMatch	CHEMBL.COMPOUND:CHEMBL2367706	"They should be combined, but they’re not — we can temporarily fix it in DrugChemical conflation, but we should figure out a comprehensive solution to this."	https://github.com/TranslatorSRI/Babel/issues/230

--- a/input_data/manual_concords/drugchemical.tsv
+++ b/input_data/manual_concords/drugchemical.tsv
@@ -12,3 +12,20 @@ MESH:D007252	skos:exactMatch	CHEMBL.COMPOUND:CHEMBL2109042	"They should be combi
 MESH:C415772	skos:exactMatch	CHEMBL.COMPOUND:CHEMBL2108230	"They should be combined, but they’re not — we can temporarily fix it in DrugChemical conflation, but we should figure out a comprehensive solution to this."	https://github.com/TranslatorSRI/NodeNormalization/issues/224
 UNII:A1ED6W905I	skos:exactMatch	CHEMBL.COMPOUND:CHEMBL2108230	"They should be combined, but they’re not — we can temporarily fix it in DrugChemical conflation, but we should figure out a comprehensive solution to this."	https://github.com/TranslatorSRI/NodeNormalization/issues/224
 UNII:XX73205DH5	skos:exactMatch	CHEMBL.COMPOUND:CHEMBL2367706	"They should be combined, but they’re not — we can temporarily fix it in DrugChemical conflation, but we should figure out a comprehensive solution to this."	https://github.com/TranslatorSRI/Babel/issues/230
+CHEBI:5931	skos:exactMatch	PUBCHEM.COMPOUND:70678557	Both “Insulin”	https://github.com/TranslatorSRI/Babel/issues/327 
+CHEBI:5931	skos:exactMatch	DRUGBANK:DB00030	Insulin and “Insulin human”	https://github.com/TranslatorSRI/Babel/issues/327 
+CHEBI:5931	skos:exactMatch	UNII:GFX7QIS1II	"Insulin and ""Insulin lispro""
+"	https://github.com/TranslatorSRI/Babel/issues/327 
+CHEBI:5931	skos:exactMatch	UNII:2ZM8CX04RZ	"Insulin and ""Insulin glargine""
+"	https://github.com/TranslatorSRI/Babel/issues/327 
+CHEBI:5931	skos:exactMatch	DRUGBANK:DB18001	"Insulin and ""Neutral Protamine Hagedorn (NPH) insulin"""	https://github.com/TranslatorSRI/Babel/issues/327 
+CHEBI:5931	skos:exactMatch	UNII:D933668QVX	"Insulin and ""Insulin aspart""
+"	https://github.com/TranslatorSRI/Babel/issues/327 
+CHEBI:5931	skos:exactMatch	UNII:AVT680JB39	"Insulin and ""Insulin pork""
+"	https://github.com/TranslatorSRI/Babel/issues/327 
+CHEBI:5931	skos:exactMatch	UNII:54Q18076QB	"Insulin and “Insulin degludec"""	https://github.com/TranslatorSRI/Babel/issues/327 
+CHEBI:5931	skos:exactMatch	UNII:4FT78T86XV	"Insulin and ""Insulin detemir""
+"	https://github.com/TranslatorSRI/Babel/issues/327 
+CHEBI:5931	skos:exactMatch	UNII:7XIY785AZD	"Insulin and ""Insulin glulisine”"	https://github.com/TranslatorSRI/Babel/issues/327 
+CHEBI:5931	skos:exactMatch	CHEBI:228608	"Insulin and ""Insulin beef”"	https://github.com/TranslatorSRI/Babel/issues/327 
+CHEBI:5931	skos:exactMatch	UNII:54Q18076QB	"Insulin and ""Insulin degludec"""	https://github.com/TranslatorSRI/Babel/issues/327 

--- a/kubernetes/babel-outputs.k8s.yaml
+++ b/kubernetes/babel-outputs.k8s.yaml
@@ -15,5 +15,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 750Gi
+      storage: 800Gi
   storageClassName: basic

--- a/kubernetes/babel-outputs.k8s.yaml
+++ b/kubernetes/babel-outputs.k8s.yaml
@@ -15,5 +15,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 800Gi
+      storage: 900Gi
   storageClassName: basic

--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -340,6 +340,7 @@ def build_conflation(manual_concord_filename, rxn_concord,umls_concord,pubchem_r
     # merged together because they share a normalized identifier. We can do this by adding pairs to indicate that every
     # subject and object is associated with its normalized identifier.
     pairs_to_be_glommed = []
+    pairs.extend(manual_concords)
     for (subj, obj) in pairs:
         # If either the subject or the object cannot be normalized, skip this pair entirely.
         #
@@ -363,16 +364,6 @@ def build_conflation(manual_concord_filename, rxn_concord,umls_concord,pubchem_r
         # If the object is not normalized, add a pair indicating the normalized ID.
         if preferred_curie_for_curie[obj] != obj:
             pairs_to_be_glommed.append((obj, preferred_curie_for_curie[obj]))
-
-    # Add the normalized manual concords to the gloms.
-    for (subj, obj) in manual_concords:
-        if subj not in preferred_curie_for_curie:
-            logger.warning(f"Manual concord ({subj}, {obj}) has a subject ({subj}) that cannot be normalized, skipping.")
-            continue
-        if obj not in preferred_curie_for_curie:
-            logger.warning(f"Manual concord ({subj}, {obj}) has an object ({obj}) that cannot be normalized, skipping.")
-            continue
-        pairs_to_be_glommed.extend((preferred_curie_for_curie[subj], preferred_curie_for_curie[obj]))
 
     # Glommin' time
     print("glom")

--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -367,9 +367,11 @@ def build_conflation(manual_concord_filename, rxn_concord,umls_concord,pubchem_r
     # Add the normalized manual concords to the gloms.
     for (subj, obj) in manual_concords:
         if subj not in preferred_curie_for_curie:
-            raise RuntimeError(f"Manual concord ({subj}, {obj}) has a subject ({subj}) that cannot be normalized.")
+            logger.warning(f"Manual concord ({subj}, {obj}) has a subject ({subj}) that cannot be normalized, skipping.")
+            continue
         if obj not in preferred_curie_for_curie:
-            raise RuntimeError(f"Manual concord ({subj}, {obj}) has an object ({obj}) that cannot be normalized.")
+            logger.warning(f"Manual concord ({subj}, {obj}) has an object ({obj}) that cannot be normalized, skipping.")
+            continue
         pairs_to_be_glommed.extend((preferred_curie_for_curie[subj], preferred_curie_for_curie[obj]))
 
     # Glommin' time

--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -246,7 +246,7 @@ def build_conflation(manual_concord_filename, rxn_concord,umls_concord,pubchem_r
     print("Loading manual concords ...")
     manual_concords = []
     with open(manual_concord_filename,"r") as manualf:
-        csv_reader = csv.DictReader(manualf)
+        csv_reader = csv.DictReader(manualf, dialect=csv.excel_tab)
         for row in csv_reader:
             # We're only interested in two fields, so you can add additional files ('comment', 'notes', etc.) as needed.
             if 'subject' not in row or 'object' not in row:

--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -254,7 +254,7 @@ def build_conflation(manual_concord_filename, rxn_concord,umls_concord,pubchem_r
             if row['subject'].strip() == '' or row['object'].strip() == '':
                 raise RuntimeError(f"Empty subject or object fields in {manual_concord_filename}: {row}")
             manual_concords.append((row['subject'], row['object']))
-    print("{len(manual_concords)} manual concords loaded.")
+    print(f"{len(manual_concords)} manual concords loaded.")
 
     print("load all chemical conflations so we can normalize identifiers")
     preferred_curie_for_curie = {}

--- a/src/exporters/duckdb_exporters.py
+++ b/src/exporters/duckdb_exporters.py
@@ -158,7 +158,7 @@ def check_for_identically_labeled_cliques(parquet_root, duckdb_filename, identic
 
     db.sql("""
         WITH curie_counts AS (SELECT LOWER(preferred_name) AS preferred_name_lc, COUNT(clique_leader) AS curie_count FROM cliques
-            WHERE filename NOT IN ('DrugChemicalConflated')
+            WHERE filename NOT IN ('DrugChemicalConflated', 'Publication')
             GROUP BY preferred_name_lc HAVING COUNT(clique_leader) > 1
             ORDER BY curie_count DESC)
         SELECT 

--- a/src/snakefiles/drugchemical.snakefile
+++ b/src/snakefiles/drugchemical.snakefile
@@ -36,11 +36,12 @@ rule drugchemical_conflation:
         chemical_compendia=expand("{do}/compendia/{co}", do=config['output_directory'], co=config['chemical_outputs']),
         rxnorm_concord=config['intermediate_directory']+'/drugchemical/concords/RXNORM',
         umls_concord=config['intermediate_directory']+'/drugchemical/concords/UMLS',
-        pubchem_concord=config['intermediate_directory']+'/drugchemical/concords/PUBCHEM_RXNORM'
+        pubchem_concord=config['intermediate_directory']+'/drugchemical/concords/PUBCHEM_RXNORM',
+        drugchemical_manual_concord=config['input_directory']+'/manual_concords/drugchemical.tsv',
     output:
         outfile=config['output_directory']+'/conflation/DrugChemical.txt'
     run:
-        drugchemical.build_conflation(input.rxnorm_concord,input.umls_concord,input.pubchem_concord,input.drug_compendium,input.chemical_compendia,output.outfile)
+        drugchemical.build_conflation(input.drugchemical_manual_concord,input.rxnorm_concord,input.umls_concord,input.pubchem_concord,input.drug_compendium,input.chemical_compendia,output.outfile)
 
 rule drugchemical_conflated_synonyms:
     input:


### PR DESCRIPTION
This PR adds a manual concord for DrugChemicalConflation, which is incorporated into the process by which DrugChemicalConflation is generated. I've added some examples, including the multiple insulins we've been asked to combine into a single clique.

Should be merged after PR #290.