### PR TITLE
Add a semantic type blocklist to write_umls_ids()

### DIFF
--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -26,7 +26,6 @@ def get_type_from_smiles(smiles):
 def write_umls_ids(mrsty, outfile):
     groups = ['A1.4.1.1.1.1', #antibiotic
               'A1.4.1.1.3.2', # Hormone
-              'A1.4.1.1.3.3',# Enzyme
               'A1.4.1.1.3.4',# Vitamin
               'A1.4.1.1.3.5',# Immunologic Factor
               'A1.4.1.1.4',# Indicator, Reagent, or Diagnostic Aid
@@ -40,7 +39,8 @@ def write_umls_ids(mrsty, outfile):
     #Leaving out these ones:
     exclude_umls_sty_trees = {
         'A1.4.1.1.3.6',     # Receptor
-        'A1.4.1.2.1.7',      # Amino Acid, Peptide, or Protein
+        'A1.4.1.1.3.3',     # Enzyme
+        'A1.4.1.2.1.7',     # Amino Acid, Peptide, or Protein
     }
     umlsmap = {a:CHEMICAL_ENTITY for a in groups}
     umlsmap["A1.3.3"] = DRUG

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -44,8 +44,7 @@ def write_umls_ids(mrsty, outfile):
     }
     umlsmap = {a:CHEMICAL_ENTITY for a in groups}
     umlsmap["A1.3.3"] = DRUG
-    umls.write_umls_ids(mrsty, umlsmap, outfile)
-    # umls.write_umls_ids(mrsty, umlsmap, outfile, blacklist_umls_semantic_type_tree=exclude_umls_sty_trees)
+    umls.write_umls_ids(mrsty, umlsmap, outfile, blocklist_umls_semantic_type_tree=exclude_umls_sty_trees)
 
 def write_rxnorm_ids(infile, outfile):
     groups = ['A1.4.1.1.1.1', #antibiotic

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -38,11 +38,14 @@ def write_umls_ids(mrsty, outfile):
               'A1.3.3' #Clinical Drug
              ]
     #Leaving out these ones:
-    #'A1.4.1.1.3.6',# Receptor
-    #'A1.4.1.2.1.7 Amino Acid, Peptide, or Protein
+    exclude_umls_sty_trees = {
+        'A1.4.1.1.3.6',     # Receptor
+        'A1.4.1.2.1.7',      # Amino Acid, Peptide, or Protein
+    }
     umlsmap = {a:CHEMICAL_ENTITY for a in groups}
     umlsmap["A1.3.3"] = DRUG
     umls.write_umls_ids(mrsty, umlsmap, outfile)
