### PR TITLE
Check duplicate prefixes

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -29,6 +29,9 @@ rule all:
         # Build all the Parquet files.
         config['output_directory'] + '/duckdb/done',
 
+        # Build all the DuckDB (index-wide) reports.
+        config['output_directory'] + '/reports/duckdb/done',
+
         # Build all the exports.
         config['output_directory'] + '/kgx/done',
         config['output_directory'] + '/sapbert-training-data/done',

--- a/src/exporters/duckdb_exporters.py
+++ b/src/exporters/duckdb_exporters.py
@@ -4,10 +4,9 @@ import json
 import os.path
 import pathlib
 import time
-from collections import Counter
+from collections import Counter, defaultdict
 
 import duckdb
-from black.trans import defaultdict
 
 from src.node import get_config
 

--- a/src/exporters/duckdb_exporters.py
+++ b/src/exporters/duckdb_exporters.py
@@ -1,5 +1,6 @@
 # The DuckDB exporter can be used to export particular intermediate files into the
 # in-process database engine DuckDB (https://duckdb.org) for future querying.
+import csv
 import json
 import os.path
 import pathlib
@@ -227,7 +228,7 @@ def check_for_duplicate_curies(parquet_root, duckdb_filename, duplicate_curies_t
     """).write_csv(duplicate_curies_tsv, sep="\t")
 
 
-def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json):
+def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json, prefix_report_tsv):
     """
     Generate a report about all the prefixes within this system.
 
@@ -236,7 +237,8 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json):
     :param parquet_root: The root directory for the Parquet files. We expect these to have subdirectories named
         e.g. `filename=AnatomicalEntity/Clique.parquet`, etc.
     :param duckdb_filename: A temporary DuckDB file to use.
-    :param prefix_report_json: The prefix report.
+    :param prefix_report_json: The prefix report as JSON.
+    :param prefix_report_tsv: The prefix report as TSV.
     """
 
     db = setup_duckdb(duckdb_filename)
@@ -328,7 +330,7 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json):
         by_clique_results[curie_leader_prefix]['count_curies'] = count_curies
         total_curies += count_curies
 
-    # Step 3. Write out prefix report.
+    # Step 3. Write out prefix report in JSON.
     with open(prefix_report_json, 'w') as fout:
         json.dump({
             'count_cliques': total_cliques,
@@ -336,6 +338,58 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json):
             'by_clique': by_clique_results,
             'by_curie_prefix': by_curie_prefix_results
         }, fout, indent=2, sort_keys=True)
+
+    # Step 4. Write out prefix report in TSV. This is primarily based on the by-clique information, but also
+    # includes totals.
+    with open(prefix_report_tsv, 'w') as fout:
+        csv_writer = csv.DictWriter(fout, dialect='excel-tab', fieldnames=[
+            'Clique prefix', 'Filename', 'Clique count', 'CURIEs'
+        ])
+
+        curie_totals = defaultdict(int)
+
+        for prefix in sorted(by_clique_results.keys()):
+            by_clique_result = by_clique_results[prefix]
+            by_file = by_clique_result['by_file']
+
+            count_cliques = by_clique_result['count_cliques']
+            filename_curie_counts = defaultdict(int)
+
+            for filename in by_file.keys():
+                curie_prefixes_sorted = map(lambda k, v: f"{k}: {v}", sorted(by_file[filename].items(), key=lambda x: x[1], reverse=True))
+
+                filename_count_curies = 0
+                for curie_prefix in by_file[filename]:
+                    curie_totals[curie_prefix] += by_file[filename][curie_prefix]
+                    filename_curie_counts[curie_prefix] += by_file[filename][curie_prefix]
+                    filename_count_curies += by_file[filename][curie_prefix]
+
+                csv_writer.writerow({
+                    'Clique prefix': prefix,
+                    'Filename': filename,
+                    'Clique count': count_cliques,
+                    'CURIEs': f"{filename_count_curies}: " + ', '.join(curie_prefixes_sorted)
+                })
+
+            filename_curie_sorted = map(lambda k, v: f"{k}: {v}", sorted(filename_curie_counts.items(), key=lambda x: x[1], reverse=True))
+            count_curies = sum(filename_curie_counts.values())
+
+            csv_writer.writerow({
+                'Clique prefix': prefix,
+                'Filename': f"Total for prefix {prefix}",
+                'Clique count': count_cliques,
+                'CURIEs': f"{count_curies}: " + ', '.join(filename_curie_sorted)
+            })
+
+        curie_totals_sorted = map(lambda k, v: f"{k}: {v}", sorted(curie_totals.items(), key=lambda x: x[1], reverse=True))
+        total_curies = sum(curie_totals.values())
+        csv_writer.writerow({
+            'Clique prefix': 'Total cliques',
+            'Filename': '',
+            'Clique count': total_cliques,
+            'CURIEs': f"{total_curies}: " + ', '.join(curie_totals_sorted)
+        })
+
 
 
 def get_label_distribution(duckdb_filename, output_filename):

--- a/src/exporters/duckdb_exporters.py
+++ b/src/exporters/duckdb_exporters.py
@@ -244,21 +244,15 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json):
         os.path.join(parquet_root, "**/Edge.parquet"),
         hive_partitioning=True
     )
-    cliques = db.read_parquet(
-        os.path.join(parquet_root, "**/Clique.parquet"),
-        hive_partitioning=True
-    )
 
     curie_prefix_summary = db.sql("""
         SELECT
             split_part(curie, ':', 1) AS curie_prefix,
             COUNT(curie) AS curie_count,
             COUNT(DISTINCT curie) AS curie_distinct_count,
