### PR TITLE
Change labels, synonyms and descriptions into directories

### DIFF
--- a/src/datahandlers/chembl.py
+++ b/src/datahandlers/chembl.py
@@ -1,5 +1,5 @@
 from src.prefixes import CHEMBLCOMPOUND
-from src.babel_utils import pull_via_ftp, make_local_name
+from src.babel_utils import pull_via_ftp
 import ftplib
 import pyoxigraph
 

--- a/src/datahandlers/clo.py
+++ b/src/datahandlers/clo.py
@@ -4,7 +4,6 @@ import re
 from src.prefixes import CLO
 from src.categories import CELL_LINE
 from src.babel_utils import pull_via_urllib
-from src.babel_utils import make_local_name
 from src.util import Text, LoggingUtil
 import pyoxigraph
 

--- a/src/datahandlers/datacollect.py
+++ b/src/datahandlers/datacollect.py
@@ -1,5 +1,5 @@
 from src.ubergraph import UberGraph
-from src.babel_utils import make_local_name, pull_via_ftp
+from src.babel_utils import make_local_name, pull_via_ftp, pull_via_urllib
 from collections import defaultdict
 import os, gzip
 from json import loads,dumps
@@ -8,7 +8,7 @@ def pull_pubchem_labels():
     print('LABEL PUBCHEM')
     f_name =  'CID-Title.gz'
     cname = pull_via_ftp('ftp.ncbi.nlm.nih.gov','/pubchem/Compound/Extras/', f_name, outfilename=f_name)
-    fname = make_local_name('labels', subpath='PUBCHEM.COMPOUND')
+    fname = make_local_name('pull_pubchem_labels', subpath='PUBCHEM.COMPOUND/labels')
     with open(fname, 'w') as outf, gzip.open(cname,mode='rt',encoding='latin-1') as inf:
         for line in inf:
             x = line.strip().split('\t')
@@ -17,7 +17,7 @@ def pull_pubchem_labels():
 def pull_pubchem_synonyms():
     f_name = 'CID-Synonym-filtered.gz'
     sname = pull_via_ftp('ftp.ncbi.nlm.nih.gov', '/pubchem/Compound/Extras/', f_name, outfilename=f_name)
-    fname = make_local_name('synonyms', subpath='PUBCHEM.COMPOUND')
+    fname = make_local_name('pull_pubchem_synonyms', subpath='PUBCHEM.COMPOUND/synonyms')
     with open(fname, 'w') as outf, gzip.open(sname,mode='rt',encoding='latin-1') as inf:
         for line in inf:
             x = line.strip().split('\t')
@@ -30,28 +30,6 @@ def pull_pubchem_synonyms():
 def pull_pubchem():
     pull_pubchem_labels()
     pull_pubchem_synonyms()
-
-def pull_hgnc():
-    data = pull_via_ftp('ftp.ebi.ac.uk', '/pub/databases/genenames/new/json', 'hgnc_complete_set.json')
-    hgnc_json = loads(data)
-    lname = make_local_name('labels', subpath='HGNC')
-    sname = make_local_name('synonyms', subpath='HGNC')
-    with open(lname,'w') as lfile, open(sname,'w') as sfile:
-        for gene in hgnc_json['response']['docs']:
-            hgnc_id =gene['hgnc_id']
-            symbol = gene['symbol']
-            lfile.write(f'{hgnc_id}\t{symbol}\n')
-            name = gene['name']
-            sfile.write(f'{hgnc_id}\thttp://www.geneontology.org/formats/oboInOwl#hasExactSynonym\t{name}\n')
-            if 'alias_symbol' in gene:
-                alias_symbols = gene['alias_symbol']
-                for asym in alias_symbols:
-                    sfile.write(f'{hgnc_id}\thttp://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym\t{asym}\n')
-            if 'alias_name' in gene:
-                alias_names = gene['alias_name']
-                for asym in alias_names:
-                    sfile.write(f'{hgnc_id}\thttp://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym\t{asym}\n')
-
 
 def pull_prot(which,refresh):
     #swissname = pull_via_ftplib('ftp.uniprot.org','/pub/databases/uniprot/current_release/knowledgebase/complete/',f'uniprot_{which}.fasta.gz',decompress_data=True,outfilename=f'uniprot_{which}.fasta')
