### PR TITLE
Babel 1.8 (Translator Hammerhead)

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
 
   "biolink_version": "4.2.2",
   "umls_version": "2024AA",
-  "rxnorm_version": "08052024",
+  "rxnorm_version": "09032024",
   "drugbank_version": "5-1-12",
 
   "ncbi_files": ["gene2ensembl.gz", "gene_info.gz", "gene_orthologs.gz", "gene_refseq_uniprotkb_collab.gz", "mim2gene_medgen"],

--- a/src/datahandlers/ncbigene.py
+++ b/src/datahandlers/ncbigene.py
@@ -1,11 +1,10 @@
-from src.babel_utils import pull_via_ftp, make_local_name
+from src.babel_utils import make_local_name, pull_via_urllib
 import gzip
 
 
 def pull_ncbigene(filenames):
-    remotedir = 'https://ftp.ncbi.nlm.nih.gov/gene/DATA/'
     for fn in filenames:
-        pull_via_ftp('ftp.ncbi.nlm.nih.gov', '/gene/DATA', fn, decompress_data=False, outfilename=f'NCBIGene/{fn}')
+        pull_via_urllib('https://ftp.ncbi.nlm.nih.gov/gene/DATA/', fn, decompress=False, subpath='NCBIGene')
 
 
 def pull_ncbigene_labels_synonyms_and_taxa():

--- a/src/exporters/sapbert.py
+++ b/src/exporters/sapbert.py
@@ -26,7 +26,7 @@ logger = LoggingUtil.init_logging(__name__, level=logging.INFO)
 
 # Configuration options
 # Limit DrugChemicalSmaller.txt.gz to terms that have a preferred name of 50 characters or more.
-DRUG_CHEMICAL_SMALLER_MAX_LABEL_LENGTH = 30
+DRUG_CHEMICAL_SMALLER_MAX_LABEL_LENGTH = 40
 # Include up to 50 synonym pairs for each synonym.
 MAX_SYNONYM_PAIRS = 50
 # Should we lowercase all the names?


### PR DESCRIPTION
The Translator Hammerhead release of Babel. In addition to other PRs, we only make three minor changes:
- Upgraded RxNorm to 09032024.
- Changed NCBIGene download from FTP to HTTP.
- Increased DRUG_CHEMICAL_SMALLER_MAX_LABEL_LENGTH (introduced in #330) from 30 to 40.