### PR TITLE
Added option to generate prefix labels/synonyms files for some UberGraph prefixes

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -23,6 +23,8 @@ generate_dirs_for_labels_and_synonyms_prefixes:
   - NCIT
   - UBERON
   - CHEBI
+  - HP
+  - MONDO
 
 ubergraph_ontologies:
   - UBERON

--- a/config.yaml
+++ b/config.yaml
@@ -25,6 +25,7 @@ generate_dirs_for_labels_and_synonyms_prefixes:
   - CHEBI
   - HP
   - MONDO
+  - PR
 
 ubergraph_ontologies:
   - UBERON

--- a/config.yaml
+++ b/config.yaml
@@ -22,6 +22,7 @@ generate_dirs_for_labels_and_synonyms_prefixes:
   - CL
   - NCIT
   - UBERON
+  - CHEBI
 
 ubergraph_ontologies:
   - UBERON

--- a/config.yaml
+++ b/config.yaml
@@ -17,6 +17,12 @@ ncbi_files:
   - gene_refseq_uniprotkb_collab.gz
   - mim2gene_medgen
 
+generate_dirs_for_labels_and_synonyms_prefixes:
+  - GO
+  - CL
+  - NCIT
+  - UBERON
+
 ubergraph_ontologies:
   - UBERON
   - CL

--- a/src/datahandlers/obo.py
+++ b/src/datahandlers/obo.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 from src.ubergraph import UberGraph
 from src.babel_utils import make_local_name, pull_via_ftp
@@ -16,7 +17,29 @@ def pull_uber_icRDF(icrdf_filename):
     uber = UberGraph()
     _ = uber.write_normalized_information_content(icrdf_filename)
 
-def pull_uber_labels(outputfile):
+def pull_uber_labels(outputfile, prefix_labels_files_to_generate):
+    """
+    Pulls all labels from an UberGraph, organizes them by their IRI prefixes, and writes
+    them into a single output file. Note that ALL IRI prefixes will be included in this
+    file, whether it's actually used in Babel or not.
+
+    This function retrieves all labels available in the UberGraph resource using the
+    `get_all_labels` method. The labels are categorized based on their IRI prefixes,
+    skipping certain prefixes like 'http', 'ro', prefixes starting with 't', or those
+    containing the '#' character. The categorized labels are then written to the specified
+    output file in a tab-delimited format.
+
+    To keep Snakemake working, we need to put labels for some prefixes into their own directories.
+    These will be listed as label files to create in prefix_dirs_to_generate.
+
+    :param outputfile: The path to the output file where the categorized labels will be written.
+    :type outputfile: str
+    :param prefix_labels_files_to_generate: Prefixes we need to create directories for in babel_downloads.
+    :type prefix_labels_files_to_generate: list[str]
+    :return: None
+    """
+
+    # Load all the labels from UberGraph.
     uber = UberGraph()
     labels = uber.get_all_labels()
     ldict = defaultdict(set)
@@ -25,11 +48,24 @@ def pull_uber_labels(outputfile):
         p = iri.split(':')[0]
         ldict[p].add( ( unit['iri'], unit['label'] ) )
 
+    # Write out the common output file.
     with open(outputfile, 'w') as outf:
         for p in ldict:
             if p not in ['http','ro'] and not p.startswith('t') and '#' not in p:
                 for unit in ldict[p]:
                     outf.write(f'{unit[0]}\t{unit[1]}\n')
+
+    # Create prefix directories and label files for some prefixes.
+    for prefix_labels_file in prefix_labels_files_to_generate:
+        prefix_dir = Path(prefix_labels_file).parent
+        prefix = prefix_dir.name
+        os.makedirs(prefix_dir, exist_ok=True)
+        if prefix not in ldict:
+            raise ValueError(f'Prefix {prefix} not found in UberGraph download.')
+        with open(prefix_labels_file, 'w') as outf:
+            for unit in ldict[prefix]:
+                outf.write(f'{unit[0]}\t{unit[1]}\n')
+
 
 def pull_uber_descriptions(jsonloutputfile):
     uber = UberGraph()
