### PR TITLE
Fix synonyms compression

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -74,3 +74,12 @@ rule clean_downloads:
     shell:
         "rm -rf {params.dir}/*"
 
+# Sometimes a synonyms file is available as a .gz file, but not as the .txt file itself.
+# This rule is here so that Snakemake knows how to uncompress it if needed.
+rule uncompress_synonym_file:
+    input:
+        config['output_directory'] + '/synonyms/{synonym_file}.txt.gz'
+    output:
+        config['output_directory'] + '/synonyms/{synonym_file}.txt'
+    shell:
+        'gunzip {input} -c > {output}'

--- a/src/createcompendia/leftover_umls.py
+++ b/src/createcompendia/leftover_umls.py
@@ -12,7 +12,7 @@ from src.prefixes import UMLS
 from src.categories import ACTIVITY, AGENT, DEVICE, DRUG, FOOD, SMALL_MOLECULE, PHYSICAL_ENTITY, PUBLICATION, PROCEDURE
 
 
-def write_leftover_umls(compendia, mrconso, mrsty, synonyms, umls_compendium, umls_synonyms, report, done, biolink_version):
+def write_leftover_umls(compendia, mrconso, mrsty, synonyms, umls_compendium, umls_synonyms, report, biolink_version):
     """
     Search for "leftover" UMLS concepts, i.e. those that are defined and valid in MRCONSO but are not
     mapped to a concept in Babel.
@@ -26,7 +26,6 @@ def write_leftover_umls(compendia, mrconso, mrsty, synonyms, umls_compendium, um
     :param umls_compendium: The UMLS compendium file to write out.
     :param umls_synonyms: The synonyms file to generate for this compendium.
     :param report: The report file to write out.
-    :param done: The done file to write out.
     :return: Nothing.
     """
 
