### PR TITLE
Gzip synonyms files

### DIFF
--- a/src/snakefiles/anatomy.snakefile
+++ b/src/snakefiles/anatomy.snakefile
@@ -1,5 +1,6 @@
 import src.createcompendia.anatomy as anatomy
 import src.assess_compendia as assessments
+import src.snakefiles.util as util
 
 ### AnatomicalEntity / Cell / CellularComponent
 
@@ -75,7 +76,7 @@ rule anatomy_compendia:
         icrdf_filename=config['download_directory']+'/icRDF.tsv',
     output:
         expand("{od}/compendia/{ap}", od = config['output_directory'], ap = config['anatomy_outputs']),
-        expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['anatomy_outputs'])
+        temp(expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['anatomy_outputs']))
     run:
         anatomy.build_compendia(input.concords, input.idlists, input.icrdf_filename)
 
@@ -125,7 +126,8 @@ rule anatomy:
         synonyms=expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['anatomy_outputs']),
         reports = expand("{od}/reports/{ap}",od=config['output_directory'], ap = config['anatomy_outputs'])
     output:
+        synonyms_gzipped=expand("{od}/synonyms/{ap}.gzip", od = config['output_directory'], ap = config['anatomy_outputs']),
         x=config['output_directory']+'/reports/anatomy_done'
-    shell:
-        "echo 'done' >> {output.x}"
-
+    run:
+        util.gzip_files(input.synonyms)
+        util.write_done(output.x)

--- a/src/snakefiles/anatomy.snakefile
+++ b/src/snakefiles/anatomy.snakefile
@@ -126,7 +126,7 @@ rule anatomy:
         synonyms=expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['anatomy_outputs']),
         reports = expand("{od}/reports/{ap}",od=config['output_directory'], ap = config['anatomy_outputs'])
     output:
-        synonyms_gzipped=expand("{od}/synonyms/{ap}.gzip", od = config['output_directory'], ap = config['anatomy_outputs']),
+        synonyms_gzipped=expand("{od}/synonyms/{ap}.gz", od = config['output_directory'], ap = config['anatomy_outputs']),
         x=config['output_directory']+'/reports/anatomy_done'
     run:
         util.gzip_files(input.synonyms)

--- a/src/snakefiles/chemical.snakefile
+++ b/src/snakefiles/chemical.snakefile
@@ -1,5 +1,6 @@
 import src.createcompendia.chemicals as chemicals
 import src.assess_compendia as assessments
+import src.snakefiles.util as util
 
 rule chemical_umls_ids:
     input:
@@ -219,7 +220,7 @@ rule chemical_compendia:
         icrdf_filename = config['download_directory'] + '/icRDF.tsv',
     output:
         expand("{od}/compendia/{ap}", od = config['output_directory'], ap = config['chemical_outputs']),
-        expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['chemical_outputs'])
+        temp(expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['chemical_outputs']))
     run:
         chemicals.build_compendia(input.typesfile,input.untyped_file, input.icrdf_filename)
 
@@ -292,9 +293,11 @@ rule check_drug:
 rule chemical:
     input:
         config['output_directory']+'/reports/chemical_completeness.txt',
-        expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['chemical_outputs']),
+        synonyms = expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['chemical_outputs']),
         reports = expand("{od}/reports/{ap}",od=config['output_directory'], ap = config['chemical_outputs'])
     output:
+        synonyms_gzipped = expand("{od}/synonyms/{ap}.gz", od = config['output_directory'], ap = config['chemical_outputs']),
         x=config['output_directory']+'/reports/chemicals_done'
-    shell:
-        "echo 'done' >> {output.x}"
+    run:
+        util.gzip_files(input.synonyms)
+        util.write_done(output.x)

--- a/src/snakefiles/drugchemical.snakefile
+++ b/src/snakefiles/drugchemical.snakefile
@@ -1,6 +1,6 @@
 import src.createcompendia.drugchemical as drugchemical
-import src.assess_compendia as assessments
 import src.synonyms.synonymconflation as synonymconflation
+import src.snakefiles.util as util
 
 ### Drug / Chemical
 
@@ -56,8 +56,11 @@ rule drugchemical_conflated_synonyms:
 rule drugchemical:
     input:
         config['output_directory']+'/conflation/DrugChemical.txt',
