### PR TITLE
Add taxon information to proteins

### DIFF
--- a/src/createcompendia/protein.py
+++ b/src/createcompendia/protein.py
@@ -1,6 +1,6 @@
 import re
 
-from src.prefixes import ENSEMBL, UMLS, PR, UNIPROTKB, NCIT
+from src.prefixes import ENSEMBL, UMLS, PR, UNIPROTKB, NCIT, NCBITAXON
 from src.categories import PROTEIN
 
 import src.datahandlers.umls as umls
@@ -15,7 +15,20 @@ import gzip
 
 import logging
 from src.util import LoggingUtil
-logger = LoggingUtil.init_logging(__name__, level=logging.ERROR)
+logger = LoggingUtil.init_logging(__name__, level=logging.WARNING)
+
+
+def extract_taxon_ids_from_uniprotkb(idmapping_filename, uniprotkb_taxa_filename):
+    """ Extract NCBIGene identifiers from the UniProtKB mapping file. """
+    with open(idmapping_filename, 'r') as inf, open(uniprotkb_taxa_filename, 'w') as outf:
+        for line in inf:
+            x = line.strip().split('\t')
+            if x[1] == 'NCBI_TaxID':
+                if x[0] == '' or x[2] == '':
+                    logger.warning(f'Line {x} is an NCBI_TaxID but has a blank UniProtKB ({x[0]}) or NCBITaxon ({x[2]}), skipping.')
+                    continue
+                outf.write(f'{UNIPROTKB}:{x[0]}\t{NCBITAXON}:{x[2]}\n')
+
 
 def write_ensembl_ids(ensembl_dir, outfile):
     """Loop over all the ensembl species.  Find any protein-coding gene"""

--- a/src/snakefiles/protein.snakefile
+++ b/src/snakefiles/protein.snakefile
@@ -19,6 +19,14 @@ rule protein_uniprotkb_ids:
         #This one is a simple enough transform to do with awk
         "awk '{{print $1}}' {input.infile} > {output.outfile}"
 
+rule extract_taxon_ids_from_uniprotkb:
+    input:
+        infile=config['download_directory']+'/UniProtKB/idmapping.dat'
+    output:
+        outfile=config['download_directory']+'/UniProtKB/taxa'
+    run:
+        protein.extract_taxon_ids_from_uniprotkb(input.infile, output.outfile)
+
 rule protein_umls_ids:
     input:
         mrsty=config['download_directory']+"/UMLS/MRSTY.RRF"
@@ -73,6 +81,8 @@ rule protein_compendia:
         concords=expand("{dd}/protein/concords/{ap}",dd=config['intermediate_directory'],ap=config['protein_concords']),
         idlists=expand("{dd}/protein/ids/{ap}",dd=config['intermediate_directory'],ap=config['protein_ids']),
         icrdf_filename=config['download_directory'] + '/icRDF.tsv',
+        # Include the taxon information from UniProtKB
+        uniprotkb_taxa_file=config['download_directory']+'/UniProtKB/taxa',
     output:
         expand("{od}/compendia/{ap}", od = config['output_directory'], ap = config['protein_outputs']),
         expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['protein_outputs'])


### PR DESCRIPTION
This PR adds taxon information to proteins by extracting UniProtKB to NCBITaxon mappings from the UniProtKB mapping file. The TaxonFactory should automatically include taxon information in the Protein cliques.