### PR TITLE
Fix information content comparisons (float instead of string)

### DIFF
--- a/src/node.py
+++ b/src/node.py
@@ -231,7 +231,7 @@ class InformationContentFactory:
                     unmapped_urls.append(x[0])
 
                 ic = x[1]
-                self.ic[node_id] = ic
+                self.ic[node_id] = float(ic)
 
                 # Track IC values by prefix.
                 if isinstance(node_id, str):
@@ -275,7 +275,9 @@ class InformationContentFactory:
         for ident in node['identifiers']:
             thisid = ident['identifier']
             if thisid in self.ic:
-               ICs.append(self.ic[thisid])
+                # IC values are numeric values between 0 and 100.
+                # Make sure this is a float for min() purposes.
+                ICs.append(float(self.ic[thisid]))
         if len(ICs) == 0:
             return None
         return min(ICs)


### PR DESCRIPTION
It turns out that we were doing string comparisons on information content values instead of float comparisons. This PR fixes that.