-            STRING_AGG(edges.filename, '||' ORDER BY edges.filename ASC) AS filenames,
-            STRING_AGG(cliques.biolink_type, '||' ORDER BY cliques.biolink_type ASC) AS biolink_types
+            STRING_AGG(edges.filename, '||' ORDER BY edges.filename ASC) AS filenames
         FROM
             edges
-        JOIN cliques ON cliques.clique_leader = edges.clique_leader
         GROUP BY
             curie_prefix
         ORDER BY
@@ -271,13 +265,11 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json):
         curie_prefix = row[0]
 
         filename_counts = Counter(row[3].split('||'))
-        biolink_type_counts = Counter(row[4].split('||'))
 
         result[curie_prefix] = {
             'curie_count': row[1],
             'curie_distinct_count': row[2],
             'filenames': filename_counts,
-            'biolink_types': biolink_type_counts,
         }
 
     with open(prefix_report_json, 'w') as fout:

--- a/src/exporters/duckdb_exporters.py
+++ b/src/exporters/duckdb_exporters.py
@@ -375,12 +375,14 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json, pr
             filename_curie_sorted = map(lambda x: f"{x[0]}: {x[1]}", sorted(filename_curie_counts.items(), key=lambda x: x[1], reverse=True))
             count_curies = sum(filename_curie_counts.values())
 
-            csv_writer.writerow({
-                'Clique prefix': prefix,
-                'Filename': f"Total for prefix {prefix}",
-                'Clique count': count_cliques,
-                'CURIEs': f"{count_curies}: " + ', '.join(filename_curie_sorted)
-            })
+            # Don't bother with a total for the prefix unless there are at least two files.
+            if len(by_file) > 1:
+                csv_writer.writerow({
+                    'Clique prefix': prefix,
+                    'Filename': f"Total for prefix {prefix}",
+                    'Clique count': count_cliques,
+                    'CURIEs': f"{count_curies}: " + ', '.join(filename_curie_sorted)
+                })
 
         curie_totals_sorted = map(lambda x: f"{x[0]}: {x[1]}", sorted(curie_totals.items(), key=lambda x: x[1], reverse=True))
         total_curies = sum(curie_totals.values())

--- a/src/exporters/duckdb_exporters.py
+++ b/src/exporters/duckdb_exporters.py
@@ -291,7 +291,7 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json):
         GROUP BY
             filename, clique_leader_prefix
         ORDER BY
-            curie_prefix ASC
+            filename ASC, clique_leader_prefix ASC
     """)
     rows = clique_summary.fetchall()
 

--- a/src/exporters/duckdb_exporters.py
+++ b/src/exporters/duckdb_exporters.py
@@ -345,6 +345,7 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json, pr
         csv_writer = csv.DictWriter(fout, dialect='excel-tab', fieldnames=[
             'Clique prefix', 'Filename', 'Clique count', 'CURIEs'
         ])
+        csv_writer.writeheader()
 
         curie_totals = defaultdict(int)
 
@@ -389,7 +390,6 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json, pr
             'Clique count': total_cliques,
             'CURIEs': f"{total_curies}: " + ', '.join(curie_totals_sorted)
         })
-
 
 
 def get_label_distribution(duckdb_filename, output_filename):

--- a/src/exporters/duckdb_exporters.py
+++ b/src/exporters/duckdb_exporters.py
@@ -247,8 +247,8 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json):
     results = db.sql("""
         SELECT
             split_part(curie, ':', 1) AS curie_prefix,
