### PR TITLE
Removed reference to renciorg/renci-python-image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,6 @@
 name: 'Release a new version to Github Packages'
 
 on:
-  push:
   release:
     types: [published]
 


### PR DESCRIPTION
Instead, we now pin to python:latest, which is the latest stable Debian version of Python (currently 3.13.5-bookworm).

Also updates the ENTRYPOINT to be a JSON object as per a warning.