### PR TITLE
Debug protein compendium slowdown

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -92,7 +92,7 @@ pronto==2.7.0
 propcache==0.3.1
 psutil==7.0.0
 psycopg2-binary==2.9.10
-PuLP==3.1.1
+PuLP==2.7.0
 pydantic==2.11.4
 pydantic_core==2.33.2
 PyJSG==0.11.10
@@ -128,7 +128,7 @@ ShExJSG==0.8.2
 six==1.17.0
 smart-open==7.1.0
 smmap==5.0.2
-snakemake==9.3.3
+snakemake==7.32.4
 snakemake-interface-common==1.17.4
 snakemake-interface-executor-plugins==9.3.5
 snakemake-interface-logger-plugins==1.2.3
@@ -142,10 +142,12 @@ SQLAlchemy==2.0.40
 SQLAlchemy-Utils==0.38.3
 sssom==0.4.15
 sssom-schema==1.0.0
+stopit==1.1.2
 stringcase==1.2.0
 tabulate==0.9.0
 tenacity==8.5.0
 throttler==1.2.2
+toposort==1.10
 tqdm==4.67.1
 traitlets==5.14.3
 types-python-dateutil==2.9.0.20241206

--- a/requirements.lock
+++ b/requirements.lock
@@ -93,6 +93,7 @@ propcache==0.3.1
 psutil==7.0.0
 psycopg2-binary==2.9.10
 PuLP==2.7.0
+py-spy==0.4.1
 pydantic==2.11.4
 pydantic_core==2.33.2
 PyJSG==0.11.10
@@ -128,11 +129,12 @@ ShExJSG==0.8.2
 six==1.17.0
 smart-open==7.1.0
 smmap==5.0.2
-snakemake==7.32.4
-snakemake-interface-common==1.17.4
+snakemake==9.10.0
+snakemake-interface-common==1.21.0
 snakemake-interface-executor-plugins==9.3.5
 snakemake-interface-logger-plugins==1.2.3
 snakemake-interface-report-plugins==1.1.0
+snakemake-interface-scheduler-plugins==2.0.0
 snakemake-interface-storage-plugins==4.2.1
 sortedcontainers==2.4.0
 soupsieve==2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,7 @@ pytest-cov
 python-Levenshtein-wheels
 pyyaml
 requests
-PuLP==2.7.0
-snakemake==7.32.4
+snakemake
 sparqlwrapper
 # Added by Gaurav, Jan 2022
 xmltodict

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,4 @@ git+https://github.com/gaurav/apybiomart.git@change-check-url
 
 # Added by Gaurav, Aug 2025 to check for memory information while Babel is running.
 psutil
+humanfriendly

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,6 @@ duckdb
 # on checking if it's online via http://httpstat.us/200, which is often offline. My branch of this
 # https://github.com/gaurav/apybiomart/tree/change-check-url and changes that to https://example.org.
 git+https://github.com/gaurav/apybiomart.git@change-check-url
+
+# Added by Gaurav, Aug 2025 to check for memory information while Babel is running.
+psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,4 @@ git+https://github.com/gaurav/apybiomart.git@change-check-url
 # Added by Gaurav, Aug 2025 to check for memory information while Babel is running.
 psutil
 humanfriendly
+py-spy

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -430,7 +430,9 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
                                 property_source_count[source] += 1
 
             node = node_factory.create_node(input_identifiers=slist, node_type=node_type,labels = labels, extra_prefixes = extra_prefixes)