+    # umls.write_umls_ids(mrsty, umlsmap, outfile, blacklist_umls_semantic_type_tree=exclude_umls_sty_trees)
 
 def write_rxnorm_ids(infile, outfile):
     groups = ['A1.4.1.1.1.1', #antibiotic

--- a/src/createcompendia/diseasephenotype.py
+++ b/src/createcompendia/diseasephenotype.py
@@ -84,7 +84,7 @@ def write_umls_ids(mrsty, outfile,badumlsfile):
     #A2.3 Organism Attribute
     # Includes things like "Age" which will merge with EFOs
     umlsmap['A2.3'] = PHENOTYPIC_FEATURE
-    umls.write_umls_ids(mrsty, umlsmap, outfile, blacklist_umls_ids=badumls)
+    umls.write_umls_ids(mrsty, umlsmap, outfile, blocklist_umls_ids=badumls)
 
 
 def build_disease_obo_relationships(outdir):

--- a/src/createcompendia/diseasephenotype.py
+++ b/src/createcompendia/diseasephenotype.py
@@ -84,7 +84,7 @@ def write_umls_ids(mrsty, outfile,badumlsfile):
     #A2.3 Organism Attribute
     # Includes things like "Age" which will merge with EFOs
     umlsmap['A2.3'] = PHENOTYPIC_FEATURE
-    umls.write_umls_ids(mrsty, umlsmap, outfile, blacklist=badumls)
+    umls.write_umls_ids(mrsty, umlsmap, outfile, blacklist_umls_ids=badumls)
 
 
 def build_disease_obo_relationships(outdir):

--- a/src/createcompendia/processactivitypathway.py
+++ b/src/createcompendia/processactivitypathway.py
@@ -33,7 +33,7 @@ def write_ec_ids(outfile):
 
 
 def write_umls_ids(mrsty, outfile):
-    umlsmap = { 'B2.2.1.1.4': MOLECULAR_ACTIVITY, #
+    umlsmap = { 'B2.2.1.1.4': MOLECULAR_ACTIVITY, # Molecular Function
                 'B2.2.1.1': BIOLOGICAL_PROCESS, # Physiologic Function
                 'B2.2.1.1.1': BIOLOGICAL_PROCESS, # Organism Function
                 'B2.2.1.1.2': BIOLOGICAL_PROCESS, # Organ or Tissue Function

--- a/src/datahandlers/umls.py
+++ b/src/datahandlers/umls.py
@@ -41,11 +41,11 @@ def check_mrconso_line(line):
 
     return True
 
-def write_umls_ids(mrsty, category_map, umls_output, prefix=UMLS, blacklist_umls_ids=None, blacklist_umls_semantic_type_tree=None):
-    if blacklist_umls_ids is None:
-        blacklist_umls_ids = set()
-    if blacklist_umls_semantic_type_tree is None:
-        blacklist_umls_semantic_type_tree = set()
+def write_umls_ids(mrsty, category_map, umls_output, prefix=UMLS, blocklist_umls_ids=None, blocklist_umls_semantic_type_tree=None):
+    if blocklist_umls_ids is None:
+        blocklist_umls_ids = set()
+    if blocklist_umls_semantic_type_tree is None:
+        blocklist_umls_semantic_type_tree = set()
     categories = set(category_map.keys())
 
     # Fun fact: MRSTY has duplicate records for entities that have multiple types, e.g.
@@ -69,7 +69,7 @@ def write_umls_ids(mrsty, category_map, umls_output, prefix=UMLS, blacklist_umls
             cat = x[2]
             cat_name = x[3]
             if cat in categories:
-                if x[0] in blacklist_umls_ids:
+                if x[0] in blocklist_umls_ids:
                     continue
 
                 curie = f"{prefix}:{x[0]}"
@@ -78,12 +78,12 @@ def write_umls_ids(mrsty, category_map, umls_output, prefix=UMLS, blacklist_umls
                 semantic_type_trees[curie].add(cat)
                 output_lines[curie].append(category_map[cat])
 
-        if blacklist_umls_semantic_type_tree:
+        if blocklist_umls_semantic_type_tree:
             # If we need to blacklist by UMLS semantic type trees,
             for curie in semantic_type_trees.keys():
-                if semantic_type_trees[curie] & blacklist_umls_semantic_type_tree:
+                if semantic_type_trees[curie] & blocklist_umls_semantic_type_tree:
                     sty_trees_with_names = ", ".join(map(lambda sty_tree: sty_tree + "=" + tree_names[sty_tree], semantic_type_trees[curie]))
-                    blocklist_sty_trees_with_names = ", ".join(map(lambda sty_tree: sty_tree + "=" + tree_names[sty_tree], blacklist_umls_semantic_type_tree))
+                    blocklist_sty_trees_with_names = ", ".join(map(lambda sty_tree: sty_tree + "=" + tree_names[sty_tree], blocklist_umls_semantic_type_tree))
                     logging.info(f"Deleted {curie} from UMLS IDs because its types ({sty_trees_with_names}) overlapped with the blocklist ({blocklist_sty_trees_with_names}).")
                     del output_lines[curie]
 

--- a/src/datahandlers/umls.py
+++ b/src/datahandlers/umls.py
@@ -41,15 +41,54 @@ def check_mrconso_line(line):
 
     return True
 
-def write_umls_ids(mrsty, category_map,umls_output,prefix=UMLS,blacklist=set()):
+def write_umls_ids(mrsty, category_map, umls_output, prefix=UMLS, blacklist_umls_ids=None, blacklist_umls_semantic_type_tree=None):
+    if blacklist_umls_ids is None:
+        blacklist_umls_ids = set()
+    if blacklist_umls_semantic_type_tree is None:
+        blacklist_umls_semantic_type_tree = set()
     categories = set(category_map.keys())
+
+    # Fun fact: MRSTY has duplicate records for entities that have multiple types, e.g.
+    #   CUI | TUI | STN | STY | ATUI | CVF
+    #   C0000005|T116|A1.4.1.2.1.7|Amino Acid, Peptide, or Protein|AT17648347|256|
+    #   C0000005|T121|A1.4.1.1.1|Pharmacologic Substance|AT17575038|256|
+    #   C0000005|T130|A1.4.1.1.4|Indicator, Reagent, or Diagnostic Aid|AT17634323|256|
+    #   C0000039|T109|A1.4.1.2.1|Organic Chemical|AT45562015|256|
+    # (see https://github.com/TranslatorSRI/Babel/issues/200#issuecomment-1789550364 for another example and
+    #  https://www.ncbi.nlm.nih.gov/books/NBK9685/table/ch03.Tf/ for column information.)
+    #
+    # This means that we can't blacklist UMLS types by just skipping those lines: instead, we will need to load
+    # the type information on the selected CUI, and later filter out the blacklisted UMLS type trees.
+
+    tree_names = defaultdict(set)
+    output_lines = defaultdict(list)
+    semantic_type_trees = defaultdict(set)
     with open(mrsty,'r') as inf, open(umls_output,'w') as outf:
         for line in inf:
             x = line.strip().split('|')
             cat = x[2]
+            cat_name = x[3]
             if cat in categories:
-                if not x[0] in blacklist:
-                    outf.write(f'{prefix}:{x[0]}\t{category_map[cat]}\n')
+                if x[0] in blacklist_umls_ids:
+                    continue
+
+                curie = f"{prefix}:{x[0]}"
+
+                tree_names[cat].add(cat_name)
+                semantic_type_trees[curie].add(cat)
+                output_lines[curie].append(category_map[cat])
+
+        if blacklist_umls_semantic_type_tree:
+            # If we need to blacklist by UMLS semantic type trees,
+            for curie in semantic_type_trees.keys():
+                if semantic_type_trees[curie] & blacklist_umls_semantic_type_tree:
+                    sty_trees_with_names = ", ".join(map(lambda sty_tree: sty_tree + "=" + tree_names[sty_tree], semantic_type_trees[curie]))
+                    blocklist_sty_trees_with_names = ", ".join(map(lambda sty_tree: sty_tree + "=" + tree_names[sty_tree], blacklist_umls_semantic_type_tree))
+                    logging.info(f"Deleted {curie} from UMLS IDs because its types ({sty_trees_with_names}) overlapped with the blocklist ({blocklist_sty_trees_with_names}).")
+                    del output_lines[curie]
+
+        outf.write("\n".join(output_lines))
+
 
 def write_rxnorm_ids(category_map, bad_categories, infile, outfile,prefix=RXCUI,styfile="RXNSTY.RRF",blacklist=set()):
     """It's surprising, but not everything in here has an RXCUI.

--- a/src/datahandlers/umls.py
+++ b/src/datahandlers/umls.py
@@ -42,6 +42,18 @@ def check_mrconso_line(line):
     return True
 
 def write_umls_ids(mrsty, category_map, umls_output, prefix=UMLS, blocklist_umls_ids=None, blocklist_umls_semantic_type_tree=None):
+    """
+    Write out UMLS IDs and categories (as per a category map) to a file.
+
+    :param mrsty: The file path of the MRSTY.RRF file from the UMLS download.
+    :param category_map: A dictionary mapping UMLS semantic types to Biolink types.
+    :param umls_output: The file path of the output file.
+    :param prefix: The prefix to use for the UMLS IDs. Defaults to UMLS.
+    :param blocklist_umls_ids: A set of individual UMLS IDs to block. Defaults to None.
+    :param blocklist_umls_semantic_type_tree: A set of UMLS semantic type trees to block. Defaults to None.
+    :return: None.
+    """
+
     if blocklist_umls_ids is None:
         blocklist_umls_ids = set()
     if blocklist_umls_semantic_type_tree is None:


### PR DESCRIPTION
This PR adds a `blocklist_umls_semantic_type_tree` parameter to `write_umls_ids()`, in addition to the existing `blocklist_umls_ids` parameter. The former is a list of UMLS semantic type trees (e.g. `A1.4.1.2.1.7: Amino Acid, Peptide, or Protein`), while the latter is a list of individual UMLS IDs that should be skipped. Because each UMLS ID can have multiple semantic types, we need to load all the potential UMLS IDs into memory along with all its semantic types, so we can determine whether or not we need to block it.