### PR TITLE
Fixed bug in Snakemake file: dir() -> directory()

### DIFF
--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -257,7 +257,7 @@ rule get_ncbigene_labels_synonyms_and_taxa:
 
 rule get_ensembl:
     output:
-        ensembl_dir=dir(config['download_directory']+'/ENSEMBL'),
+        ensembl_dir=directory(config['download_directory']+'/ENSEMBL'),
         complete_file=config['download_directory']+'/ENSEMBL/BioMartDownloadComplete'
     run:
         ensembl.pull_ensembl(output.ensembl_dir, output.complete_file)


### PR DESCRIPTION
This PR fixes a bug in datacollect.snakemake: I used `dir()` (the Python function) instead of `directory()` (the Snakemake function) that I intended to do.