@@ -82,7 +60,7 @@ def pull_prot(which,refresh):
 
 def pull_prots(refresh_swiss=False,refresh_trembl=False):
     swiss,labels = pull_prot('sprot',refresh_swiss)
-    fname = make_local_name('labels', subpath='UNIPROTKB')
+    fname = make_local_name('pull_prots', subpath='UNIPROTKB/labels')
     with open(fname,'w') as synonyms:
         for k,v in labels.items():
             synonyms.write(f'{k}\t{v}\n')

--- a/src/datahandlers/ec.py
+++ b/src/datahandlers/ec.py
@@ -1,9 +1,8 @@
 from src.prefixes import EC
 from src.categories import MOLECULAR_ACTIVITY
 from src.babel_utils import pull_via_urllib
-from src.babel_utils import make_local_name, pull_via_ftp
+from src.babel_utils import make_local_name
 import pyoxigraph
-from collections import defaultdict
 
 
 def pull_ec():

--- a/src/datahandlers/hgnc.py
+++ b/src/datahandlers/hgnc.py
@@ -12,8 +12,8 @@ def pull_hgnc():
 def pull_hgnc_labels_and_synonyms(infile):
     with open(infile,'r') as data:
         hgnc_json = json.load(data)
-    lname = make_local_name('labels', subpath='HGNC')
-    sname = make_local_name('synonyms', subpath='HGNC')
+    lname = make_local_name('pull_hgnc_labels_and_synonyms', subpath='HGNC/labels')
+    sname = make_local_name('pull_hgnc_labels_and_synonyms', subpath='HGNC/synonyms')
     with open(lname,'w') as lfile, open(sname,'w') as sfile:
         for gene in hgnc_json['response']['docs']:
             hgnc_id =gene['hgnc_id']

--- a/src/datahandlers/hgncfamily.py
+++ b/src/datahandlers/hgncfamily.py
@@ -1,6 +1,4 @@
-from pronto.utils.io import decompress
-
-from src.babel_utils import make_local_name, pull_via_ftp, pull_via_urllib
+from src.babel_utils import pull_via_urllib
 from src.prefixes import HGNCFAMILY
 
 def pull_hgncfamily():