-        config['output_directory']+'/synonyms/DrugChemicalConflated.txt'
+        config['output_directory']+'/synonyms/DrugChemicalConflated.txt',
+        chemical_synonyms=expand("{do}/synonyms/{co}", do=config['output_directory'], co=config['chemical_outputs']),
     output:
+        chemical_synonyms_gzipped=expand("{do}/synonyms/{co}.gz", do=config['output_directory'], co=config['chemical_outputs']),
         x=config['output_directory']+'/reports/drugchemical_done'
-    shell:
-        "echo 'done' >> {output.x}"
+    run:
+        util.gzip_files(input.chemical_synonyms)
+        util.write_done(output.x)

--- a/src/snakefiles/leftover_umls.snakefile
+++ b/src/snakefiles/leftover_umls.snakefile
@@ -1,6 +1,6 @@
-from src.createcompendia import leftover_umls
+from src.createcompendia.leftover_umls import write_leftover_umls
 from src.snakefiles.util import get_all_compendia
-
+import src.snakefiles.util as util
 
 ##
 ## This Snakefile implements the algorithm proposed in
@@ -29,8 +29,16 @@ rule leftover_umls:
         synonyms = config['download_directory'] + '/UMLS/synonyms'
     output:
         umls_compendium = config['output_directory'] + "/compendia/umls.txt",
-        umls_synonyms = config['output_directory'] + "/synonyms/umls.txt",
+        umls_synonyms = temp(config['output_directory'] + "/synonyms/umls.txt"),
         report = config['output_directory'] + "/reports/umls.txt",
         done = config['output_directory'] + "/reports/umls_done"
     run:
-        leftover_umls.write_leftover_umls(input.input_compendia, input.mrconso, input.mrsty, input.synonyms, output.umls_compendium, output.umls_synonyms, output.report, output.done, config['biolink_version'])
+        write_leftover_umls(input.input_compendia, input.mrconso, input.mrsty, input.synonyms, output.umls_compendium, output.umls_synonyms, output.report, output.done, config['biolink_version'])
+
+rule compress_umls:
+    input:
+        umls_synonyms = config['output_directory'] + "/synonyms/umls.txt",
+    output:
+        umls_synonyms_gzipped = config['output_directory'] + "/synonyms/umls.txt.gz",
+    run:
+        util.gzip_files([input.umls_synonyms])

--- a/src/snakefiles/macromolecular_complex.snakefile
+++ b/src/snakefiles/macromolecular_complex.snakefile
@@ -1,5 +1,6 @@
 import src.createcompendia.macromolecular_complex as macromolecular_complex
 import src.assess_compendia as assessments
+import src.snakefiles.util as util
 
 rule macromolecular_complex_ids:
     input:
@@ -17,7 +18,7 @@ rule macromolecular_complex_compendia:
         icrdf_filename = config['download_directory'] + '/icRDF.tsv',
     output:
         config['output_directory']+'/compendia/MacromolecularComplex.txt',
-        config['output_directory']+'/synonyms/MacromolecularComplex.txt'
+        temp(config['output_directory']+'/synonyms/MacromolecularComplex.txt')
     run:
         macromolecular_complex.build_compendia([input.idlists], icrdf_filename=input.icrdf_filename)
 
@@ -39,11 +40,13 @@ rule check_macromolecular_complex:
 
 rule macromolecular_complex:
     input:
-        config['output_directory']+'/synonyms/MacromolecularComplex.txt',
-        config['output_directory']+'/reports/macromolecular_complex_completeness.txt',
+        synonym=config['output_directory']+'/synonyms/MacromolecularComplex.txt',
+        completeness=config['output_directory']+'/reports/macromolecular_complex_completeness.txt',
         reports = config['output_directory']+'/reports/MacromolecularComplex.txt'
     output:
+        synonym_gzipped = config['output_directory']+'/synonyms/MacromolecularComplex.txt.gz',
         x = config['output_directory']+'/reports/macromolecular_complex_done'
-    shell:
-        "echo 'done' >> {output.x}"
+    run:
+        util.gzip_files([input.synonym])
+        util.write_done(output.x)
 

--- a/src/snakefiles/process.snakefile
+++ b/src/snakefiles/process.snakefile
@@ -136,7 +136,7 @@ rule process:
         synonyms=expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['process_outputs']),
         reports = expand("{od}/reports/{ap}",od=config['output_directory'], ap = config['process_outputs'])
     output:
-        synonyms_gzipped=expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['process_outputs']),
+        synonyms_gzipped=expand("{od}/synonyms/{ap}.gz", od = config['output_directory'], ap = config['process_outputs']),
         x=config['output_directory']+'/reports/process_done'
     run:
         util.gzip_files(input.synonyms)