@@ -243,10 +242,5 @@ def write_leftover_umls(compendia, mrconso, mrsty, synonyms, umls_compendium, um
 
         logging.info(f"Wrote out {count_synonym_objs} synonym objects into the leftover UMLS synonyms file.")
         reportf.write(f"Wrote out {count_synonym_objs} synonym objects into the leftover UMLS synonyms file.\n")
-
-
-    # Write out `done` file.
-    with open(done, 'w') as outf:
-        outf.write(f"done\n{datetime.now()}\n")
 
     logging.info("Complete")

--- a/src/createcompendia/leftover_umls.py
+++ b/src/createcompendia/leftover_umls.py
@@ -30,7 +30,7 @@ def write_leftover_umls(compendia, mrconso, mrsty, synonyms, umls_compendium, um
     """
 
     logging = Logger()
-    logging.info(f"write_leftover_umls({compendia}, {mrconso}, {mrsty}, {synonyms}, {umls_compendium}, {umls_synonyms}, {report}, {done})")
+    logging.info(f"write_leftover_umls({compendia}, {mrconso}, {mrsty}, {synonyms}, {umls_compendium}, {umls_synonyms}, {report}, {biolink_version})")
 
     # For now, we have many more UMLS entities in MRCONSO than in the compendia, so
     # we'll make an in-memory list of those first. Once that flips, this should be

--- a/src/exporters/duckdb_exporters.py
+++ b/src/exporters/duckdb_exporters.py
@@ -97,7 +97,7 @@ def export_compendia_to_parquet(compendium_filename, clique_parquet_filename, du
         )
 
 
-def export_synonyms_to_parquet(synonyms_filename, duckdb_filename, synonyms_parquet_filename):
+def export_synonyms_to_parquet(synonyms_filename_gz, duckdb_filename, synonyms_parquet_filename):
     """
     Export a synonyms file to a DuckDB directory.
 
@@ -115,7 +115,7 @@ def export_synonyms_to_parquet(synonyms_filename, duckdb_filename, synonyms_parq
 
     with setup_duckdb(duckdb_filename) as db:
         # Step 1. Load the entire synonyms file.
-        synonyms_jsonl = db.read_json(synonyms_filename, format='newline_delimited')
+        synonyms_jsonl = db.read_json(synonyms_filename_gz, format='newline_delimited')
 
         # Step 2. Create a Cliques table with all the cliques from this file.
         #db.sql("CREATE TABLE Cliques (curie TEXT PRIMARY KEY, label TEXT, clique_identifier_count INT, biolink_type TEXT)")

--- a/src/exporters/sapbert.py
+++ b/src/exporters/sapbert.py
@@ -136,14 +136,14 @@ def convert_synonyms_to_sapbert(synonym_filename_gz, sapbert_filename_gzipped):
                         generate_smaller_file.write(line)
                         count_smaller_rows += 1
 
-    logger.info(f"Converted {synonym_filename} to SAPBERT training file {synonym_filename}: " +
+    logger.info(f"Converted {synonym_filename_gz} to SAPBERT training file {synonym_filename_gz}: " +
                 f"read {count_entry} entries and wrote out {count_training_rows} training rows.")
 
     # Close SmallerFile if needed.
     if generate_smaller_file:
         generate_smaller_file.close()
         percentage = count_smaller_rows / float(count_training_rows) * 100
-        logger.info(f"Converted {synonym_filename} to smaller SAPBERT training file {generate_smaller_filename}: " +
+        logger.info(f"Converted {synonym_filename_gz} to smaller SAPBERT training file {generate_smaller_filename}: " +
                     f"read {count_entry} entries and wrote out {count_smaller_rows} training rows ({percentage:.2f}%).")
 
 

--- a/src/exporters/sapbert.py
+++ b/src/exporters/sapbert.py
@@ -35,24 +35,24 @@ MAX_SYNONYM_PAIRS = 50
 LOWERCASE_ALL_NAMES = True
 
 
-def convert_synonyms_to_sapbert(synonym_filename, sapbert_filename_gzipped):
+def convert_synonyms_to_sapbert(synonym_filename_gz, sapbert_filename_gzipped):
     """
     Convert a synonyms file to the training format for SAPBERT (https://github.com/RENCI-NER/sapbert).
 
     Based on the code in https://github.com/TranslatorSRI/babel-validation/blob/f21b1b308e54ec0af616f2c24f7e2738ac4c261c/src/main/scala/org/renci/babel/utils/converter/Converter.scala#L107-L207
 
-    :param synonym_filename: The compendium file to convert.
+    :param synonym_filename_gz: The compendium file to convert.
     :param sapbert_filename_gzipped: The SAPBERT training file to generate.
     """
 
-    logger.info(f"convert_synonyms_to_sapbert({synonym_filename}, {sapbert_filename_gzipped})")
+    logger.info(f"convert_synonyms_to_sapbert({synonym_filename_gz}, {sapbert_filename_gzipped})")
 
     # For now, the simplest way to identify the DrugChemicalConflated file is by name.
     # In this case we still generate DrugChemicalConflated.txt, but we also generate
     # DrugChemicalConflatedSmaller.txt, which ignores cliques whose preferred label is
     # longer than config['demote_labels_longer_than'].
     generate_smaller_filename = None
-    if GENERATE_DRUG_CHEMICAL_SMALLER_FILE and synonym_filename.endswith('/DrugChemicalConflated.txt'):
+    if GENERATE_DRUG_CHEMICAL_SMALLER_FILE and synonym_filename_gz.endswith('/DrugChemicalConflated.txt.gz'):
         generate_smaller_filename = sapbert_filename_gzipped.replace('.txt.gz', 'Smaller.txt.gz')
 
     # Make the output directories if they don't exist.
@@ -67,7 +67,7 @@ def convert_synonyms_to_sapbert(synonym_filename, sapbert_filename_gzipped):
     count_entry = 0
     count_training_rows = 0
     count_smaller_rows = 0
-    with open(synonym_filename, "r", encoding="utf-8") as synonymf, gzip.open(sapbert_filename_gzipped, "wt", encoding="utf-8") as sapbertf:
+    with gzip.open(synonym_filename_gz, "rt", encoding="utf-8") as synonymf, gzip.open(sapbert_filename_gzipped, "wt", encoding="utf-8") as sapbertf:
         for input_line in synonymf:
             count_entry += 1
             entry = json.loads(input_line)

--- a/src/snakefiles/cell_line.snakefile
+++ b/src/snakefiles/cell_line.snakefile
@@ -1,6 +1,7 @@
 import src.datahandlers.clo as clo
 import src.createcompendia.cell_line as cell_line
 import src.assess_compendia as assessments
+import src.snakefiles.util as util
 
 ### Cell Line
 
@@ -26,7 +27,7 @@ rule cell_line_compendia:
         icrdf_filename=config['download_directory']+'/icRDF.tsv',
     output:
         config['output_directory']+"/compendia/CellLine.txt",
-        config['output_directory']+"/synonyms/CellLine.txt"
+        temp(config['output_directory']+"/synonyms/CellLine.txt")
     run:
         cell_line.build_compendia(input.ids,input.icrdf_filename)
 
@@ -49,9 +50,11 @@ rule check_cell_line:
 rule cell_line:
     input:
         config['output_directory']+'/reports/cell_line_completeness.txt',
-        config['output_directory'] + "/synonyms/CellLine.txt",
-        config['output_directory'] + "/reports/CellLine.txt"
+        config['output_directory'] + "/reports/CellLine.txt",
+        cell_line_synonyms=config['output_directory'] + "/synonyms/CellLine.txt",
     output:
+        config['output_directory'] + "/synonyms/CellLine.txt.gz",
         x=config['output_directory']+'/reports/cell_line_done'
-    shell:
-        "echo 'done' >> {output.x}"
+    run:
+        util.gzip_files([input.cell_line_synonyms])
+        util.write_done(output.x)

--- a/src/snakefiles/drugchemical.snakefile
+++ b/src/snakefiles/drugchemical.snakefile
@@ -66,12 +66,9 @@ rule drugchemical:
     input:
         config['output_directory']+'/conflation/DrugChemical.txt',
         drug_chemical_conflated=config['output_directory']+'/synonyms/DrugChemicalConflated.txt',
-        chemical_synonyms=expand("{do}/synonyms/{co}", do=config['output_directory'], co=config['chemical_outputs']),
     output:
-        chemical_synonyms_gzipped=expand("{do}/synonyms/{co}.gz", do=config['output_directory'], co=config['chemical_outputs']),
         drug_chemical_conflated_gz=config['output_directory']+'/synonyms/DrugChemicalConflated.txt.gz',
         x=config['output_directory']+'/reports/drugchemical_done'
     run:
-        util.gzip_files(input.chemical_synonyms)
         util.gzip_files([input.drug_chemical_conflated])
         util.write_done(output.x)

--- a/src/snakefiles/drugchemical.snakefile
+++ b/src/snakefiles/drugchemical.snakefile
@@ -58,18 +58,20 @@ rule drugchemical_conflated_synonyms:
         chemical_compendia=expand("{do}/compendia/{co}", do=config['output_directory'], co=config['chemical_outputs']),
         chemical_synonyms=expand("{do}/synonyms/{co}", do=config['output_directory'], co=config['chemical_outputs']),
     output:
-        drugchemical_conflated=config['output_directory']+'/synonyms/DrugChemicalConflated.txt',
+        drugchemical_conflated=temp(config['output_directory']+'/synonyms/DrugChemicalConflated.txt'),
     run:
         synonymconflation.conflate_synonyms(input.chemical_synonyms, input.chemical_compendia, input.drugchemical_conflation, output.drugchemical_conflated)
 
 rule drugchemical:
     input:
         config['output_directory']+'/conflation/DrugChemical.txt',
-        config['output_directory']+'/synonyms/DrugChemicalConflated.txt',
+        drug_chemical_conflated=config['output_directory']+'/synonyms/DrugChemicalConflated.txt',
         chemical_synonyms=expand("{do}/synonyms/{co}", do=config['output_directory'], co=config['chemical_outputs']),
     output:
         chemical_synonyms_gzipped=expand("{do}/synonyms/{co}.gz", do=config['output_directory'], co=config['chemical_outputs']),
+        drug_chemical_conflated_gz=config['output_directory']+'/synonyms/DrugChemicalConflated.txt.gz',
         x=config['output_directory']+'/reports/drugchemical_done'
     run:
         util.gzip_files(input.chemical_synonyms)
+        util.gzip_files([input.drug_chemical_conflated])
         util.write_done(output.x)

--- a/src/snakefiles/drugchemical.snakefile
+++ b/src/snakefiles/drugchemical.snakefile
@@ -58,7 +58,7 @@ rule drugchemical_conflated_synonyms:
         chemical_compendia=expand("{do}/compendia/{co}", do=config['output_directory'], co=config['chemical_outputs']),
         chemical_synonyms_gz=expand("{do}/synonyms/{co}.gz", do=config['output_directory'], co=config['chemical_outputs']),
     output:
-        drugchemical_conflated_gz=temp(config['output_directory']+'/synonyms/DrugChemicalConflated.txt.gz'),
+        drugchemical_conflated_gz=config['output_directory']+'/synonyms/DrugChemicalConflated.txt.gz',
     run:
         synonymconflation.conflate_synonyms(input.chemical_synonyms_gz, input.chemical_compendia, input.drugchemical_conflation, output.drugchemical_conflated_gz)
 

--- a/src/snakefiles/drugchemical.snakefile
+++ b/src/snakefiles/drugchemical.snakefile
@@ -58,17 +58,15 @@ rule drugchemical_conflated_synonyms:
         chemical_compendia=expand("{do}/compendia/{co}", do=config['output_directory'], co=config['chemical_outputs']),
         chemical_synonyms_gz=expand("{do}/synonyms/{co}.gz", do=config['output_directory'], co=config['chemical_outputs']),
     output:
-        drugchemical_conflated=temp(config['output_directory']+'/synonyms/DrugChemicalConflated.txt'),
+        drugchemical_conflated_gz=temp(config['output_directory']+'/synonyms/DrugChemicalConflated.txt.gz'),
     run:
-        synonymconflation.conflate_synonyms(input.chemical_synonyms_gz, input.chemical_compendia, input.drugchemical_conflation, output.drugchemical_conflated)
+        synonymconflation.conflate_synonyms(input.chemical_synonyms_gz, input.chemical_compendia, input.drugchemical_conflation, output.drugchemical_conflated_gz)
 
 rule drugchemical:
     input:
         config['output_directory']+'/conflation/DrugChemical.txt',
-        drug_chemical_conflated=config['output_directory']+'/synonyms/DrugChemicalConflated.txt',
+        config['output_directory']+'/synonyms/DrugChemicalConflated.txt.gz',
     output:
-        drug_chemical_conflated_gz=config['output_directory']+'/synonyms/DrugChemicalConflated.txt.gz',
-        x=config['output_directory']+'/reports/drugchemical_done'
+        done=config['output_directory']+'/reports/drugchemical_done'
     run:
-        util.gzip_files([input.drug_chemical_conflated])
-        util.write_done(output.x)
+        util.write_done(output.done)

--- a/src/snakefiles/drugchemical.snakefile
+++ b/src/snakefiles/drugchemical.snakefile
@@ -56,11 +56,11 @@ rule drugchemical_conflated_synonyms:
     input:
         drugchemical_conflation=[config['output_directory']+'/conflation/DrugChemical.txt'],
         chemical_compendia=expand("{do}/compendia/{co}", do=config['output_directory'], co=config['chemical_outputs']),
-        chemical_synonyms=expand("{do}/synonyms/{co}", do=config['output_directory'], co=config['chemical_outputs']),
+        chemical_synonyms_gz=expand("{do}/synonyms/{co}.gz", do=config['output_directory'], co=config['chemical_outputs']),
     output:
         drugchemical_conflated=temp(config['output_directory']+'/synonyms/DrugChemicalConflated.txt'),
     run:
-        synonymconflation.conflate_synonyms(input.chemical_synonyms, input.chemical_compendia, input.drugchemical_conflation, output.drugchemical_conflated)
+        synonymconflation.conflate_synonyms(input.chemical_synonyms_gz, input.chemical_compendia, input.drugchemical_conflation, output.drugchemical_conflated)
 
 rule drugchemical:
     input:

--- a/src/snakefiles/duckdb.snakefile
+++ b/src/snakefiles/duckdb.snakefile
@@ -44,7 +44,7 @@ rule export_all_synonyms_to_duckdb:
 # Generic rule for generating the Parquet files for a particular compendia file.
 rule export_synonyms_to_duckdb:
     input:
-        synonyms_file=config['output_directory'] + "/synonyms/{filename}.txt",
+        synonyms_file=config['output_directory'] + "/synonyms/{filename}.txt.gz",
     output:
         duckdb_filename=temp(config['output_directory'] + "/duckdb/duckdbs/filename={filename}/synonyms.duckdb"),
         synonyms_parquet_filename=config['output_directory'] + "/duckdb/parquet/filename={filename}/Synonyms.parquet",

--- a/src/snakefiles/exports.snakefile
+++ b/src/snakefiles/exports.snakefile
@@ -49,7 +49,7 @@ rule export_all_to_sapbert_training:
 # Generic rule for generating the KGX files for a particular compendia file.
 rule generate_sapbert_training_data:
     input:
-        synonym_file=config['output_directory'] + "/synonyms/{filename}.gz",
+        synonym_file_gz=config['output_directory'] + "/synonyms/{filename}.gz",
     output:
         sapbert_training_data_file=config['output_directory'] + "/sapbert-training-data/{filename}.gz",
     run:

--- a/src/snakefiles/exports.snakefile
+++ b/src/snakefiles/exports.snakefile
@@ -49,8 +49,8 @@ rule export_all_to_sapbert_training:
 # Generic rule for generating the KGX files for a particular compendia file.
 rule generate_sapbert_training_data:
     input:
-        synonym_file=config['output_directory'] + "/synonyms/{filename}",
+        synonym_file=config['output_directory'] + "/synonyms/{filename}.gz",
     output:
         sapbert_training_data_file=config['output_directory'] + "/sapbert-training-data/{filename}.gz",
     run:
-        sapbert.convert_synonyms_to_sapbert(input.synonym_file, output.sapbert_training_data_file)
+        sapbert.convert_synonyms_to_sapbert(input.synonym_file_gz, output.sapbert_training_data_file)

--- a/src/snakefiles/leftover_umls.snakefile
+++ b/src/snakefiles/leftover_umls.snakefile
@@ -32,7 +32,7 @@ rule leftover_umls:
         umls_synonyms = temp(config['output_directory'] + "/synonyms/umls.txt"),
         report = config['output_directory'] + "/reports/umls.txt",
     run:
-        write_leftover_umls(input.input_compendia, input.mrconso, input.mrsty, input.synonyms, output.umls_compendium, output.umls_synonyms, output.report, output.done, config['biolink_version'])
+        write_leftover_umls(input.input_compendia, input.mrconso, input.mrsty, input.synonyms, output.umls_compendium, output.umls_synonyms, output.report, config['biolink_version'])
 
 rule compress_umls:
     input:

--- a/src/snakefiles/leftover_umls.snakefile
+++ b/src/snakefiles/leftover_umls.snakefile
@@ -31,7 +31,6 @@ rule leftover_umls:
         umls_compendium = config['output_directory'] + "/compendia/umls.txt",
         umls_synonyms = temp(config['output_directory'] + "/synonyms/umls.txt"),
         report = config['output_directory'] + "/reports/umls.txt",
-        done = config['output_directory'] + "/reports/umls_done"
     run:
         write_leftover_umls(input.input_compendia, input.mrconso, input.mrsty, input.synonyms, output.umls_compendium, output.umls_synonyms, output.report, output.done, config['biolink_version'])
 
@@ -40,5 +39,7 @@ rule compress_umls:
         umls_synonyms = config['output_directory'] + "/synonyms/umls.txt",
     output:
         umls_synonyms_gzipped = config['output_directory'] + "/synonyms/umls.txt.gz",
+        done = config['output_directory'] + "/reports/umls_done",
     run:
         util.gzip_files([input.umls_synonyms])
+        util.write_done(output.done)

--- a/src/snakefiles/reports.snakefile
+++ b/src/snakefiles/reports.snakefile
@@ -40,7 +40,7 @@ rule check_synonyms_gzipped_files:
         donefile = config['output_directory']+'/reports/check_synonyms_files.done'
     run:
         assert_files_in_directory(synonyms_path,
-            get_all_gzipped(config, synonyms_files),
+            get_all_gzipped(synonyms_files),
             output.donefile
         )
 

--- a/src/snakefiles/reports.snakefile
+++ b/src/snakefiles/reports.snakefile
@@ -1,4 +1,4 @@
-from src.snakefiles.util import get_all_compendia, get_all_synonyms
+from src.snakefiles.util import get_all_compendia, get_all_synonyms, get_all_gzipped
 import os
 
 from src.reports.compendia_per_file_reports import assert_files_in_directory, \
@@ -32,7 +32,7 @@ rule check_compendia_files:
         )
 
 # Make sure we have all the expected Synonyms files.
-rule check_synonyms_files:
+rule check_synonyms_gzipped_files:
     input:
         # Don't run this until all the outputs have been generated.
         config['output_directory'] + '/reports/outputs_done'
@@ -40,7 +40,7 @@ rule check_synonyms_files:
         donefile = config['output_directory']+'/reports/check_synonyms_files.done'
     run:
         assert_files_in_directory(synonyms_path,
-            synonyms_files,
+            get_all_gzipped(config, synonyms_files),
             output.donefile
         )
 

--- a/src/snakefiles/util.py
+++ b/src/snakefiles/util.py
@@ -113,3 +113,14 @@ def get_all_synonyms_with_drugchemicalconflated(config):
             config['umls_outputs'] +
             config['macromolecularcomplex_outputs']
     )
+
+
+def get_all_gzipped(config, list):
+    """
+    Helper method to add '.gz' to all the files in a list (presumably from get_all_synonyms_*()).
+
+    :param config: The Babel config to use.
+    :param list: List of filenames.
+    :return: List of filenames with '.gz' appended.
+    """
+    return list(map(lambda x: x + '.gz', list))

--- a/src/snakefiles/util.py
+++ b/src/snakefiles/util.py
@@ -21,10 +21,10 @@ def gzip_files(input_filenames):
     logger.info(f"Compressing: {input_filenames}")
     for filename in input_filenames:
         output_filename = filename + '.gz'
-        with open(filename, 'rb') as f_in:
-            with gzip.open(output_filename, 'wb') as f_out:
-                shutil.copyfileobj(f_in, f_out)
-                logger.info(f"Compressed {filename} to {output_filename} using Gzip.")
+        with open(filename, 'rb') as f_in, gzip.open(output_filename, 'wb') as f_out:
+            shutil.copyfileobj(f_in, f_out)
+        logger.info(f"Compressed {filename} to {output_filename} using the gzip module.")
+    logger.info(f"Done compressing: {input_filenames}")
 
 
 # List of all the compendia files that need to be converted.

--- a/src/snakefiles/util.py
+++ b/src/snakefiles/util.py
@@ -115,12 +115,11 @@ def get_all_synonyms_with_drugchemicalconflated(config):
     )
 
 
-def get_all_gzipped(config, list):
+def get_all_gzipped(file_list):
     """
     Helper method to add '.gz' to all the files in a list (presumably from get_all_synonyms_*()).
 
-    :param config: The Babel config to use.
-    :param list: List of filenames.
+    :param file_list: List of filenames.
     :return: List of filenames with '.gz' appended.
     """
-    return list(map(lambda x: x + '.gz', list))
+    return list(map(lambda x: x + '.gz', file_list))

--- a/src/synonyms/synonymconflation.py
+++ b/src/synonyms/synonymconflation.py
@@ -22,18 +22,18 @@ logging.basicConfig(level=logging.INFO)
 #click.option('--conflation-file', multiple=True, type=click.Path(exists=True))
 #click.option('--output', type=click.Path(exists=False), default='-')
 #click.argument("synonym_files", nargs=-1, type=click.Path(exists=True))
-def conflate_synonyms(synonym_files_gz, compendia_files, conflation_file, output):
+def conflate_synonyms(synonym_files_gz, compendia_files, conflation_file, output_gz):
     """
     Generate a synonym file based on a single input synonym, the conflation described in the input conflation files,
     and any cross-references present in the input compendia files.
 
     :param synonym_files_gz: The input synonym files (gzipped).
     :param conflation_file: Any conflation files to apply.
-    :param output: The file to write the synonyms to.
+    :param output_gz: The file to write the synonyms to.
     :return:
     """
 
-    logging.info(f"conflate_synonyms({synonym_files_gz}, {compendia_files}, {conflation_file}, {output})")
+    logging.info(f"conflate_synonyms({synonym_files_gz}, {compendia_files}, {conflation_file}, {output_gz})")
 
     # Some common code to manage the conflation index.
     # This is simply a large dictionary, where every key is an identifier and the value is the identifier to map it to.
@@ -103,8 +103,8 @@ def conflate_synonyms(synonym_files_gz, compendia_files, conflation_file, output
 
     logging.info(f"Added {count_clique_ids_added} IDs from {len(cliques_with_conflations)} cliques involved in conflation.")
 
-    logging.info(f"Writing output to {output}.")
-    with open(output, 'w') as outputf:
+    logging.info(f"Writing output to {output_gz}.")
+    with gzip.open(output_gz, 'wt', encoding='utf8') as outputf:
         # Step 2. Conflate the synonyms.
         synonyms_to_conflate = defaultdict(lambda: defaultdict(list))
         for synonym_filename_gz in synonym_files_gz:

--- a/src/synonyms/synonymconflation.py
+++ b/src/synonyms/synonymconflation.py
@@ -4,6 +4,7 @@
 conflate-synonyms.py is a Python script for conflating synonym files using one or more
 conflation files.
 """
+import gzip
 import sys
 import json
 import logging
@@ -21,18 +22,18 @@ logging.basicConfig(level=logging.INFO)
 #click.option('--conflation-file', multiple=True, type=click.Path(exists=True))
 #click.option('--output', type=click.Path(exists=False), default='-')
 #click.argument("synonym_files", nargs=-1, type=click.Path(exists=True))
-def conflate_synonyms(synonym_files, compendia_files, conflation_file, output):
+def conflate_synonyms(synonym_files_gz, compendia_files, conflation_file, output):
     """
     Generate a synonym file based on a single input synonym, the conflation described in the input conflation files,
     and any cross-references present in the input compendia files.
 
-    :param synonym_files: The input synonym files.
+    :param synonym_files_gz: The input synonym files (gzipped).
     :param conflation_file: Any conflation files to apply.
     :param output: The file to write the synonyms to.
     :return:
     """
 
-    logging.info(f"conflate_synonyms({synonym_files}, {compendia_files}, {conflation_file}, {output})")
+    logging.info(f"conflate_synonyms({synonym_files_gz}, {compendia_files}, {conflation_file}, {output})")
 
     # Some common code to manage the conflation index.
     # This is simply a large dictionary, where every key is an identifier and the value is the identifier to map it to.
@@ -106,9 +107,9 @@ def conflate_synonyms(synonym_files, compendia_files, conflation_file, output):
     with open(output, 'w') as outputf:
         # Step 2. Conflate the synonyms.
         synonyms_to_conflate = defaultdict(lambda: defaultdict(list))
-        for synonym_filename in synonym_files:
-            logging.info(f"Reading synonym file {synonym_filename}")
-            with open(synonym_filename, "r") as synonymsf:
+        for synonym_filename_gz in synonym_files_gz:
+            logging.info(f"Reading synonym file {synonym_filename_gz}")
+            with gzip.open(synonym_filename_gz, "rt", encoding="utf-8") as synonymsf:
                 for synonym_text in synonymsf:
                     synonym = json.loads(synonym_text)
 


### PR DESCRIPTION
Actually running the synonym compression code in Babel v1.10.0 (https://github.com/TranslatorSRI/Babel/pull/424) revealed that it wasn't working properly. This PR should fix that.