@@ -48,7 +84,19 @@ def pull_uber_descriptions(jsonloutputfile):
                 # Couldn't extract a prefix for this CURIE, so let's ignore it.
                 continue
 
-def pull_uber_synonyms(jsonloutputfile):
+def pull_uber_synonyms(jsonloutputfile, prefix_synonyms_files_to_generate):
+    """
+    Extracts synonyms from the UberGraph, structures them by identifiers (CURIEs), and writes
+    them in JSON Lines format to the specified output file. The function filters synonyms
+    based on certain prefix constraints and organizes them by predicates.
+
+    :param jsonloutputfile: File path to write the output in JSON Lines format.
+    :type jsonloutputfile: str
+    :param prefix_synonyms_files_to_generate: A list of synonyms files to generate for certain prefixes.
+    :type prefix_synonyms_files_to_generate: list[str]
+    :return: None
+    """
+    # Load all the synonyms from UberGraph.
     uber = UberGraph()
     synonyms = uber.get_all_synonyms()
     ldict = defaultdict(dict)
@@ -60,6 +108,7 @@ def pull_uber_synonyms(jsonloutputfile):
             ldict[curie][predicate] = []
         ldict[curie][predicate].append(synonym)
 
+    # Write all the synonyms into a common synonym file.
     with open(jsonloutputfile, 'w') as outf:
         for curie in ldict.keys():
             try:
@@ -71,6 +120,17 @@ def pull_uber_synonyms(jsonloutputfile):
                 for predicate in ldict[curie].keys():
                     for synonym in ldict[curie][predicate]:
                         outf.write(json.dumps({'curie': curie, 'predicate': predicate, 'synonym': synonym}) + '\n')
+
+    # Create directories and synonyms files for some synonyms.
+    for prefix_synonyms_file in prefix_synonyms_files_to_generate:
+        prefix_dir = Path(prefix_synonyms_file).parent
+        prefix = prefix_dir.name
+        os.makedirs(prefix_dir, exist_ok=True)
+        with open(prefix_synonyms_file, 'w') as outf:
+            if prefix not in ldict:
+                raise ValueError(f'Prefix {prefix} not found in UberGraph download.')
+            for unit in ldict[prefix]:
+                outf.write(f'{unit[0]}\t{unit[1]}\n')
 
 def pull_uber(expected_ontologies, icrdf_filename):
     pull_uber_icRDF(icrdf_filename)

--- a/src/datahandlers/obo.py
+++ b/src/datahandlers/obo.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from pathlib import Path
 
 from src.ubergraph import UberGraph
@@ -61,7 +62,7 @@ def pull_uber_labels(outputfile, prefix_labels_files_to_generate):
         prefix = prefix_dir.name
         os.makedirs(prefix_dir, exist_ok=True)
         if prefix not in ldict:
-            raise ValueError(f'Prefix {prefix} not found in UberGraph download.')
+            raise ValueError(f'Prefix {prefix} not found in UberGraph labels download.')
         with open(prefix_labels_file, 'w') as outf:
             for unit in ldict[prefix]:
                 outf.write(f'{unit[0]}\t{unit[1]}\n')
@@ -128,7 +129,8 @@ def pull_uber_synonyms(jsonloutputfile, prefix_synonyms_files_to_generate):
         os.makedirs(prefix_dir, exist_ok=True)
         with open(prefix_synonyms_file, 'w') as outf:
             if prefix not in ldict:
-                raise ValueError(f'Prefix {prefix} not found in UberGraph download.')
+                logging.warning(f'Prefix {prefix} not found in UberGraph synonyms download.')
+                outf.write('')
             for unit in ldict[prefix]:
                 outf.write(f'{unit[0]}\t{unit[1]}\n')
 

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -1,3 +1,5 @@
+from snakemake.linting.links import params
+
 import src.node as node
 import src.datahandlers.mesh as mesh
 import src.datahandlers.clo as clo