--- a/src/snakefiles/process.snakefile
+++ b/src/snakefiles/process.snakefile
@@ -1,5 +1,6 @@
 import src.createcompendia.processactivitypathway as pap
 import src.assess_compendia as assessments
+import src.snakefiles.util as util
 
 ### Process / Activity / Pathway
 
@@ -93,7 +94,7 @@ rule process_compendia:
         icrdf_filename=config['download_directory']+'/icRDF.tsv',
     output:
         expand("{od}/compendia/{ap}", od = config['output_directory'], ap = config['process_outputs']),
-        expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['process_outputs'])
+        temp(expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['process_outputs']))
     run:
         pap.build_compendia(input.concords,input.idlists,input.icrdf_filename)
 
@@ -132,9 +133,11 @@ rule check_pathway:
 rule process:
     input:
         config['output_directory']+'/reports/process_completeness.txt',
-        expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['process_outputs']),
+        synonyms=expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['process_outputs']),
         reports = expand("{od}/reports/{ap}",od=config['output_directory'], ap = config['process_outputs'])
     output:
+        synonyms_gzipped=expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['process_outputs']),
         x=config['output_directory']+'/reports/process_done'
-    shell:
-        "echo 'done' >> {output.x}"
+    run:
+        util.gzip_files(input.synonyms)
+        util.write_done(output.x)

--- a/src/snakefiles/protein.snakefile
+++ b/src/snakefiles/protein.snakefile
@@ -1,6 +1,7 @@
 import src.createcompendia.protein as protein
 import src.assess_compendia as assessments
 #import src.filter_compendia as filter
+import src.snakefiles.util as util
 
 ### Gene / Protein
 
@@ -85,7 +86,7 @@ rule protein_compendia:
         uniprotkb_taxa_file=config['download_directory']+'/UniProtKB/taxa',
     output:
         expand("{od}/compendia/{ap}", od = config['output_directory'], ap = config['protein_outputs']),
-        expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['protein_outputs'])
+        temp(expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['protein_outputs']))
     run:
         protein.build_protein_compendia(input.concords,input.idlists, input.icrdf_filename)
 
@@ -108,12 +109,15 @@ rule check_protein:
 rule protein:
     input:
         config['output_directory']+'/reports/protein_completeness.txt',
-        expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['protein_outputs']),
+        synonyms=expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['protein_outputs']),
         reports = expand("{od}/reports/{ap}",od=config['output_directory'], ap = config['protein_outputs'])
     output:
+        synonyms_gzipped=expand("{od}/synonyms/{ap}.gz", od = config['output_directory'], ap = config['protein_outputs']),
         x=config['output_directory']+'/reports/protein_done'
-    shell:
-        "echo 'done' >> {output.x}"
+    run:
+        util.gzip_files(input.synonyms)
+        util.write_done(output.x)
+
 #
 #rule filter_protein:
 #    input:

--- a/src/snakefiles/util.py
+++ b/src/snakefiles/util.py
@@ -1,4 +1,31 @@
 # Shared code used by Snakemake files
+import shutil
+import gzip
+
+import src.util
+
+logger = src.util.LoggingUtil.init_logging(__name__, level="INFO")
+
+def write_done(filename):
+    """ Write a file to indicate that we are done. """
+    with open(filename, 'w') as f:
+        print("done", f)
+
+
+def gzip_files(input_filenames):
+    """ Compress files using Gzip. Like with `gzip`, we compress the file by adding `.gz` to the end of the filename, but
+    we do NOT delete the original file -- we'll leave that to the user.
+
+    :param input_filenames: A list of Gzip files to compress.
+    """
+    logger.info(f"Compressing: {input_filenames}")
+    for filename in input_filenames:
+        output_filename = filename + '.gz'
+        with open(filename, 'rb') as f_in:
+            with gzip.open(output_filename, 'wb') as f_out:
+                shutil.copyfileobj(f_in, f_out)
+                logger.info(f"Compressed {filename} to {output_filename} using Gzip.")
+
 
 # List of all the compendia files that need to be converted.
 def get_all_compendia(config):


### PR DESCRIPTION
We can compress all the synonym files, which will save us some disk space.

Ideally, we'd also compress the compendia files, but we need to split those for loading. So maybe it would make sense to split those here?

Partially solves #125.