-            if node is not None:
+            if node is None:
+                raise RuntimeError(f"Could not create node for ({slist}, {node_type}, {labels}, {extra_prefixes}): returned None.")
+            else:
                 count_cliques += 1
                 count_eq_ids += len(slist)
 

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -371,7 +371,7 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
     :param properties_files: (OPTIONAL) A list of SQLite3 files containing properties to be added to the output.
     :return:
     """
-    logging.info(f"Starting write_compendium({metadata_yamls}, {synonym_list}, {ofname}, {node_type}, {labels}, {extra_prefixes}, {icrdf_filename}, {properties_jsonl_gz_files})")
+    logging.info(f"Starting write_compendium({metadata_yamls}, {len(synonym_list)} slists, {ofname}, {node_type}, {len(labels)} labels, {extra_prefixes}, {icrdf_filename}, {properties_jsonl_gz_files})")
     logging.info(f" - Memory usage: {get_memory_usage_summary()}")
 
     if extra_prefixes is None:

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -13,6 +13,7 @@ import os
 import urllib
 import jsonlines
 import yaml
+from humanfriendly import format_timespan
 
 from src.metadata.provenance import write_combined_metadata
 from src.node import NodeFactory, SynonymFactory, DescriptionFactory, InformationContentFactory, TaxonFactory
@@ -437,6 +438,7 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
                 hours, remainder = divmod(time_remaining_seconds, 3600)
                 minutes, seconds = divmod(remainder, 60)
                 logging.info(f" - Estimated time remaining: {time_remaining_seconds:.2f} seconds ({hours:} hours, {minutes:02} minutes, {seconds:02} seconds)")
+                logging.info(f" - Estimated time remaining: {format_timespan(time_remaining_seconds)}")
 
             # At this point, we insert any HAS_ADDITIONAL_ID properties we have.
             # The logic we use is: we insert all additional IDs for a CURIE *AFTER* that CURIE, in a random order, as long

--- a/src/createcompendia/protein.py
+++ b/src/createcompendia/protein.py
@@ -173,7 +173,7 @@ def build_protein_compendia(concordances, metadata_yamls, identifiers, icrdf_fil
         pairs = []
         with open(infile, 'r') as inf:
             for line_index, line in enumerate(inf):
-                if line_index % 100000 == 0:
+                if line_index % 1000000 == 0:
                     logging.info(f"Loading concordance file {infile}: line {line_index:,}")
                 x = line.strip().split('\t')
                 pairs.append(set([x[0], x[2]]))

--- a/src/node.py
+++ b/src/node.py
@@ -456,7 +456,7 @@ class NodeFactory:
                 print(type(i))
                 print(Text.get_curie(i))
                 print(Text.get_curie(i).upper())
-            raise ValueError('something very bad')
+            raise RuntimeError('something very bad')
         identifiers = []
         accepted_ids = set()
         #Converting identifiers from LabeledID to dicts
@@ -489,19 +489,10 @@ class NodeFactory:
                     self.ignored_prefixes.add( (k,node_type) )
         if len(identifiers) == 0:
             return None
-        best_id = identifiers[0]['identifier']
-        # identifiers is in preferred order, so choose the first non-empty label to be the node label
-        labels = list(filter(lambda x:len(x) > 0, [ l['label'] for l in identifiers if 'label' in l ]))
-        label = None
-        if len(labels) > 0:
-            label = labels[0]
-
         node = {
             'identifiers': identifiers,
             'type': node_type
         }
-        #if label is not None:
-        #    node['id']['label'] =  label
         return node
 
 def pubchemsort(pc_ids, labeled_ids):

--- a/src/snakefiles/chemical.snakefile
+++ b/src/snakefiles/chemical.snakefile
@@ -240,7 +240,7 @@ rule chemical_compendia:
         temp(expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['chemical_outputs'])),
         expand("{od}/metadata/{ap}.yaml", od = config['output_directory'], ap = config['chemical_outputs']),
     run:
-        chemicals.build_compendia(input.typesfile, input.untyped_file, input.properties_jsonl_gz, input.icrdf_filename)
+        chemicals.build_compendia(input.typesfile, input.untyped_file, input.properties_jsonl_gz, input.metadata_yamls, input.icrdf_filename)
 
 rule check_chemical_completeness:
     input:

--- a/src/util.py
+++ b/src/util.py
@@ -10,6 +10,7 @@ import copy
 from logging.handlers import RotatingFileHandler
 
 from bmt import Toolkit
+from humanfriendly import format_size
 
 from src.LabeledID import LabeledID
 from src.prefixes import OMIM, OMIMPS, UMLS, SNOMEDCT, KEGGPATHWAY, KEGGREACTION, NCIT, ICD10, ICD10CM, ICD11FOUNDATION
@@ -342,4 +343,4 @@ def get_memory_usage_summary():
     process.memory_percent()
     mem_info = process.memory_info()
 
-    return f"Using {process.memory_percent():.2f}% of available memory (RSS: {mem_info.rss / 1024 ** 3:.2f} GB, VMS: {mem_info.vms / 1024 ** 3:.2f} GB)"
+    return f"Using {process.memory_percent():.2f}% of available memory (RSS: {format_size(mem_info.rss, binary=True)}, VMS: {format_size(mem_info.vms, binary=True)})"

--- a/src/util.py
+++ b/src/util.py
@@ -4,6 +4,7 @@ import os
 
 import curies
 import yaml
+import psutil
 from collections import namedtuple
 import copy
 from logging.handlers import RotatingFileHandler
@@ -72,7 +73,7 @@ class Munge(object):
     @staticmethod
     def gene (gene):
         return gene.split ("/")[-1:][0] if gene.startswith ("http://") else gene
-    
+
 class Text:
     """ Utilities for processing text. """
     prefixmap = { x.lower(): x for k,x in vars(prefixes).items() if not k.startswith("__")}
@@ -114,7 +115,7 @@ class Text:
     @staticmethod
     def un_curie (text):
         return ':'.join(text.split (':', 1)[1:]) if ':' in text else text
-        
+
     @staticmethod
     def short (obj, limit=80):
         text = str(obj) if obj else None
@@ -171,7 +172,7 @@ class Text:
             return Text.recurie(r)
         else:
             raise ValueError(f"Unable to opt_to_curie({text}): output calculated as {r}, which has no colon.")
-        
+
         return r
 
     @staticmethod
@@ -217,7 +218,7 @@ class Resource:
         with open (path, 'r') as stream:
             result = yaml.load (stream.read ())
         return result
-    
+
     def get_resource_obj (resource_name, format='json'):
         result = None
         path = Resource.get_resource_path (resource_name)
@@ -330,3 +331,15 @@ def get_biolink_prefix_map():
             f'https://raw.githubusercontent.com/biolink/biolink-model/v' + biolink_version +
             '/project/prefixmap/biolink_model_prefix_map.json'
         )
+
+def get_memory_usage_summary():
+    """
+    Provide a short summary of current memory usage to write into logs.
+
+    :return: A string summarizing current memory usage.
+    """
+    process = psutil.Process()
+    process.memory_percent()
+    mem_info = process.memory_info()
+
+    return f"Using {process.memory_percent():.2f}% of available memory (RSS: {mem_info.rss / 1024 ** 2:.2f} MB, VMS: {mem_info.vms / 1024 ** 2:.2f} MB)"

--- a/src/util.py
+++ b/src/util.py
@@ -342,4 +342,4 @@ def get_memory_usage_summary():
     process.memory_percent()
     mem_info = process.memory_info()
 
-    return f"Using {process.memory_percent():.2f}% of available memory (RSS: {mem_info.rss / 1024 ** 2:.2f} MB, VMS: {mem_info.vms / 1024 ** 2:.2f} MB)"
+    return f"Using {process.memory_percent():.2f}% of available memory (RSS: {mem_info.rss / 1024 ** 3:.2f} GB, VMS: {mem_info.vms / 1024 ** 3:.2f} GB)"


### PR DESCRIPTION
The protein compendia was taking an impossibly long time to run because we've hit our memory limit on Sterling. This PR is intended to help debug that by making two changes:
1. It adds a `get_memory_usage_summary()` function that returns a string summarizing the current memory usage. This isn't perfect -- it returns the node-level memory usage, so the percentage isn't relative to our maximum available memory for our Kubernetes pod. But that still tells us how close we are to running out of memory.
    * A bonus goal would be to someday use regexes to find all the memory usage reports throughout the run process so we know how it varies.
2. It adds a bit of code to `write_compendium()` so that it provides clique production rate/time elapsed/remaining time estimated every 1M cliques it produces. That way, we can see how it compares with the expected rate (~9000 cliques/sec).
3. It adds `py-spy` to requirements.txt. This [very useful program](https://github.com/benfred/py-spy) allows top-like tracking of a running Python program using only its PID.

We incidentally upgrade Snakemake to 9.10.0 (although that happened after the run finished).