### PR TITLE
Added database sizes for Babel 2025jan23 and 2025mar31, including NameRes Solr

### DIFF
--- a/releases/2025jan23.md
+++ b/releases/2025jan23.md
@@ -39,6 +39,18 @@ Previous release: [Translator "Hammerhead" November 2024](./TranslatorHammerhead
 
 ## Summary
 
+| Database name    | Database ID         | Number of keys | Memory used |
+|------------------|---------------------|----------------|-------------|
+| id-id            | eq_id_to_id_db      | 675,693,472    |             |
+| id-eq-id         | id_to_eqids_db      | 481,687,260    |             |
+| id-categories    | id_to_type_db       | 481,687,260    |             |
+| semantic-count   | curie_to_bl_type_db | 135            |             |
+| info-content     | info_content_db     | 3,367,948      |             |
+| conflation-db    | gene_protein_db     | 20,709,878     |             |
+| chemical-drug-db | chemical_drug_db    | 107,321        |             |
+
+## Summary of changes
+
 | **Filename**                  | **babel-2024oct24** | **babel-2024jan23** | **Diff**     | **% Diff** |
 | ----------------------------- | ------------------- | ----------------------- | -----------: | ---------: |
 | Count of CURIEs in all files  | 666,832,906         | 675,768,955             | 8,936,049    | 1.34%      |

--- a/releases/2025mar31.md
+++ b/releases/2025mar31.md
@@ -34,6 +34,7 @@ Previous release: [Translator "Hammerhead" November 2024](./TranslatorHammerhead
 | info-content     | info_content_db     | 3,368,041      | 216.55M     |
 | conflation-db    | gene_protein_db     | 20,629,618     | 3.62G       |
 | chemical-drug-db | chemical_drug_db    | 107,907        | 207.12M     |
+| Solr             | name_lookup         | 438,096,729    | 145.79 GB   |
 
 ## Summary of changes
 

--- a/releases/2025mar31.md
+++ b/releases/2025mar31.md
@@ -25,6 +25,18 @@ Previous release: [Translator "Hammerhead" November 2024](./TranslatorHammerhead
 
 ## Summary
 
+| Database name    | Database ID         | Number of keys | Memory used |
+|------------------|---------------------|----------------|-------------|
+| id-id            | eq_id_to_id_db      | 677,692,235    | 68.82G      |
+| id-eq-id         | id_to_eqids_db      | 481,959,561    | 114.65G     |
+| id-categories    | id_to_type_db       | 481,959,561    | 45.17G      |
+| semantic-count   | curie_to_bl_type_db | 134            | 13.32M      |
+| info-content     | info_content_db     | 3,368,041      | 216.55M     |
+| conflation-db    | gene_protein_db     | 20,629,618     | 3.62G       |
+| chemical-drug-db | chemical_drug_db    | 107,907        | 207.12M     |
+
+## Summary of changes
+
 | Filename                      | babel-2025jan23 | babel-2025mar31 | Diff        | % Diff    |
 | ----------------------------- | --------------- | --------------- | ----------- | --------- |
 | Count of CURIEs in all files  | 675,768,955     | 677,806,537     | +2,037,582  | 0.30%     |


### PR DESCRIPTION
This PR adds the database sizes for Babel 2025jan23 and 2025mar31 for both NodeNorm and NameRes.