@@ -183,15 +185,33 @@ rule get_umls_labels_and_synonyms:
 
 rule get_obo_labels:
     output:
-        obo_labels=config['download_directory']+'/common/ubergraph/labels'
+        obo_labels=config['download_directory']+'/common/ubergraph/labels',
+
+        # A bunch of files depend on UberGraph labels being created in prefix directories (e.g. babel_downloads/GO/labels),
+        # but these are now only included in the common labels file (i.e. babel_downloads/common/ubergraph/labels).
+        # However, since they are needed to make Snakemake work, we'll generate these here.
+        generated_labels = expand(
+            "{download_directory}/{prefix}/labels",
+            download_directory=config['download_directory'],
+            prefix=config['generate_dirs_for_labels_and_synonyms_prefixes']
+        ),
     run:
-        obo.pull_uber_labels(output.obo_labels)
+        obo.pull_uber_labels(output.obo_labels, output.generated_labels, output.generated_labels)
 
 rule get_obo_synonyms:
     output:
-        obo_synonyms=config['download_directory']+'/common/ubergraph/synonyms.jsonl'
+        obo_synonyms=config['download_directory']+'/common/ubergraph/synonyms.jsonl',
+
+        # A bunch of files depend on UberGraph labels being created in prefix directories (e.g. babel_downloads/GO/labels),
+        # but these are now only included in the common labels file (i.e. babel_downloads/common/ubergraph/labels).
+        # However, since they are needed to make Snakemake work, we'll generate these here.
+        generated_synonyms = expand(
+            "{download_directory}/{prefix}/synonyms",
+            download_directory=config['download_directory'],
+            prefix=config['generate_dirs_for_labels_and_synonyms_prefixes']
+        ),
     run:
-        obo.pull_uber_synonyms(output.obo_synonyms)
+        obo.pull_uber_synonyms(output.obo_synonyms, output.generated_synonyms)
 
 rule get_obo_descriptions:
     output:

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -196,7 +196,7 @@ rule get_obo_labels:
             prefix=config['generate_dirs_for_labels_and_synonyms_prefixes']
         ),
     run:
-        obo.pull_uber_labels(output.obo_labels, output.generated_labels, output.generated_labels)
+        obo.pull_uber_labels(output.obo_labels, output.generated_labels)
 
 rule get_obo_synonyms:
     output:

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -1,5 +1,3 @@
-from snakemake.linting.links import params
-
 import src.node as node
 import src.datahandlers.mesh as mesh
 import src.datahandlers.clo as clo
@@ -35,8 +33,6 @@ import src.datahandlers.pantherfamily as pantherfamily
 import src.datahandlers.complexportal as complexportal
 import src.datahandlers.drugbank as drugbank
 from src.babel_utils import pull_via_wget
-
-import src.prefixes as prefixes
 
 #####
 #

--- a/src/ubergraph.py
+++ b/src/ubergraph.py
@@ -1,3 +1,5 @@
+import logging
+
 from src.triplestore import TripleStore
 from src.util import Text
 from collections import defaultdict
@@ -64,7 +66,7 @@ class UberGraph:
                 try:
                     y['iri'] = Text.opt_to_curie(x['thing'])
                 except ValueError as verr:
-                    print(f"WARNING: Unable to translate {x['thing']} to a CURIE; it will be used as-is: {verr}")
+                    logging.warning(f"WARNING: Unable to translate {x['thing']} to a CURIE; it will be used as-is: {verr}")
                     y['iri'] = x['thing']
                 y['label'] = x['label']
                 results.append(y)


### PR DESCRIPTION
We now store all UberGraph labels and synonyms in a single location (`${babel_downloads}/common/ubergraph/(labels|synonyms).jsonl`). However, a bunch of Snakemake steps require the label/synonym files to be generated in the correct places (e.g. `UBERON/labels`, `UBERON/synonyms`) -- AS LONG AS there are no other methods generating these files, it should be safe to do this. This PR adds a configuration option to provide a list of prefixes that we should do this for, and the appropriate code to do this.