### PR TITLE
Create get_biolink_model_toolkit() utility function

### DIFF
--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -12,8 +12,8 @@ import requests
 import os
 import urllib
 import jsonlines
-from src.node import NodeFactory, SynonymFactory, DescriptionFactory, InformationContentFactory, TaxonFactory, get_config
-from src.util import Text
+from src.node import NodeFactory, SynonymFactory, DescriptionFactory, InformationContentFactory, TaxonFactory
+from src.util import Text, get_config
 from src.LabeledID import LabeledID
 from collections import defaultdict
 import sqlite3

--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -1,6 +1,6 @@
 import csv
 
-from src.node import NodeFactory, get_config, InformationContentFactory
+from src.node import NodeFactory, InformationContentFactory
 from src.prefixes import RXCUI, PUBCHEMCOMPOUND, UMLS
 from src.categories import (CHEMICAL_ENTITY, DRUG, MOLECULAR_MIXTURE, FOOD, COMPLEX_MOLECULAR_MIXTURE,
                             SMALL_MOLECULE, NUCLEIC_ACID_ENTITY, MOLECULAR_ENTITY, FOOD_ADDITIVE,
@@ -10,7 +10,8 @@ from collections import defaultdict
 import os,json
 
 import logging
-from src.util import LoggingUtil
+from src.util import LoggingUtil, get_config
+
 logger = LoggingUtil.init_logging(__name__, level=logging.INFO)
 
 # RXNORM has lots of relationships.

--- a/src/createcompendia/leftover_umls.py
+++ b/src/createcompendia/leftover_umls.py
@@ -5,7 +5,8 @@ from pathlib import Path
 
 from snakemake.logging import Logger
 
-from src.node import NodeFactory, get_biolink_model_toolkit
+from src.node import NodeFactory
+from src.util import get_biolink_model_toolkit
 from src.datahandlers import umls
 from src.prefixes import UMLS
 from src.categories import ACTIVITY, AGENT, DEVICE, DRUG, FOOD, SMALL_MOLECULE, PHYSICAL_ENTITY, PUBLICATION, PROCEDURE

--- a/src/createcompendia/leftover_umls.py
+++ b/src/createcompendia/leftover_umls.py
@@ -4,9 +4,8 @@ import jsonlines
 from pathlib import Path
 
 from snakemake.logging import Logger
-from bmt import Toolkit
 
-from src.node import NodeFactory
+from src.node import NodeFactory, get_biolink_model_toolkit
 from src.datahandlers import umls
 from src.prefixes import UMLS
 from src.categories import ACTIVITY, AGENT, DEVICE, DRUG, FOOD, SMALL_MOLECULE, PHYSICAL_ENTITY, PUBLICATION, PROCEDURE
@@ -27,6 +26,7 @@ def write_leftover_umls(compendia, umls_labels_filename, mrconso, mrsty, synonym
     :param umls_compendium: The UMLS compendium file to write out.
     :param umls_synonyms: The synonyms file to generate for this compendium.
     :param report: The report file to write out.
+    :param biolink_version: The Biolink Model version to use.
     :return: Nothing.
     """
 
@@ -49,7 +49,7 @@ def write_leftover_umls(compendia, umls_labels_filename, mrconso, mrsty, synonym
 
     with open(umls_compendium, 'w') as compendiumf, open(report, 'w') as reportf:
         # This defaults to the version of the Biolink model that is included with this BMT.
-        biolink_toolkit = Toolkit()
+        biolink_toolkit = get_biolink_model_toolkit(biolink_version)
 
         for compendium in compendia:
             logging.info(f"Starting compendium: {compendium}")

--- a/src/datahandlers/drugbank.py
+++ b/src/datahandlers/drugbank.py
@@ -5,7 +5,7 @@ import os.path
 import shutil
 from zipfile import ZipFile
 
-from src.node import get_config
+from src.util import get_config
 import requests
 
 from src.prefixes import DRUGBANK

--- a/src/datahandlers/ensembl.py
+++ b/src/datahandlers/ensembl.py
@@ -1,6 +1,7 @@
 import traceback
 
-from src.babel_utils import make_local_name, get_config
+from src.babel_utils import make_local_name
+from src.util import get_config
 from apybiomart import find_datasets, query, find_attributes
 import os
 

--- a/src/datahandlers/obo.py
+++ b/src/datahandlers/obo.py
@@ -2,12 +2,12 @@ import json
 
 from src.ubergraph import UberGraph
 from src.babel_utils import make_local_name, pull_via_ftp
-from src.node import get_config
 from collections import defaultdict
 import os, gzip
 from json import loads,dumps
 
-from src.util import Text
+from src.util import Text, get_config
+
 
 def pull_uber_icRDF(icrdf_filename):
     """

--- a/src/datahandlers/unii.py
+++ b/src/datahandlers/unii.py
@@ -5,7 +5,7 @@ import requests
 
 from src.prefixes import UNII
 from src.babel_utils import pull_via_urllib
-from src.node import get_config
+from src.util import get_config
 
 
 def pull_unii():

--- a/src/exporters/duckdb_exporters.py
+++ b/src/exporters/duckdb_exporters.py
@@ -9,7 +9,7 @@ from collections import Counter, defaultdict
 
 import duckdb
 
-from src.node import get_config
+from src.util import get_config
 
 
 def setup_duckdb(duckdb_filename):

--- a/src/exporters/sapbert.py
+++ b/src/exporters/sapbert.py
@@ -18,8 +18,7 @@ from itertools import combinations
 
 import logging
 
-from src.node import get_config
-from src.util import LoggingUtil
+from src.util import LoggingUtil, get_config
 
 # Default logger for this file.
 logger = LoggingUtil.init_logging(__name__, level=logging.INFO)

--- a/src/node.py
+++ b/src/node.py
@@ -1,4 +1,3 @@
-import yaml
 import json
 import logging
 import os
@@ -7,57 +6,9 @@ from urllib.parse import urlparse
 
 import curies
 
-from src.util import Text
+from src.util import Text, get_config, get_biolink_model_toolkit, get_biolink_prefix_map
 from src.LabeledID import LabeledID
-from bmt import Toolkit
 from src.prefixes import PUBCHEMCOMPOUND
-
-
-def get_config():
-    """
-    Retrieve the configuration data from the 'config.yaml' file.
-
-    :return: The configuration data loaded from the 'config.yaml' file.
-    """
-    cname = os.path.join(os.path.dirname(__file__),'..', 'config.yaml')
-    with open(cname,'r') as yaml_file:
-        data = yaml.safe_load(yaml_file)
-    return data
-
-
-def get_biolink_model_toolkit(biolink_version):
-    """
-    Return a BMT Toolkit object for the specified Biolink Model version.
-
-    :param biolink_version: The Biolink Model version to use (e.g. "v4.2.6-rc5").
-    :return: A Toolkit instance from the bmt library using the specified Biolink version.
-    """
-    return Toolkit(f'https://raw.githubusercontent.com/biolink/biolink-model/v{biolink_version}/biolink-model.yaml')
-
-
-def get_biolink_prefix_map():
-    """
-    Get the prefix map for the BioLink Model.
-
-    :return: The prefix map for the BioLink Model.
-    :raises RuntimeError: If the BioLink version is not supported.
-    """
-    config = get_config()
-    biolink_version = config['biolink_version']
-    if biolink_version.startswith('1.') or biolink_version.startswith('2.'):
-        raise RuntimeError(f"Biolink version {biolink_version} is not supported.")
-    elif biolink_version.startswith('3.'):
-        # biolink-model v3.* releases keeps the prefix map in a different place.
-        return curies.Converter.from_prefix_map(
-            'https://raw.githubusercontent.com/biolink/biolink-model/v' + biolink_version +
-            '/prefix-map/biolink-model-prefix-map.json'
-        )
-    else:
-        # biolink-model v4.0.0 and beyond is in the /project directory.
-        return curies.Converter.from_prefix_map(
-            f'https://raw.githubusercontent.com/biolink/biolink-model/v' + biolink_version +
-            '/project/prefixmap/biolink_model_prefix_map.json'
-        )
 
 
 class SynonymFactory:

--- a/src/node.py
+++ b/src/node.py
@@ -25,6 +25,16 @@ def get_config():
     return data
 
 
+def get_biolink_model_toolkit(biolink_version):
+    """
+    Return a BMT Toolkit object for the specified Biolink Model version.
+
+    :param biolink_version: The Biolink Model version to use (e.g. "v4.2.6-rc5").
+    :return: A Toolkit instance from the bmt library using the specified Biolink version.
+    """
+    return Toolkit(f'https://raw.githubusercontent.com/biolink/biolink-model/v{biolink_version}/biolink-model.yaml')
+
+
 def get_biolink_prefix_map():
     """
     Get the prefix map for the BioLink Model.
@@ -322,7 +332,7 @@ class InformationContentFactory:
 
 class NodeFactory:
     def __init__(self,label_dir,biolink_version):
-        self.toolkit = Toolkit(f'https://raw.githubusercontent.com/biolink/biolink-model/v{biolink_version}/biolink-model.yaml')
+        self.toolkit = get_biolink_model_toolkit(biolink_version)
         self.ancestor_map = {}
         self.prefix_map = {}
         self.ignored_prefixes = set()

--- a/src/util.py
+++ b/src/util.py
@@ -1,10 +1,15 @@
 import logging
 import json
 import os
+
+import curies
 import yaml
 from collections import namedtuple
 import copy
 from logging.handlers import RotatingFileHandler
+
+from bmt import Toolkit
+
 from src.LabeledID import LabeledID
 from src.prefixes import OMIM, OMIMPS, UMLS, SNOMEDCT, KEGGPATHWAY, KEGGREACTION, NCIT, ICD10, ICD10CM, ICD11FOUNDATION
 import src.prefixes as prefixes
@@ -278,3 +283,50 @@ class DataStructure:
     @staticmethod
     def to_named_tuple (type_name, d):
         return namedtuple(type_name, d.keys())(**d)
+
+
+def get_config():
+    """
+    Retrieve the configuration data from the 'config.yaml' file.
+
+    :return: The configuration data loaded from the 'config.yaml' file.
+    """
+    cname = os.path.join(os.path.dirname(__file__),'..', 'config.yaml')
+    with open(cname,'r') as yaml_file:
+        data = yaml.safe_load(yaml_file)
+    return data
+
+
+def get_biolink_model_toolkit(biolink_version):
+    """
+    Return a BMT Toolkit object for the specified Biolink Model version.
+
+    :param biolink_version: The Biolink Model version to use (e.g. "v4.2.6-rc5").
+    :return: A Toolkit instance from the bmt library using the specified Biolink version.
+    """
+    return Toolkit(f'https://raw.githubusercontent.com/biolink/biolink-model/v{biolink_version}/biolink-model.yaml')
+
+
+def get_biolink_prefix_map():
+    """
+    Get the prefix map for the BioLink Model.
+
+    :return: The prefix map for the BioLink Model.
+    :raises RuntimeError: If the BioLink version is not supported.
+    """
+    config = get_config()
+    biolink_version = config['biolink_version']
+    if biolink_version.startswith('1.') or biolink_version.startswith('2.'):
+        raise RuntimeError(f"Biolink version {biolink_version} is not supported.")
+    elif biolink_version.startswith('3.'):
+        # biolink-model v3.* releases keeps the prefix map in a different place.
+        return curies.Converter.from_prefix_map(
+            'https://raw.githubusercontent.com/biolink/biolink-model/v' + biolink_version +
+            '/prefix-map/biolink-model-prefix-map.json'
+        )
+    else:
+        # biolink-model v4.0.0 and beyond is in the /project directory.
+        return curies.Converter.from_prefix_map(
+            f'https://raw.githubusercontent.com/biolink/biolink-model/v' + biolink_version +
+            '/project/prefixmap/biolink_model_prefix_map.json'
+        )


### PR DESCRIPTION
This is to ensure that we always load the configured version. I also moved some utility functions into `utils.py`.

Closes #447.