--- a/src/datahandlers/mesh.py
+++ b/src/datahandlers/mesh.py
@@ -105,7 +105,7 @@ class Mesh:
                 WHERE { ?term rdfs:label ?label }
                 ORDER BY ?term
         """
-        ofname = make_local_name('labels', subpath='MESH')
+        ofname = make_local_name('pull_mesh_labels', subpath='MESH/labels')
         qres = self.m.query(s)
         with open(ofname, 'w', encoding='utf8') as outf:
             for row in list(qres):
@@ -148,7 +148,7 @@ def write_ids(meshmap,outfile,order=['biolink:CellularComponent','biolink:Cell',
 
 
 #    ifname = make_local_name('mesh.nt', subpath='MESH')
-#    ofname = make_local_name('labels', subpath='MESH')
+#    ofname = make_local_name('MESH', subpath='MESH/labels')
 #    badlines = 0
 #    with open(ofname, 'w') as outf, open(ifname,'r') as data:
 #        for line in data:

--- a/src/datahandlers/ncbigene.py
+++ b/src/datahandlers/ncbigene.py
@@ -10,8 +10,8 @@ def pull_ncbigene(filenames):
 def pull_ncbigene_labels_synonyms_and_taxa():
     # File format described here: https://ftp.ncbi.nlm.nih.gov/gene/DATA/README
     ifname = make_local_name('gene_info.gz', subpath='NCBIGene')
-    labelname = make_local_name('labels', subpath='NCBIGene')
-    synname = make_local_name('synonyms', subpath='NCBIGene')
+    labelname = make_local_name('pull_ncbigene_labels_synonyms_and_taxa', subpath='NCBIGene/labels')
+    synname = make_local_name('pull_ncbigene_labels_synonyms_and_taxa', subpath='NCBIGene/synonyms')
     taxaname = make_local_name('taxa', subpath='NCBIGene')
     bad_gene_types = {'biological-region', 'other', 'unknown'}
     with gzip.open(ifname, 'r') as inf, \

--- a/src/datahandlers/obo.py
+++ b/src/datahandlers/obo.py
@@ -24,7 +24,7 @@ def pull_uber_labels(expected):
         ldict[p].add( ( unit['iri'], unit['label'] ) )
     for p in ldict:
         if p not in ['http','ro'] and not p.startswith('t') and not '#' in p:
-            fname = make_local_name('labels',subpath=p)
+            fname = make_local_name('pull_uber_labels',subpath=p + "/labels")
             with open(fname,'w') as outf:
                 for unit in ldict[p]:
                     outf.write(f'{unit[0]}\t{unit[1]}\n')
@@ -39,7 +39,7 @@ def pull_uber_descriptions(expected):
         ldict[p].add( ( unit['iri'], unit['description'] ) )
     for p in ldict:
         if p not in ['http','ro'] and not p.startswith('t') and not '#' in p:
-            fname = make_local_name('descriptions',subpath=p)
+            fname = make_local_name('pull_uber_descriptions',subpath=p + "/descriptions")
             with open(fname,'w') as outf:
                 for unit in ldict[p]:
                     outf.write(f'{unit[0]}\t{unit[1]}\n')
@@ -57,7 +57,7 @@ def pull_uber_synonyms(expected):
     # we are going to make some zero-length files for it
     for p in expected:
         if p not in ['http','ro'] and not p.startswith('t') and not '#' in p:
-            fname = make_local_name('synonyms',subpath=p)
+            fname = make_local_name('pull_uber_synonyms',subpath=p + "/synonyms")
             with open(fname,'w') as outf:
                 for unit in ldict[p]:
                     outf.write(f'{unit[0]}\t{unit[1]}\t{unit[2]}\n')

--- a/src/datahandlers/pantherfamily.py
+++ b/src/datahandlers/pantherfamily.py
@@ -1,4 +1,4 @@
-from src.babel_utils import make_local_name, pull_via_ftp
+from src.babel_utils import pull_via_ftp
 from src.prefixes import PANTHERFAMILY
 
 def pull_pantherfamily():

--- a/src/datahandlers/umls.py
+++ b/src/datahandlers/umls.py
@@ -305,8 +305,8 @@ def pull_umls(mrconso):
     """Run through MRCONSO.RRF creating label and synonym files for UMLS and SNOMEDCT"""
     rows = defaultdict(list)
     priority = read_umls_priority()
-    snomed_label_name = make_local_name('labels', subpath='SNOMEDCT')
-    snomed_syn_name = make_local_name('synonyms', subpath='SNOMEDCT')
+    snomed_label_name = make_local_name('pull_umls', subpath='SNOMEDCT/labels')
+    snomed_syn_name = make_local_name('pull_umls', subpath='SNOMEDCT/synonyms')
     with open(mrconso, 'r') as inf, open(snomed_label_name,'w') as snolabels, open(snomed_syn_name,'w') as snosyns:
         for line in inf:
             if not check_mrconso_line(line):
@@ -335,8 +335,8 @@ def pull_umls(mrconso):
                 #print(pkey)
                 pri = 1000000
             rows[cui].append( (pri,term,line) )
-    lname = make_local_name('labels', subpath='UMLS')
-    sname = make_local_name('synonyms', subpath='UMLS')
+    lname = make_local_name('pull_umls', subpath='UMLS/labels')
+    sname = make_local_name('pull_umls', subpath='UMLS/synonyms')
     re_numerical = re.compile(r"^\s*[+-]*[\d\.]+\s*$")
     with open(lname,'w') as labels, open(sname,'w') as synonyms:
         for cui,crows in rows.items():

--- a/src/datahandlers/uniprotkb.py
+++ b/src/datahandlers/uniprotkb.py
@@ -3,9 +3,7 @@ import logging
 import os
 
 import requests
-from requests import request
-
-from src.babel_utils import pull_via_urllib, make_local_name, pull_via_wget
+from src.babel_utils import make_local_name
 
 
 def readlabels(which):


### PR DESCRIPTION
This would allow us to support labels, synonyms and descriptions from multiple sources (closes #428) and will prevent one label writing script from overwriting another (closes #398).

I'm not changing `taxa` as yet because (1) this is only used in NCBIGene and UniProtKB for now, and (2) there are unlikely to be multiple sources for the taxa that a particular concept applies to.

WIP. Needs to be completed and tested.