### PR TITLE
Try to fix an issue in anatomy

### DIFF
--- a/src/createcompendia/anatomy.py
+++ b/src/createcompendia/anatomy.py
@@ -193,7 +193,7 @@ def create_typed_sets(eqsets,types):
         prefixes = get_prefixes(equivalent_ids)
         found  = False
         for prefix in [GO, CL, UBERON]:
-            if prefix in prefixes and not found:
+            if prefix in prefixes and prefixes[prefix][0] in types and not found:
                 mytype = types[prefixes[prefix][0]]
                 typed_sets[mytype].add(equivalent_ids)
                 found = True


### PR DESCRIPTION
This PR fixes an edge case that showed up in the latest Babel run: sometimes the prefix is not found in types at all.