### PR TITLE
Collect common files in a single location

### DIFF
--- a/config.json
+++ b/config.json
@@ -15,6 +15,18 @@
   "ubergraph_ontologies": ["UBERON", "CL", "GO", "NCIT", "ECO", "ECTO", "ENVO", "HP", "UPHENO","BFO","BSPO","CARO","CHEBI","CP","GOREL","IAO","MAXO","MONDO","PATO","PR","RO","UBPROP"],
   "mods": ["WormBase","FB","MGI","ZFIN","RGD","SGD"],
 
+  "common": {
+    "labels": [
+      "ubergraph/labels"
+    ],
+    "synonyms": [
+      "ubergraph/synonyms"
+    ],
+    "descriptions": [
+      "ubergraph/descriptions"
+    ]
+  },
+
   "anatomy_prefixes": ["UBERON","GO","CL","UMLS","MESH","NCIT","SNOMEDCT"],
   "anatomy_ids": ["UBERON","GO","CL","UMLS","MESH","NCIT"],
   "anatomy_concords": ["UBERON","GO","CL","UMLS", "WIKIDATA"],

--- a/src/createcompendia/leftover_umls.py
+++ b/src/createcompendia/leftover_umls.py
@@ -12,7 +12,7 @@ from src.prefixes import UMLS
 from src.categories import ACTIVITY, AGENT, DEVICE, DRUG, FOOD, SMALL_MOLECULE, PHYSICAL_ENTITY, PUBLICATION, PROCEDURE
 
 
-def write_leftover_umls(compendia, mrconso, mrsty, synonyms, umls_compendium, umls_synonyms, report, biolink_version):
+def write_leftover_umls(compendia, umls_labels_filename, mrconso, mrsty, synonyms, umls_compendium, umls_synonyms, report, biolink_version):
     """
     Search for "leftover" UMLS concepts, i.e. those that are defined and valid in MRCONSO but are not
     mapped to a concept in Babel.
@@ -20,6 +20,7 @@ def write_leftover_umls(compendia, mrconso, mrsty, synonyms, umls_compendium, um
     As described in https://github.com/TranslatorSRI/NodeNormalization/issues/119#issuecomment-1154751451
 
     :param compendia: A list of compendia to collect.
+    :param umls_labels_filename: The filename of the UMLS labels file to use for this compendium (e.g. 'babel_downloads/UMLS/labels').
     :param mrconso: MRCONSO.RRF file path
     :param mrsty: MRSTY.RRF file path
     :param synonyms: synonyms file for UMLS
@@ -30,7 +31,7 @@ def write_leftover_umls(compendia, mrconso, mrsty, synonyms, umls_compendium, um
     """
 
     logging = Logger()
-    logging.info(f"write_leftover_umls({compendia}, {mrconso}, {mrsty}, {synonyms}, {umls_compendium}, {umls_synonyms}, {report}, {biolink_version})")
+    logging.info(f"write_leftover_umls({compendia}, {umls_labels_filename}, {mrconso}, {mrsty}, {synonyms}, {umls_compendium}, {umls_synonyms}, {report}, {biolink_version})")
 
     # For now, we have many more UMLS entities in MRCONSO than in the compendia, so
     # we'll make an in-memory list of those first. Once that flips, this should be
