### PR TITLE
Setting PubChem Input encoding to ISO-8859-1

### DIFF
--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -380,7 +380,7 @@ def make_pubchem_mesh_concord(pubcheminput,meshlabels,outfile):
     # first mapping is the 'best' i.e. the one most frequently reported.
     # We will only use the first one
     used_pubchem = set()
-    with open(pubcheminput,'r', encoding='ISO-8859') as inf, open(outfile,'w') as outf:
+    with open(pubcheminput,'r', encoding='ISO-8859-1') as inf, open(outfile,'w') as outf:
         for line in inf:
             x = line.strip().split('\t') # x[0] = puchemid (no prefix), x[1] = mesh label
             if x[0] in used_pubchem:


### PR DESCRIPTION
This was indicated by `file` and by an encoding error we ran into loading this file:

> UnicodeDecodeError in file "/code/babel/src/snakefiles/chemical.snakefile", line 173:
> 'utf-8' codec can't decode byte 0xe8 in position 2252: invalid continuation byte
>   File "/code/babel/src/snakefiles/chemical.snakefile", line 173, in __rule_get_chemical_pubchem_mesh_concord
>   File "/code/babel/src/createcompendia/chemicals.py", line 397, in make_pubchem_mesh_concord
>   File "<frozen codecs>", line 322, in decode

I've just confirmed this with [`chardetect`](https://pypi.org/project/chardet/):

```
$ chardetect babel_downloads/PUBCHEM.COMPOUND/CID-MeSH
babel_downloads/PUBCHEM.COMPOUND/CID-MeSH: ISO-8859-1 with confidence 0.73
```

There appear to be 18 lines with malformed UTF-8 encoded text.