### PR TITLE
Moved UMLSToBiolinkTypeConverter into umls.py

### DIFF
--- a/src/createcompendia/leftover_umls.py
+++ b/src/createcompendia/leftover_umls.py
@@ -48,8 +48,9 @@ def write_leftover_umls(compendia, umls_labels_filename, mrconso, mrsty, synonym
     Path(umls_compendium).touch()
 
     with open(umls_compendium, 'w') as compendiumf, open(report, 'w') as reportf:
-        # This defaults to the version of the Biolink model that is included with this BMT.
-        biolink_toolkit = Toolkit()
+
+        umls_type_by_id = dict()
+        preferred_name_by_id = dict()
 
         for compendium in compendia:
             logging.info(f"Starting compendium: {compendium}")
@@ -69,35 +70,13 @@ def write_leftover_umls(compendia, umls_labels_filename, mrconso, mrsty, synonym
         reportf.write(f"Completed all compendia with {len(umls_ids_in_other_compendia)} UMLS IDs.\n")
         # print(umls_ids_in_other_compendia)
 
-        # Load all the semantic types.
-        umls_type_by_id = dict()
-        preferred_name_by_id = dict()
-        types_by_id = dict()
-        types_by_tui = dict()
-        with open(mrsty, 'r') as inf:
-            for line in inf:
-                x = line.strip().split('|')
-                umls_id = f"{UMLS}:{x[0]}"
-                tui = x[1]
-                # stn = x[2]
-                sty = x[3]
-
-                if umls_id not in types_by_id:
-                    types_by_id[umls_id] = dict()
-                if tui not in types_by_id[umls_id]:
-                    types_by_id[umls_id][tui] = set()
-                types_by_id[umls_id][tui].add(sty)
-
-                if tui not in types_by_tui:
-                    types_by_tui[tui] = set()
-                types_by_tui[tui].add(sty)
-
-        logging.info(f"Completed loading {len(types_by_id.keys())} UMLS IDs from MRSTY.RRF.")
-        reportf.write(f"Completed loading {len(types_by_id.keys())} UMLS IDs from MRSTY.RRF.\n")
+        umls_to_biolink = umls.UMLSToBiolinkTypeConverter(mrsty)
+        logging.info(f"Completed loading {len(umls_to_biolink.types_by_id.keys())} UMLS IDs from MRSTY.RRF.")
+        reportf.write(f"Completed loading {len(umls_to_biolink.types_by_id.keys())} UMLS IDs from MRSTY.RRF.\n")
 
         with open('babel_outputs/reports/umls-types.tsv', 'w') as outf:
-            for tui in sorted(types_by_tui.keys()):
-                for sty in sorted(list(types_by_tui[tui])):
+            for tui in sorted(umls_to_biolink.types_by_tui.keys()):
+                for sty in sorted(list(umls_to_biolink.types_by_tui[tui])):
                     outf.write(f"{tui}\t{sty}\n")
 
         # Create a compendium that consists solely of all MRCONSO entries that haven't been referenced.
@@ -121,50 +100,20 @@ def write_leftover_umls(compendia, umls_labels_filename, mrconso, mrsty, synonym
                 # The STR value should be the label.
                 label = x[14]
 
-                # Lookup type.
-                def umls_type_to_biolink_type(umls_tui):
-                    biolink_type = biolink_toolkit.get_element_by_mapping(f'STY:{umls_tui}', most_specific=True, formatted=True, mixin=True)
-                    if biolink_type is None:
-                        logging.debug(f"No Biolink type found for UMLS TUI {umls_tui}")
-                    return biolink_type
+                biolink_types = umls_to_biolink.get_biolink_types(umls_id)
+                if len(biolink_types) > 1:
+                    count_multiple_umls_type += 1
+                biolink_type = umls_to_biolink.choose_single_biolink_type(umls_id, biolink_types)
 
-                umls_type_results = types_by_id.get(umls_id, {'biolink:NamedThing': {'Named thing'}})
-                biolink_types = set(list(map(umls_type_to_biolink_type, umls_type_results.keys())))
-
-                # How to deal with multiple Biolink types? We currently only have the following multiple
-                # types, so we can resolve these manually:
-                biolink_types_as_set = set(map(lambda t: "(None)" if t is None else t, list(biolink_types)))
-                biolink_types_as_str = '|'.join(sorted(list(biolink_types_as_set)))
-
-                if None in biolink_types:
-                    # One of the TUIs couldn't be converted; let's delete all of them so that we can report this.
-                    biolink_types = list()
-
-                # Some Biolink multiple types we handle manually.
-                if biolink_types_as_set == {DEVICE, DRUG}:
-                    biolink_types = [DRUG]
-                elif biolink_types_as_set == {DRUG, SMALL_MOLECULE}:
-                    biolink_types = [SMALL_MOLECULE]
-                elif biolink_types_as_set == {AGENT, PHYSICAL_ENTITY}:
-                    biolink_types = [AGENT]
-                elif biolink_types_as_set == {PHYSICAL_ENTITY, PUBLICATION}:
-                    biolink_types = [PUBLICATION]
-                elif biolink_types_as_set == {ACTIVITY, PROCEDURE}:
-                    biolink_types = [PROCEDURE]
-                elif biolink_types_as_set == {DRUG, FOOD}:
-                    biolink_types = [FOOD]
-
-                if len(biolink_types) == 0:
+                if biolink_type is None:
+                    umls_type_results = umls_to_biolink.types_by_id.get(umls_id, {'biolink:NamedThing': {'Named thing'}})
                     logging.debug(f"No UMLS type found for {umls_id}: {umls_type_results} -> {biolink_types}, skipping")
                     reportf.write(f"NO_UMLS_TYPE [{umls_id}]: {umls_type_results} -> {biolink_types}\n")
                     count_no_umls_type += 1
-                    continue
-                if len(biolink_types) > 1:
-                    logging.debug(f"Multiple UMLS types not yet supported for {umls_id}: {umls_type_results} -> {biolink_types}, skipping")
-                    reportf.write(f"MULTIPLE_UMLS_TYPES [{umls_id}]\t{biolink_types_as_str}\t{umls_type_results} -> {biolink_types}\n")
-                    count_multiple_umls_type += 1
-                    continue
-                biolink_type = list(biolink_types)[0]
+
+                    # Default to it being a biolink:NamedThing.
+                    biolink_type = 'biolink:NamedThing'
+
                 umls_type_by_id[umls_id] = biolink_type
                 preferred_name_by_id[umls_id] = label
 


### PR DESCRIPTION
This is to ensure that these type mappings can be used elsewhere in the source code if needed.

WIP: should we refined after #750