@@ -206,7 +207,7 @@ def write_leftover_umls(compendia, mrconso, mrsty, synonyms, umls_compendium, um
         reportf.write(f"Collected synonyms for {len(synonyms_by_id)} UMLS IDs into the leftover UMLS synonyms file.\n")
 
         # Write out synonyms to synonym file.
-        node_factory = NodeFactory('babel_downloads/UMLS/labels', biolink_version)
+        node_factory = NodeFactory(umls_labels_filename, biolink_version)
         count_synonym_objs = 0
         with jsonlines.open(umls_synonyms, 'w') as umls_synonymsf:
             for id in synonyms_by_id:

--- a/src/datahandlers/obo.py
+++ b/src/datahandlers/obo.py
@@ -14,7 +14,7 @@ def pull_uber_icRDF(icrdf_filename):
     uber = UberGraph()
     _ = uber.write_normalized_information_content(icrdf_filename)
 
-def pull_uber_labels(expected):
+def pull_uber_labels(outputfile):
     uber = UberGraph()
     labels = uber.get_all_labels()
     ldict = defaultdict(set)
@@ -22,14 +22,14 @@ def pull_uber_labels(expected):
         iri = unit['iri']
         p = iri.split(':')[0]
         ldict[p].add( ( unit['iri'], unit['label'] ) )
-    for p in ldict:
-        if p not in ['http','ro'] and not p.startswith('t') and not '#' in p:
-            fname = make_local_name('labels',subpath=p)
-            with open(fname,'w') as outf:
+
+    with open(outputfile, 'w') as outf:
+        for p in ldict:
+            if p not in ['http','ro'] and not p.startswith('t') and '#' not in p:
                 for unit in ldict[p]:
                     outf.write(f'{unit[0]}\t{unit[1]}\n')
 
-def pull_uber_descriptions(expected):
+def pull_uber_descriptions(outputfile):
     uber = UberGraph()
     labels = uber.get_all_descriptions()
     ldict = defaultdict(set)
@@ -37,15 +37,15 @@ def pull_uber_descriptions(expected):
         iri = unit['iri']
         p = iri.split(':')[0]
         ldict[p].add( ( unit['iri'], unit['description'] ) )
-    for p in ldict:
-        if p not in ['http','ro'] and not p.startswith('t') and not '#' in p:
-            fname = make_local_name('descriptions',subpath=p)
-            with open(fname,'w') as outf:
+
+    with open(outputfile, 'w') as outf:
+        for p in ldict:
+            if p not in ['http','ro'] and not p.startswith('t') and '#' not in p:
                 for unit in ldict[p]:
                     outf.write(f'{unit[0]}\t{unit[1]}\n')
 
 
-def pull_uber_synonyms(expected):
+def pull_uber_synonyms(outputfile):
     uber = UberGraph()
     labels = uber.get_all_synonyms()
     ldict = defaultdict(set)
@@ -53,12 +53,10 @@ def pull_uber_synonyms(expected):
         iri = unit[0]
         p = iri.split(':')[0]
         ldict[p].add(  unit )
-    #There are some of the ontologies that we don't get synonyms for.   But this makes snakemake unhappy so
-    # we are going to make some zero-length files for it
-    for p in expected:
-        if p not in ['http','ro'] and not p.startswith('t') and not '#' in p:
-            fname = make_local_name('synonyms',subpath=p)
-            with open(fname,'w') as outf:
+
+    with open(outputfile, 'w') as outf:
+        for p in ldict:
+            if p not in ['http','ro'] and not p.startswith('t') and '#' not in p:
                 for unit in ldict[p]:
                     outf.write(f'{unit[0]}\t{unit[1]}\t{unit[2]}\n')
 

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -181,15 +181,37 @@ rule get_umls_labels_and_synonyms:
 
 ### OBO Ontologies
 
-rule get_ontology_labels_descriptions_and_synonyms:
+rule get_obo_labels:
     output:
-        expand("{download_directory}/{onto}/labels", download_directory = config['download_directory'], onto = config['ubergraph_ontologies']),
-        expand("{download_directory}/{onto}/synonyms", download_directory = config['download_directory'], onto = config['ubergraph_ontologies']),
-        icrdf_filename = config['download_directory']+'/icRDF.tsv',
-        # This would make sense if we had descriptions for every ontology, but since we don't, we can't make these outputs explicit.
-        # expand("{download_directory}/{onto}/descriptions", download_directory = config['download_directory'], onto = config['ubergraph_ontologies']),
+        obo_labels=config['download_directory']+'/common/ubergraph/labels'
     run:
-        obo.pull_uber(config['ubergraph_ontologies'], output.icrdf_filename)
+        obo.pull_uber_labels(output.obo_labels)
+
+rule get_obo_synonyms:
+    output:
+        obo_synonyms=config['download_directory']+'/common/ubergraph/synonyms'
+    run:
+        obo.pull_uber_synonyms(output.obo_synonyms)
+
+rule get_obo_descriptions:
+    output:
+        obo_descriptions=config['download_directory']+'/common/ubergraph/descriptions'
+    run:
+        obo.pull_uber_descriptions(output.obo_descriptions)
+
+rule get_icrdf:
+    input:
+        # Ideally, we would correctly mark all the dependencies for Ubergraph labels, synonyms and descriptions
+        # throughout the system, but that would require a bunch of rewriting. Luckily, we already have the icRDF file
+        # marked as required for all compendia, so we just need to make sure that OBO/Ubergraph has been downloaded
+        # before the icRDF file is downloaded.
+        config['download_directory']+'/common/ubergraph/labels',
+        config['download_directory']+'/common/ubergraph/synonyms',
+        config['download_directory']+'/common/ubergraph/descriptions'
+    output:
+        icrdf_filename=config['download_directory']+'/icRDF.tsv'
+    run:
+        obo.pull_uber_icRDF(output.icrdf_filename)
 
         # Try to load the icRDF.tsv file (this will produce an error if the file can't be read).
         node.InformationContentFactory(output.icrdf_filename)

--- a/src/snakefiles/leftover_umls.snakefile
+++ b/src/snakefiles/leftover_umls.snakefile
@@ -24,6 +24,7 @@ rule leftover_umls:
     input:
         input_compendia = expand("{output}/compendia/{compendium}", output=config['output_directory'],
             compendium=[x for x in get_all_compendia(config) if x not in {'umls.txt'}]),
+        umls_label_filename = config['download_directory'] + "/UMLS/labels",
         mrconso = config['download_directory'] + '/UMLS/MRCONSO.RRF',
         mrsty = config['download_directory'] + '/UMLS/MRSTY.RRF',
         synonyms = config['download_directory'] + '/UMLS/synonyms'
@@ -32,7 +33,7 @@ rule leftover_umls:
         umls_synonyms = temp(config['output_directory'] + "/synonyms/umls.txt"),
         report = config['output_directory'] + "/reports/umls.txt",
     run:
-        write_leftover_umls(input.input_compendia, input.mrconso, input.mrsty, input.synonyms, output.umls_compendium, output.umls_synonyms, output.report, config['biolink_version'])
+        write_leftover_umls(input.input_compendia, input.umls_label_filename, input.mrconso, input.mrsty, input.synonyms, output.umls_compendium, output.umls_synonyms, output.report, config['biolink_version'])
 
 rule compress_umls:
     input:


### PR DESCRIPTION
In #398, we run into a problem where Ubergraph labels are overwriting labels obtained from other sources.

To fix this issue, I'm going to collect "common" label, synonym and description files into `babel_downloads/{source}` (e.g. `babel_downloads/ubergraph`. These files will be generated in the normal course of running Babel (since `icRDF.tsv`, a required file for all compendia, will not be generated until they have been downloaded). For now, we can add other common files as prerequisites to `icRDF.tsv` -- if we adopt this approach, I'll open a ticket to replace that with a more elegant dependency mechanism in the future based on the `common` file lists in the config file.

I've also modified the NodeFactory so that it loads the common labels into memory first (choosing the lost available label from Ubergraph), and then uses that only if there isn't a prefix-specific label.

I've also modified the SynonymFactory and DescriptionFactory so that they load the common synonyms/descriptions into memory first, and then add them after the prefix-specific synonyms and descriptions.

WIP: needs to be tested.