### PR TITLE
Efo

### DIFF
--- a/src/createcompendia/diseasephenotype.py
+++ b/src/createcompendia/diseasephenotype.py
@@ -81,6 +81,9 @@ def write_umls_ids(mrsty, outfile,badumlsfile):
     #A2.2.2 Sign or Symptom
     umlsmap['A2.2.1'] = PHENOTYPIC_FEATURE
     umlsmap['A2.2.2'] = PHENOTYPIC_FEATURE
+    #A2.3 Organism Attribute
+    # Includes things like "Age" which will merge with EFOs
+    umlsmap['A2.3'] = PHENOTYPIC_FEATURE
     umls.write_umls_ids(mrsty, umlsmap, outfile, blacklist=badumls)
 
 

--- a/src/datahandlers/efo.py
+++ b/src/datahandlers/efo.py
@@ -96,6 +96,7 @@ class EFOgraph:
          }}
          """
         qres = self.m.query(query)
+        nwrite = 0
         for row in list(qres):
             other = str(row["match"])
             otherid = Text.opt_to_curie(other[1:-1])
@@ -105,6 +106,29 @@ class EFOgraph:
                 print(otherid)
                 exit()
             outfile.write(f"{iri}\tskos:exactMatch\t{otherid}\n")
+            nwrite += 1
+        return nwrite
+    def get_xrefs(self, iri, outfile):
+        query = f"""
+         prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+         prefix EFO: <http://www.ebi.ac.uk/efo/EFO_>
+         prefix oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+         SELECT DISTINCT ?match
+         WHERE {{
+             {{ {iri} oboInOwl:hasDbXref ?match. }}
+         }}
+         """
+        qres = self.m.query(query)
+        for row in list(qres):
+            other = str(row["match"])
+            otherid = Text.opt_to_curie(other[1:-1])
+            if otherid.startswith("ORPHANET"):
+                print(row["match"])
+                print(other)
+                print(otherid)
+                exit()
+            outfile.write(f"{iri}\toboInOwl:hasDbXref\t{otherid}\n")
+
 
 def make_labels(labelfile,synfile):
     m = EFOgraph()
@@ -120,4 +144,6 @@ def make_concords(idfilename, outfilename):
     with open(idfilename,"r") as inf, open(outfilename,"w") as concfile:
         for line in inf:
             efo_id = line.split('\t')[0]
-            m.get_exacts(efo_id,concfile)
+            nexacts = m.get_exacts(efo_id,concfile)
+            if nexacts == 0:
+                m.get_xrefs(efo_id,concfile)

--- a/src/datahandlers/efo.py
+++ b/src/datahandlers/efo.py
@@ -127,7 +127,9 @@ class EFOgraph:
                 print(other)
                 print(otherid)
                 exit()
-            outfile.write(f"{iri}\toboInOwl:hasDbXref\t{otherid}\n")
+            #EFO occasionally has xrefs that are just strings, not IRIs or CURIEs
+            if ":" in otherid:
+                outfile.write(f"{iri}\toboInOwl:hasDbXref\t{otherid}\n")
 
 
 def make_labels(labelfile,synfile):

--- a/src/datahandlers/efo.py
+++ b/src/datahandlers/efo.py
@@ -128,7 +128,7 @@ class EFOgraph:
                 print(otherid)
                 exit()
             #EFO occasionally has xrefs that are just strings, not IRIs or CURIEs
-            if ":" in otherid:
+            if ":" in otherid and not otherid.startswith(":"):
                 outfile.write(f"{iri}\toboInOwl:hasDbXref\t{otherid}\n")
 
 


### PR DESCRIPTION
Trying to create a bit more cohesion specifically in phenotypic features.

Reviewing Bagel results, we found that EFO was often unlinked, especially for measurements (e.g. Age).  

Made 2 basic changes
1. EFO has a lot of skos:ExactMatch edges, but not for every EFO.  There are lots of entries where there are only dbXrefs.  Now, we pull in dbXref matches for EFO terms, but ONLY for terms that don't have exactMatch terms.  The thought being that if we have some as marked with exact then things that aren't explicitily exact probably are not.  But if we don't have anything that is exact, then dbXrefs are our best guess
2. Brought in one more UMLS class.  (OrganismAttribute).  This brings in things like "Age" which are coming in from EFO anyway.