-            COUNT(*) AS curie_count,
-            COUNT(DISTINCT *) AS curie_distinct_count,
+            COUNT(curie) AS curie_count,
+            COUNT(DISTINCT curie) AS curie_distinct_count,
             STRING_AGG(filename, '||' ORDER BY filename ASC) AS filenames
         FROM
             edges

--- a/src/exporters/duckdb_exporters.py
+++ b/src/exporters/duckdb_exporters.py
@@ -321,18 +321,21 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json):
     total_cliques = 0
     total_curies = 0
     for curie_leader_prefix in by_clique_results.keys():
+        count_curies = 0
         total_cliques += by_clique_results[curie_leader_prefix]['count_cliques']
         for filename in by_clique_results[curie_leader_prefix]['by_file'].keys():
-            total_curies += sum(by_clique_results[curie_leader_prefix]['by_file'][filename].values())
-        by_clique_results[curie_leader_prefix]['count_curies'] = total_curies
-    by_clique_results['count_cliques'] = total_cliques
+            count_curies += sum(by_clique_results[curie_leader_prefix]['by_file'][filename].values())
+        by_clique_results[curie_leader_prefix]['count_curies'] = count_curies
+        total_curies += count_curies
 
     # Step 3. Write out prefix report.
     with open(prefix_report_json, 'w') as fout:
         json.dump({
+            'count_cliques': total_cliques,
+            'count_curies': total_curies,
             'by_clique': by_clique_results,
             'by_curie_prefix': by_curie_prefix_results
-        }, fout, indent=2)
+        }, fout, indent=2, sort_keys=True)
 
 
 def get_label_distribution(duckdb_filename, output_filename):

--- a/src/exporters/duckdb_exporters.py
+++ b/src/exporters/duckdb_exporters.py
@@ -250,6 +250,7 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json):
             split_part(curie, ':', 1) AS curie_prefix,
             COUNT(curie) AS curie_count,
             COUNT(DISTINCT curie) AS curie_distinct_count,
+            COUNT(DISTINCT clique_leader) AS clique_distinct_count,
             STRING_AGG(edges.filename, '||' ORDER BY edges.filename ASC) AS filenames
         FROM
             edges
@@ -264,11 +265,12 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json):
     for row in rows:
         curie_prefix = row[0]
 
-        filename_counts = Counter(row[3].split('||'))
+        filename_counts = Counter(row[4].split('||'))
 
         result[curie_prefix] = {
             'curie_count': row[1],
             'curie_distinct_count': row[2],
+            'clique_distinct_count': row[3],
             'filenames': filename_counts,
         }
 

--- a/src/exporters/duckdb_exporters.py
+++ b/src/exporters/duckdb_exporters.py
@@ -356,7 +356,7 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json, pr
             filename_curie_counts = defaultdict(int)
 
             for filename in by_file.keys():
-                curie_prefixes_sorted = map(lambda k, v: f"{k}: {v}", sorted(by_file[filename].items(), key=lambda x: x[1], reverse=True))
+                curie_prefixes_sorted = map(lambda x: f"{x[0]}: {x[1]}", sorted(by_file[filename].items(), key=lambda x: x[1], reverse=True))
 
                 filename_count_curies = 0
                 for curie_prefix in by_file[filename]:
@@ -371,7 +371,7 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json, pr
                     'CURIEs': f"{filename_count_curies}: " + ', '.join(curie_prefixes_sorted)
                 })
 
-            filename_curie_sorted = map(lambda k, v: f"{k}: {v}", sorted(filename_curie_counts.items(), key=lambda x: x[1], reverse=True))
+            filename_curie_sorted = map(lambda x: f"{x[0]}: {x[1]}", sorted(filename_curie_counts.items(), key=lambda x: x[1], reverse=True))
             count_curies = sum(filename_curie_counts.values())
 
             csv_writer.writerow({
@@ -381,7 +381,7 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json, pr
                 'CURIEs': f"{count_curies}: " + ', '.join(filename_curie_sorted)
             })
 
-        curie_totals_sorted = map(lambda k, v: f"{k}: {v}", sorted(curie_totals.items(), key=lambda x: x[1], reverse=True))
+        curie_totals_sorted = map(lambda x: f"{x[0]}: {x[1]}", sorted(curie_totals.items(), key=lambda x: x[1], reverse=True))
         total_curies = sum(curie_totals.values())
         csv_writer.writerow({
             'Clique prefix': 'Total cliques',

--- a/src/exporters/duckdb_exporters.py
+++ b/src/exporters/duckdb_exporters.py
@@ -258,7 +258,7 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json):
             STRING_AGG(cliques.biolink_type, '||' ORDER BY cliques.biolink_type ASC) AS biolink_types
         FROM
             edges
-        JOIN cliques ON clique.clique_leader = edges.clique_leader
+        JOIN cliques ON cliques.clique_leader = edges.clique_leader
         GROUP BY
             curie_prefix
         ORDER BY

--- a/src/exporters/duckdb_exporters.py
+++ b/src/exporters/duckdb_exporters.py
@@ -301,9 +301,7 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json):
         clique_leader_prefix = row[1]
         clique_count = row[2]
         curie_prefixes = row[3].split('||')
-
-        clique_count = len(curie_prefixes)
-        curie_prefix_counts = Counter(row[2].split('||'))
+        curie_prefix_counts = Counter(curie_prefixes.split('||'))
 
         if clique_leader_prefix not in by_clique_results:
             by_clique_results[clique_leader_prefix] = {

--- a/src/exporters/duckdb_exporters.py
+++ b/src/exporters/duckdb_exporters.py
@@ -301,7 +301,7 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json):
         clique_leader_prefix = row[1]
         clique_count = row[2]
         curie_prefixes = row[3].split('||')
-        curie_prefix_counts = Counter(curie_prefixes.split('||'))
+        curie_prefix_counts = Counter(curie_prefixes)
 
         if clique_leader_prefix not in by_clique_results:
             by_clique_results[clique_leader_prefix] = {

--- a/src/snakefiles/duckdb.snakefile
+++ b/src/snakefiles/duckdb.snakefile
@@ -91,9 +91,12 @@ rule generate_prefix_report:
         parquet_dir = config['output_directory'] + '/duckdb/parquet/',
     output:
         duckdb_filename = config['output_directory'] + '/duckdb/prefix_report.duckdb',
-        prefix_report = config['output_directory'] + '/reports/duckdb/prefix_report.json',
+        prefix_report_json = config['output_directory'] + '/reports/duckdb/prefix_report.json',
+        prefix_report_tsv = config['output_directory'] + '/reports/duckdb/prefix_report.tsv',
     run:
-        duckdb_exporters.generate_prefix_report(input.parquet_dir, output.duckdb_filename, output.prefix_report)
+        duckdb_exporters.generate_prefix_report(input.parquet_dir, output.duckdb_filename,
+            output.prefix_report_json,
+            output.prefix_report_tsv)
 
 rule all_duckdb_reports:
     input:

--- a/src/snakefiles/duckdb.snakefile
+++ b/src/snakefiles/duckdb.snakefile
@@ -94,3 +94,14 @@ rule generate_prefix_report:
         prefix_report = config['output_directory'] + '/reports/duckdb/prefix_report.json',
     run:
         duckdb_exporters.generate_prefix_report(input.parquet_dir, output.duckdb_filename, output.prefix_report)
+
+rule all_duckdb_reports:
+    input:
+        config['output_directory'] + '/duckdb/done',
+        identically_labeled_cliques_tsv = config['output_directory'] + '/reports/duckdb/identically_labeled_cliques.tsv',
+        duplicate_curies = config['output_directory'] + '/reports/duckdb/duplicate_curies.tsv',
+        prefix_report = config['output_directory'] + '/reports/duckdb/prefix_report.json',
+    output:
+        x = config['output_directory'] + '/reports/duckdb/done',
+    shell:
+        "echo 'done' >> {output.x}"

--- a/src/snakefiles/duckdb.snakefile
+++ b/src/snakefiles/duckdb.snakefile
@@ -84,3 +84,13 @@ rule check_for_duplicate_curies:
         duplicate_curies = config['output_directory'] + '/reports/duckdb/duplicate_curies.tsv',
     run:
         duckdb_exporters.check_for_duplicate_curies(input.parquet_dir, output.duckdb_filename, output.duplicate_curies)
+
+rule generate_prefix_report:
+    input:
+        config['output_directory'] + '/duckdb/done',
+        parquet_dir = config['output_directory'] + '/duckdb/parquet/',
+    output:
+        duckdb_filename = config['output_directory'] + '/duckdb/prefix_report.duckdb',
+        prefix_report = config['output_directory'] + '/reports/duckdb/prefix_report.json',
+    run:
+        duckdb_exporters.generate_prefix_report(input.parquet_dir, output.duckdb_filename, output.prefix_report)


### PR DESCRIPTION
This PR adds a prefix report that should be more useful in comparing one Babel run with another.

The output this produced for Babel 1.9 (#365) is: 
[prefix_report-dev-2025jan23.json](https://github.com/user-attachments/files/18515797/prefix_report-dev-2025jan23.json) and [prefix_report.txt](https://github.com/user-attachments/files/18515813/prefix_report.txt) (actually a TSV file).

Closes #359.