### PR TITLE
Slowdown fix and improved logging

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -20,6 +20,11 @@ include: "src/snakefiles/duckdb.snakefile"
 include: "src/snakefiles/reports.snakefile"
 include: "src/snakefiles/exports.snakefile"
 
+# Some global settings.
+import os
+os.environ['TMPDIR'] = config['tmp_directory']
+
+# Top-level rules.
 rule all:
     input:
         # See rule all_outputs later in this file for how we generate all the outputs.

--- a/config.yaml
+++ b/config.yaml
@@ -3,6 +3,7 @@ input_directory: input_data
 download_directory: babel_downloads
 intermediate_directory: babel_outputs/intermediate
 output_directory: babel_outputs
+tmp_directory: babel_downloads/tmp
 
 # Versions that need to be updated on every release.
 biolink_version: "4.2.6-rc5"

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,4 @@ git+https://github.com/gaurav/apybiomart.git@change-check-url
 # Added by Gaurav, Aug 2025 to check for memory information while Babel is running.
 psutil
 humanfriendly
+py-spy

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -625,7 +625,7 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
                     print(node["type"])
                     print(node_factory.get_ancestors(node["type"]))
                     traceback.print_exc()
-                    exit()
+                    raise ex
 
     # Write out the metadata.yaml file combining information from all the metadata.yaml files.
     write_combined_metadata(

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -448,7 +448,7 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
                 # count_slist --> time_elapsed_seconds
                 # remaining_slist --> remaining_slist/count_slit*time_elapsed_seconds
                 logger.info(f"Generating compendia and synonyms for {ofname} currently at {count_slist:,} out of {total_slist:,} ({count_slist/total_slist*100:.2f}%) in {format_timespan(time_elapsed_seconds)}: {get_memory_usage_summary()}")
-                logger.info(f" - Current rate: {count_slist/time_elapsed_seconds:.2f} cliques/second or {time_elapsed_seconds/count_slist:.4f} seconds/clique.")
+                logger.info(f" - Current rate: {count_slist/time_elapsed_seconds:.2f} cliques/second or {time_elapsed_seconds/count_slist:.6f} seconds/clique.")
 
                 time_remaining_seconds = (time_elapsed_seconds / count_slist * remaining_slist)
                 logger.info(f" - Estimated time remaining: {format_timespan(time_remaining_seconds)}")

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -428,7 +428,7 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
         for slist in synonym_list:
             # Before we get started, let's estimate where we're at.
             count_slist += 1
-            if count_slist % 1000000 == 0:
+            if count_slist % 100000 == 0:
                 time_elapsed_seconds = (time.time_ns() - start_time) / 1E9
                 remaining_slist = total_slist - count_slist
                 # count_slist --> time_elapsed_seconds

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -447,7 +447,7 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
                 remaining_slist = total_slist - count_slist
                 # count_slist --> time_elapsed_seconds
                 # remaining_slist --> remaining_slist/count_slit*time_elapsed_seconds
-                logger.info(f"Generating compendia and synonyms for {ofname} currently at {count_slist:,} out of {total_slist:,} ({count_slist/total_slist*100:.2f}%): {get_memory_usage_summary()}")
+                logger.info(f"Generating compendia and synonyms for {ofname} currently at {count_slist:,} out of {total_slist:,} ({count_slist/total_slist*100:.2f}%) in {format_timespan(time_elapsed_seconds)}: {get_memory_usage_summary()}")
                 logger.info(f" - Current rate: {count_slist/time_elapsed_seconds:.2f} cliques/second or {time_elapsed_seconds/count_slist:.4f} seconds/clique.")
 
                 time_remaining_seconds = (time_elapsed_seconds / count_slist * remaining_slist)

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -433,7 +433,7 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
                 remaining_slist = total_slist - count_slist
                 # count_slist --> time_elapsed_seconds
                 # remaining_slist --> remaining_slist/count_slit*time_elapsed_seconds
-                logger.info(f"Generated compendia and synonyms for {count_slist:,} out of {total_slist:,} ({count_slist/total_slist*100:.2f}%).")
+                logger.info(f"Generating compendia and synonyms for {ofname} currently at {count_slist:,} out of {total_slist:,} ({count_slist/total_slist*100:.2f}%).")
                 logger.info(f" - Current rate: {count_slist/time_elapsed_seconds:.2f} cliques/second or {time_elapsed_seconds/count_slist:.2f} seconds/clique.")
 
                 time_remaining_seconds = (time_elapsed_seconds / count_slist * remaining_slist)

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -448,7 +448,7 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
                 # count_slist --> time_elapsed_seconds
                 # remaining_slist --> remaining_slist/count_slit*time_elapsed_seconds
                 logger.info(f"Generating compendia and synonyms for {ofname} currently at {count_slist:,} out of {total_slist:,} ({count_slist/total_slist*100:.2f}%): {get_memory_usage_summary()}")
-                logger.info(f" - Current rate: {count_slist/time_elapsed_seconds:.2f} cliques/second or {time_elapsed_seconds/count_slist:.2f} seconds/clique.")
+                logger.info(f" - Current rate: {count_slist/time_elapsed_seconds:.2f} cliques/second or {time_elapsed_seconds/count_slist:.4f} seconds/clique.")
 
                 time_remaining_seconds = (time_elapsed_seconds / count_slist * remaining_slist)
                 logger.info(f" - Estimated time remaining: {format_timespan(time_remaining_seconds)}")

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -451,9 +451,6 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
                 logger.info(f" - Current rate: {count_slist/time_elapsed_seconds:.2f} cliques/second or {time_elapsed_seconds/count_slist:.2f} seconds/clique.")
 
                 time_remaining_seconds = (time_elapsed_seconds / count_slist * remaining_slist)
-                hours, remainder = divmod(time_remaining_seconds, 3600)
-                minutes, seconds = divmod(remainder, 60)
-                logger.info(f" - Estimated time remaining: {time_remaining_seconds:.2f} seconds ({hours:} hours, {minutes:02} minutes, {seconds:02} seconds)")
                 logger.info(f" - Estimated time remaining: {format_timespan(time_remaining_seconds)}")
 
             # At this point, we insert any HAS_ADDITIONAL_ID properties we have.

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -1,4 +1,3 @@
-import logging
 import subprocess
 import traceback
 from enum import Enum
@@ -18,11 +17,14 @@ from humanfriendly import format_timespan
 from src.metadata.provenance import write_combined_metadata
 from src.node import NodeFactory, SynonymFactory, DescriptionFactory, InformationContentFactory, TaxonFactory
 from src.properties import PropertyList, HAS_ADDITIONAL_ID
-from src.util import Text, get_config, get_memory_usage_summary
+from src.util import Text, get_config, get_memory_usage_summary, get_logger
 from src.LabeledID import LabeledID
 from collections import defaultdict
 import sqlite3
 from typing import List, Tuple
+
+# Set up logger.
+logger = get_logger()
 
 def make_local_name(fname,subpath=None):
     config = get_config()
@@ -284,7 +286,7 @@ def pull_via_wget(
             wget_command_line.extend(['--recursive', '--no-parent', '--no-directories', '--level=1', '--directory-prefix=' + dl_file_name])
 
     # Execute wget.
-    logging.info(f"Downloading {dl_file_name} using wget: {wget_command_line}")
+    logger.info(f"Downloading {dl_file_name} using wget: {wget_command_line}")
     process = subprocess.run(wget_command_line)
     if process.returncode != 0:
         raise RuntimeError(f"Could not execute wget {wget_command_line}: {process.stderr}")
@@ -302,17 +304,17 @@ def pull_via_wget(
 
         if os.path.isfile(uncompressed_filename):
             file_size = os.path.getsize(uncompressed_filename)
-            logging.info(f"Downloaded {uncompressed_filename} from {url}, file size {file_size} bytes.")
+            logger.info(f"Downloaded {uncompressed_filename} from {url}, file size {file_size} bytes.")
         else:
             raise RuntimeError(f'Expected uncompressed file {uncompressed_filename} does not exist.')
     else:
         if os.path.isfile(dl_file_name):
             file_size = os.path.getsize(dl_file_name)
-            logging.info(f"Downloaded {dl_file_name} from {url}, file size {file_size} bytes.")
+            logger.info(f"Downloaded {dl_file_name} from {url}, file size {file_size} bytes.")
         elif os.path.isdir(dl_file_name):
             # Count the number of files in directory dl_file_name
             dir_size = sum(os.path.getsize(os.path.join(dl_file_name, f)) for f in os.listdir(dl_file_name) if os.path.isfile(os.path.join(dl_file_name, f)))
-            logging.info(f"Downloaded {dir_size} files from {url} to {dl_file_name}.")
+            logger.info(f"Downloaded {dir_size} files from {url} to {dl_file_name}.")
         else:
             raise RuntimeError(f'Unknown file type {dl_file_name}')
 
@@ -372,8 +374,8 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
     :param properties_files: (OPTIONAL) A list of SQLite3 files containing properties to be added to the output.
     :return:
     """
-    logging.info(f"Starting write_compendium({metadata_yamls}, {len(synonym_list)} slists, {ofname}, {node_type}, {len(labels)} labels, {extra_prefixes}, {icrdf_filename}, {properties_jsonl_gz_files})")
-    logging.info(f" - Memory usage: {get_memory_usage_summary()}")
+    logger.info(f"Starting write_compendium({metadata_yamls}, {len(synonym_list)} slists, {ofname}, {node_type}, {len(labels)} labels, {extra_prefixes}, {icrdf_filename}, {properties_jsonl_gz_files})")
+    logger.info(f" - Memory usage: {get_memory_usage_summary()}")
 
     if extra_prefixes is None:
         extra_prefixes = []
@@ -431,14 +433,14 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
                 remaining_slist = total_slist - count_slist
                 # count_slist --> time_elapsed_seconds
                 # remaining_slist --> remaining_slist/count_slit*time_elapsed_seconds
-                logging.info(f"Generated compendia and synonyms for {count_slist:,} out of {total_slist:,} ({count_slist/total_slist*100:.2f}%).")
-                logging.info(f" - Current rate: {count_slist/time_elapsed_seconds:.2f} cliques/second or {time_elapsed_seconds/count_slist:.2f} seconds/clique.")
+                logger.info(f"Generated compendia and synonyms for {count_slist:,} out of {total_slist:,} ({count_slist/total_slist*100:.2f}%).")
+                logger.info(f" - Current rate: {count_slist/time_elapsed_seconds:.2f} cliques/second or {time_elapsed_seconds/count_slist:.2f} seconds/clique.")
 
                 time_remaining_seconds = (time_elapsed_seconds / count_slist * remaining_slist)
                 hours, remainder = divmod(time_remaining_seconds, 3600)
                 minutes, seconds = divmod(remainder, 60)
-                logging.info(f" - Estimated time remaining: {time_remaining_seconds:.2f} seconds ({hours:} hours, {minutes:02} minutes, {seconds:02} seconds)")
-                logging.info(f" - Estimated time remaining: {format_timespan(time_remaining_seconds)}")
+                logger.info(f" - Estimated time remaining: {time_remaining_seconds:.2f} seconds ({hours:} hours, {minutes:02} minutes, {seconds:02} seconds)")
+                logger.info(f" - Estimated time remaining: {format_timespan(time_remaining_seconds)}")
 
             # At this point, we insert any HAS_ADDITIONAL_ID properties we have.
             # The logic we use is: we insert all additional IDs for a CURIE *AFTER* that CURIE, in a random order, as long
@@ -571,7 +573,7 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
                     if preferred_name:
                         document["preferred_name"] = preferred_name
                     else:
-                        logging.debug(
+                        logger.debug(
                             f"No preferred name for {node}, probably because all names were filtered out, skipping."
                         )
                         continue
@@ -584,7 +586,7 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
 
                     # Since synonyms_list is sorted, we can use the length of the first term as the synonym.
                     if len(synonyms_list) == 0:
-                        logging.debug(f"Synonym list for {node} is empty: no valid name. Skipping.")
+                        logger.debug(f"Synonym list for {node} is empty: no valid name. Skipping.")
                         continue
                     else:
                         document["shortest_name_length"] = len(synonyms_list[0])

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -23,6 +23,9 @@ from collections import defaultdict
 import sqlite3
 from typing import List, Tuple
 
+# Configuration items
+WRITE_COMPENDIUM_LOG_EVERY_X_CLIQUES = 1_000_000
+
 # Set up a logger.
 logger = get_logger(__name__)
 
@@ -439,7 +442,7 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
         for slist in synonym_list:
             # Before we get started, let's estimate where we're at.
             count_slist += 1
-            if (count_slist == 1) or (count_slist % 100000 == 0):
+            if (count_slist == 1) or (count_slist % WRITE_COMPENDIUM_LOG_EVERY_X_CLIQUES == 0):
                 time_elapsed_seconds = (time.time_ns() - start_time) / 1E9
                 if time_elapsed_seconds < 0.001:
                     # We don't want to divide by zero.

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -447,7 +447,7 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
                 remaining_slist = total_slist - count_slist
                 # count_slist --> time_elapsed_seconds
                 # remaining_slist --> remaining_slist/count_slit*time_elapsed_seconds
-                logger.info(f"Generating compendia and synonyms for {ofname} currently at {count_slist:,} out of {total_slist:,} ({count_slist/total_slist*100:.2f}%).")
+                logger.info(f"Generating compendia and synonyms for {ofname} currently at {count_slist:,} out of {total_slist:,} ({count_slist/total_slist*100:.2f}%): {get_memory_usage_summary()}")
                 logger.info(f" - Current rate: {count_slist/time_elapsed_seconds:.2f} cliques/second or {time_elapsed_seconds/count_slist:.2f} seconds/clique.")
 
                 time_remaining_seconds = (time_elapsed_seconds / count_slist * remaining_slist)

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -422,7 +422,7 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
     with jsonlines.open(os.path.join(cdir,'compendia',ofname),'w') as outf, jsonlines.open(os.path.join(cdir,'synonyms',ofname),'w') as sfile:
         # Calculate an estimated time to completion.
         start_time = time.time_ns()
-        count_slist = 0
+        count_slist = -1 # So that we display one when we start.
         total_slist = len(synonym_list)
 
         for slist in synonym_list:
@@ -430,6 +430,9 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
             count_slist += 1
             if count_slist % 100000 == 0:
                 time_elapsed_seconds = (time.time_ns() - start_time) / 1E9
+                if time_elapsed_seconds < 0.001:
+                    # We don't want to divide by zero.
+                    time_elapsed_seconds = 0.001
                 remaining_slist = total_slist - count_slist
                 # count_slist --> time_elapsed_seconds
                 # remaining_slist --> remaining_slist/count_slit*time_elapsed_seconds

--- a/src/createcompendia/protein.py
+++ b/src/createcompendia/protein.py
@@ -13,7 +13,7 @@ from src.babel_utils import read_identifier_file,glom,write_compendium,Text
 import os
 from src.util import get_memory_usage_summary, get_logger
 
-logger = get_logger()
+logger = get_logger(__name__)
 
 
 def extract_taxon_ids_from_uniprotkb(idmapping_filename, uniprotkb_taxa_filename):
@@ -162,7 +162,7 @@ def build_protein_compendia(concordances, metadata_yamls, identifiers, icrdf_fil
         new_identifiers, new_types = read_identifier_file(ifile)
         glom(dicts, new_identifiers, unique_prefixes= uniques)
         types.update(new_types)
-        logger.info(f"Loaded identifier file {ifile}")
+        logger.info(f"Loaded identifier file {ifile}: {get_memory_usage_summary()}")
     logger.info(f"Finished loading identifiers, memory usage: {get_memory_usage_summary()}")
     for infile in concordances:
         logger.info(f"Loading concordance file {infile}")
@@ -175,7 +175,7 @@ def build_protein_compendia(concordances, metadata_yamls, identifiers, icrdf_fil
                 pairs.append(set([x[0], x[2]]))
         # print("glomming", infile) # This takes a while, but doesn't add much to the memory
         glom(dicts, pairs, unique_prefixes=uniques)
-        logger.info(f"Loaded concordance file {infile}")
+        logger.info(f"Loaded concordance file {infile}: {get_memory_usage_summary()}")
     logger.info(f"Finished loading concordances, memory usage: {get_memory_usage_summary()}")
     logger.info(f"Building gene sets")
     gene_sets = set([frozenset(x) for x in dicts.values()])

--- a/src/createcompendia/protein.py
+++ b/src/createcompendia/protein.py
@@ -11,13 +11,9 @@ from src.ubergraph import UberGraph
 from src.babel_utils import read_identifier_file,glom,write_compendium,Text
 
 import os
-import json
-import gzip
+from src.util import get_memory_usage_summary, get_logger
 
-import logging
-from src.util import LoggingUtil, get_memory_usage_summary
-
-logger = LoggingUtil.init_logging(__name__, level=logging.WARNING)
+logger = get_logger()
 
 
 def extract_taxon_ids_from_uniprotkb(idmapping_filename, uniprotkb_taxa_filename):
@@ -160,30 +156,30 @@ def build_protein_compendia(concordances, metadata_yamls, identifiers, icrdf_fil
     dicts = {}
     types = {}
     uniques = [UNIPROTKB,PR]
-    logging.info(f"Started building protein comendium ({concordances}, {metadata_yamls}, {identifiers}, {icrdf_filename}) with uniques {uniques}")
+    logger.info(f"Started building protein compendia ({concordances}, {metadata_yamls}, {identifiers}, {icrdf_filename}) with uniques {uniques}")
     for ifile in identifiers:
-        logging.info(f"Loading identifier file {ifile}")
+        logger.info(f"Loading identifier file {ifile}")
         new_identifiers, new_types = read_identifier_file(ifile)
         glom(dicts, new_identifiers, unique_prefixes= uniques)
         types.update(new_types)
-        logging.info(f"Loaded identifier file {ifile}")
-    logging.info(f"Finished loading identifiers, memory usage: {get_memory_usage_summary()}")
+        logger.info(f"Loaded identifier file {ifile}")
+    logger.info(f"Finished loading identifiers, memory usage: {get_memory_usage_summary()}")
     for infile in concordances:
-        logging.info(f"Loading concordance file {infile}")
+        logger.info(f"Loading concordance file {infile}")
         pairs = []
         with open(infile, 'r') as inf:
             for line_index, line in enumerate(inf):
                 if line_index % 1000000 == 0:
-                    logging.info(f"Loading concordance file {infile}: line {line_index:,}")
+                    logger.info(f"Loading concordance file {infile}: line {line_index:,}")
                 x = line.strip().split('\t')
                 pairs.append(set([x[0], x[2]]))
         # print("glomming", infile) # This takes a while, but doesn't add much to the memory
         glom(dicts, pairs, unique_prefixes=uniques)
-        logging.info(f"Loaded concordance file {infile}")
-    logging.info(f"Finished loading concordances, memory usage: {get_memory_usage_summary()}")
-    logging.info(f"Building gene sets")
+        logger.info(f"Loaded concordance file {infile}")
+    logger.info(f"Finished loading concordances, memory usage: {get_memory_usage_summary()}")
+    logger.info(f"Building gene sets")
     gene_sets = set([frozenset(x) for x in dicts.values()])
-    logging.info(f"Gene sets built, memory usage: {get_memory_usage_summary()}")
+    logger.info(f"Gene sets built, memory usage: {get_memory_usage_summary()}")
     #Try to preserve some memory here.
     dicts.clear()
 
@@ -192,6 +188,6 @@ def build_protein_compendia(concordances, metadata_yamls, identifiers, icrdf_fil
     # only then generate the compendium from those input files.
 
     baretype = PROTEIN.split(':')[-1]
-    logging.info(f"Writing compendium for {baretype}, memory usage: {get_memory_usage_summary()}")
+    logger.info(f"Writing compendium for {baretype}, memory usage: {get_memory_usage_summary()}")
     write_compendium(metadata_yamls, gene_sets, f'{baretype}.txt', PROTEIN, {}, icrdf_filename=icrdf_filename)
-    logging.info(f"Wrote compendium for {baretype}, memory usage: {get_memory_usage_summary()}")
+    logger.info(f"Wrote compendium for {baretype}, memory usage: {get_memory_usage_summary()}")

--- a/src/node.py
+++ b/src/node.py
@@ -11,6 +11,7 @@ from src.util import (
     get_biolink_model_toolkit,
     get_biolink_prefix_map,
     get_logger,
+    get_memory_usage_summary,
 )
 from src.LabeledID import LabeledID
 from src.prefixes import PUBCHEMCOMPOUND
@@ -46,7 +47,7 @@ class SynonymFactory:
     def load_synonyms(self,prefix):
         lbs = defaultdict(set)
         labelfname = os.path.join(self.synonym_dir, prefix, 'labels')
-        logger.info(f'Loading synonyms for {prefix} from {labelfname}')
+        logger.info(f'Loading synonyms for {prefix} from {labelfname}: {get_memory_usage_summary()}')
         count_labels = 0
         count_synonyms = 0
         if os.path.exists(labelfname):
@@ -65,7 +66,7 @@ class SynonymFactory:
                     lbs[x[0]].add( (x[1], x[2]) )
                     count_synonyms += 1
         self.synonyms[prefix] = lbs
-        logger.info(f'Loaded {count_labels:,} labels and {count_synonyms:,} synonyms for {prefix} from {labelfname}')
+        logger.info(f'Loaded {count_labels:,} labels and {count_synonyms:,} synonyms for {prefix} from {labelfname}: {get_memory_usage_summary()}')
 
     def get_synonyms(self,node):
         config = get_config()
@@ -83,7 +84,7 @@ class SynonymFactory:
                         row = json.loads(line)
                         self.common_synonyms[row['curie']].add((row['predicate'], row['synonym']))
                         count_common_file_synonyms += 1
-                logger.info(f"Loaded {count_common_file_synonyms:,} common synonyms from {common_synonyms_path}")
+                logger.info(f"Loaded {count_common_file_synonyms:,} common synonyms from {common_synonyms_path}: {get_memory_usage_summary()}")
 
         node_synonyms = set()
         for ident in node['identifiers']:
@@ -160,7 +161,7 @@ class TaxonFactory:
         self.taxa = {}
 
     def load_taxa(self, prefix):
-        logger.info(f'Loading taxa for {prefix}')
+        logger.info(f'Loading taxa for {prefix}: {get_memory_usage_summary()}')
         taxa_per_prefix = defaultdict(set)
         taxafilename = os.path.join(self.root_dir, prefix, 'taxa')
         taxon_count = 0
@@ -171,7 +172,7 @@ class TaxonFactory:
                     taxa_per_prefix[x[0]].add("\t".join(x[1:]))
                     taxon_count += 1
         self.taxa[prefix] = taxa_per_prefix
-        logger.info(f'Loaded {taxon_count} taxon-CURIE mappings for {prefix}')
+        logger.info(f'Loaded {taxon_count} taxon-CURIE mappings for {prefix}: {get_memory_usage_summary()}')
 
     def get_taxa(self, node):
         node_taxa = defaultdict(set)

--- a/src/node.py
+++ b/src/node.py
@@ -16,7 +16,7 @@ from src.util import (
 from src.LabeledID import LabeledID
 from src.prefixes import PUBCHEMCOMPOUND
 
-logger = get_logger()
+logger = get_logger(__name__)
 
 class SynonymFactory:
     """

--- a/src/node.py
+++ b/src/node.py
@@ -411,7 +411,7 @@ class NodeFactory:
                                 continue
                         self.common_labels[x[0]] = x[1]
                         count_common_file_labels += 1
-                logger.info(f"Loaded {count_common_file_labels} common labels from {common_labels_path}")
+                logger.info(f"Loaded {count_common_file_labels} common labels from {common_labels_path}: {get_memory_usage_summary()}")
 
         #Originally we needed to clean up the identifer lists, because there would be both labeledids and
         # string ids and we had to reconcile them.

--- a/src/node.py
+++ b/src/node.py
@@ -1,15 +1,21 @@
 import json
-import logging
 import os
 from collections import defaultdict
 from urllib.parse import urlparse
 
 import curies
 
-from src.util import Text, get_config, get_biolink_model_toolkit, get_biolink_prefix_map
+from src.util import (
+    Text,
+    get_config,
+    get_biolink_model_toolkit,
+    get_biolink_prefix_map,
+    get_logger,
+)
 from src.LabeledID import LabeledID
 from src.prefixes import PUBCHEMCOMPOUND
 
+logger = get_logger()
 
 class SynonymFactory:
     """
@@ -35,12 +41,12 @@ class SynonymFactory:
         self.synonym_dir = syndir
         self.synonyms = {}
         self.common_synonyms = None
-        print(f"Created SynonymFactory for directory {syndir}")
+        logger.info(f"Created SynonymFactory for directory {syndir}")
 
     def load_synonyms(self,prefix):
         lbs = defaultdict(set)
         labelfname = os.path.join(self.synonym_dir, prefix, 'labels')
-        print(f'Loading synonyms for {prefix} from {labelfname}')
+        logger.info(f'Loading synonyms for {prefix} from {labelfname}')
         count_labels = 0
         count_synonyms = 0
         if os.path.exists(labelfname):
@@ -59,7 +65,7 @@ class SynonymFactory:
                     lbs[x[0]].add( (x[1], x[2]) )
                     count_synonyms += 1
         self.synonyms[prefix] = lbs
-        print(f'Loaded {count_labels} labels and {count_synonyms} synonyms for {prefix} from {labelfname}')
+        logger.info(f'Loaded {count_labels:,} labels and {count_synonyms:,} synonyms for {prefix} from {labelfname}')
 
     def get_synonyms(self,node):
         config = get_config()
@@ -77,7 +83,7 @@ class SynonymFactory:
                         row = json.loads(line)
                         self.common_synonyms[row['curie']].add((row['predicate'], row['synonym']))
                         count_common_file_synonyms += 1
-                logging.info(f"Loaded {count_common_file_synonyms} common synonyms from {common_synonyms_path}")
+                logger.info(f"Loaded {count_common_file_synonyms:,} common synonyms from {common_synonyms_path}")
 
         node_synonyms = set()
         for ident in node['identifiers']:
@@ -99,10 +105,10 @@ class DescriptionFactory:
         self.root_dir = rootdir
         self.descriptions = {}
         self.common_descriptions = None
-        print(f"Created DescriptionFactory for directory {rootdir}")
+        logger.info(f"Created DescriptionFactory for directory {rootdir}")
 
     def load_descriptions(self,prefix):
-        print(f'Loading descriptions for {prefix}')
+        logger.info(f'Loading descriptions for {prefix}')
         descs = defaultdict(set)
         descfname = os.path.join(self.root_dir, prefix, 'descriptions')
         desc_count = 0
@@ -113,7 +119,7 @@ class DescriptionFactory:
                     descs[x[0]].add("\t".join(x[1:]))
                     desc_count += 1
         self.descriptions[prefix] = descs
-        print(f'Loaded {desc_count} descriptions for {prefix}')
+        logger.info(f'Loaded {desc_count:,} descriptions for {prefix}')
 
     def get_descriptions(self,node):
         config = get_config()
@@ -131,7 +137,7 @@ class DescriptionFactory:
                         row = json.loads(line)
                         self.common_descriptions[row['curie']].extend(row['descriptions'])
                         count_common_file_descriptions += 1
-                logging.info(f"Loaded {count_common_file_descriptions} common descriptions from {common_descriptions_path}")
+                logger.info(f"Loaded {count_common_file_descriptions} common descriptions from {common_descriptions_path}")
 
 
         node_descriptions = defaultdict(set)
@@ -154,7 +160,7 @@ class TaxonFactory:
         self.taxa = {}
 
     def load_taxa(self, prefix):
-        print(f'Loading taxa for {prefix}')
+        logger.info(f'Loading taxa for {prefix}')
         taxa_per_prefix = defaultdict(set)
         taxafilename = os.path.join(self.root_dir, prefix, 'taxa')
         taxon_count = 0
@@ -165,7 +171,7 @@ class TaxonFactory:
                     taxa_per_prefix[x[0]].add("\t".join(x[1:]))
                     taxon_count += 1
         self.taxa[prefix] = taxa_per_prefix
-        print(f'Loaded {taxon_count} taxon-CURIE mappings for {prefix}')
+        logger.info(f'Loaded {taxon_count} taxon-CURIE mappings for {prefix}')
 
     def get_taxa(self, node):
         node_taxa = defaultdict(set)
@@ -244,10 +250,10 @@ class InformationContentFactory:
         # Sort the dictionary items by value in descending order
         sorted_by_prefix = sorted(count_by_prefix.items(), key=lambda item: item[1], reverse=True)
 
-        print(f"Loaded {len(self.ic)} InformationContent values from {len(count_by_prefix.keys())} prefixes:")
+        logger.info(f"Loaded {len(self.ic)} InformationContent values from {len(count_by_prefix.keys())} prefixes:")
         # Now you can print the sorted items
         for key, value in sorted_by_prefix:
-            print(f'- {key}: {value}')
+            logger.info(f'- {key}: {value}')
 
         # We see a number of URLs being mapped to None (250,871 at present). Let's optionally raise an error if that
         # happens.
@@ -259,12 +265,12 @@ class InformationContentFactory:
                 unmapped_urls_by_netloc[netloc].append(url)
 
             # Print them in reverse count order.
-            print(f"Found {len(unmapped_urls)} unmapped URLs:")
+            logger.info(f"Found {len(unmapped_urls)} unmapped URLs:")
             netlocs_by_count = sorted(unmapped_urls_by_netloc.items(), key=lambda item: len(item[1]), reverse=True)
             for netloc, urls in netlocs_by_count:
-                print(f" - {netloc} [{len(urls)}]")
+                logger.info(f" - {netloc} [{len(urls)}]")
                 for url in sorted(urls):
-                    print(f"   - {url}")
+                    logger.info(f"   - {url}")
 
             assert None not in sorted_by_prefix, ("Found invalid CURIEs in information content values, probably "
                                                   "because they couldn't be mapped from URLs to CURIEs.")
@@ -285,6 +291,7 @@ class InformationContentFactory:
 
 class NodeFactory:
     def __init__(self,label_dir,biolink_version):
+        self.biolink_version = biolink_version
         self.toolkit = get_biolink_model_toolkit(biolink_version)
         self.ancestor_map = {}
         self.prefix_map = {}
@@ -306,7 +313,7 @@ class NodeFactory:
     def get_prefixes(self,input_type):
         if input_type in self.prefix_map:
             return self.prefix_map[input_type]
-        print(input_type)
+        logger.info(f"NodeFactory({self.label_dir}, {self.biolink_version}).get_prefixes({input_type}) called")
         j = self.toolkit.get_element(input_type)
         prefs = j['id_prefixes']
         # biolink doesnt yet include UMLS as a valid prefix for biological process. There is a PR here:
@@ -361,16 +368,15 @@ class NodeFactory:
                         wrote = True
                         break
                 if not wrote:
-                    print(input_identifiers)
-                    exit()
+                    raise ValueError(f"Can't clean up list {v}")
         return cleaned
 
     def load_extra_labels(self,prefix):
         if self.label_dir is None:
-            print (f"WARNING: no label_dir specified in load_extra_labels({self}, {prefix}), can't load extra labels for {prefix}. Skipping.")
+            logger.warning(f"no label_dir specified in load_extra_labels({self}, {prefix}), can't load extra labels for {prefix}. Skipping.")
             return
         if prefix is None:
-            print (f"WARNING: no prefix specified in load_extra_labels({self}, {prefix}), can't load extra labels. Skipping.")
+            logger.warning(f"no prefix specified in load_extra_labels({self}, {prefix}), can't load extra labels. Skipping.")
             return
         labelfname = os.path.join(self.label_dir,prefix,'labels')
         lbs = {}
@@ -404,7 +410,7 @@ class NodeFactory:
                                 continue
                         self.common_labels[x[0]] = x[1]
                         count_common_file_labels += 1
-                logging.info(f"Loaded {count_common_file_labels} common labels from {common_labels_path}")
+                logger.info(f"Loaded {count_common_file_labels} common labels from {common_labels_path}")
 
         #Originally we needed to clean up the identifer lists, because there would be both labeledids and
         # string ids and we had to reconcile them.
@@ -419,7 +425,7 @@ class NodeFactory:
                 try:
                     prefix = Text.get_prefix(iid)
                 except ValueError as e:
-                    print(f"ERROR: Unable to apply_labels({self}, {input_identifiers}, {labels}): could not obtain prefix for identifier {iid}")
+                    logger.error(f"Unable to apply_labels({self}, {input_identifiers}, {labels}): could not obtain prefix for identifier {iid}")
                     raise e
                 if prefix not in self.extra_labels:
                     self.load_extra_labels(prefix)
@@ -441,7 +447,7 @@ class NodeFactory:
         if len(input_identifiers) == 0:
             return None
         if len(input_identifiers) > 1000:
-            logging.warning(f'this seems like a lot of input_identifiers in node.create_node() [{len(input_identifiers)}]: {input_identifiers}')
+            logger.warning(f'this seems like a lot of input_identifiers in node.create_node() [{len(input_identifiers)}]: {input_identifiers}')
         cleaned = self.apply_labels(input_identifiers,labels)
         try:
             idmap = defaultdict(list)
@@ -476,7 +482,7 @@ class NodeFactory:
                 try:
                     newids.sort()
                 except TypeError as e:
-                    print(newids)
+                    logger.error(f"Could not sort {newids} because of a TypeError: {e}")
                     raise e
                 if pupper == PUBCHEMCOMPOUND.upper() and len(newids) > 1:
                     newids = pubchemsort(newids,cleaned)
@@ -485,7 +491,7 @@ class NodeFactory:
         for k,vals in idmap.items():
             for v in vals:
                 if v not in accepted_ids and (k,node_type) not in self.ignored_prefixes:
-                    print(f'Ignoring prefix {k} for type {node_type}, identifier {v}')
+                    logger.warning(f'Ignoring prefix {k} for type {node_type}, identifier {v}')
                     self.ignored_prefixes.add( (k,node_type) )
         if len(identifiers) == 0:
             return None

--- a/src/node.py
+++ b/src/node.py
@@ -44,7 +44,7 @@ class SynonymFactory:
         self.config = get_config()
 
         # Load the common synonyms.
-        common_synonyms = defaultdict(set)
+        self.common_synonyms = defaultdict(set)
 
         for common_synonyms_file in self.config['common']['synonyms']:
             common_synonyms_path = os.path.join(self.config['download_directory'], 'common', common_synonyms_file)
@@ -58,7 +58,6 @@ class SynonymFactory:
                     count_common_file_synonyms += 1
             logger.info(f"Loaded {count_common_file_synonyms:,} common synonyms from {common_synonyms_path}: {get_memory_usage_summary()}")
 
-        self.common_synonyms = common_synonyms
         logger.info(f"Created SynonymFactory for directory {syndir}")
 
     def load_synonyms(self,prefix):
@@ -108,7 +107,7 @@ class DescriptionFactory:
         self.common_descriptions = None
 
         self.config = get_config()
-        common_descriptions = defaultdict(list)
+        self.common_descriptions = defaultdict(list)
         for common_descriptions_file in self.config['common']['descriptions']:
             common_descriptions_path = os.path.join(self.config['download_directory'], 'common', common_descriptions_file)
             count_common_file_descriptions = 0
@@ -120,7 +119,6 @@ class DescriptionFactory:
                     self.common_descriptions[row['curie']].extend(row['descriptions'])
                     count_common_file_descriptions += 1
             logger.info(f"Loaded {count_common_file_descriptions} common descriptions from {common_descriptions_path}")
-        self.common_descriptions = common_descriptions
 
         logger.info(f"Created DescriptionFactory for directory {rootdir}")
 

--- a/src/node.py
+++ b/src/node.py
@@ -141,7 +141,7 @@ class DescriptionFactory:
         for ident in node['identifiers']:
             thisid = ident['identifier']
             pref = thisid.split(':', 1)[0]
-            if not pref in self.descriptions:
+            if pref not in self.descriptions:
                 self.load_descriptions(pref)
             node_descriptions[thisid].update( self.descriptions[pref][thisid] )
             node_descriptions[thisid].update( self.common_descriptions.get(thisid, {}) )
@@ -175,7 +175,7 @@ class TaxonFactory:
         for ident in node['identifiers']:
             thisid = ident['identifier']
             pref = thisid.split(':', 1)[0]
-            if not pref in self.taxa:
+            if pref not in self.taxa:
                 self.load_taxa(pref)
             node_taxa[thisid].update(self.taxa[pref][thisid])
         return node_taxa

--- a/src/util.py
+++ b/src/util.py
@@ -29,7 +29,7 @@ def get_logger(name, loglevel=logging.INFO):
 
     # Set up the root handler for a logger. Ideally we would call this in one central location, but I'm not sure
     # what they would be for Snakemake. basicConfig() should be safe to call from multiple threads after
-    formatter = logging.Formatter('%(levelname)s %(name)s [%(asctime)s]: %(message)s')
+    formatter = logging.Formatter('%(levelname)s %(name)s [%(asctime)s]: %(message)s', "%Y-%m-%dT%H:%M:%S%z")
     formatter.converter = gmtime
 
     stream_handler = logging.StreamHandler(sys.stderr)

--- a/src/util.py
+++ b/src/util.py
@@ -18,6 +18,7 @@ from src.LabeledID import LabeledID
 from src.prefixes import OMIM, OMIMPS, UMLS, SNOMEDCT, KEGGPATHWAY, KEGGREACTION, NCIT, ICD10, ICD10CM, ICD11FOUNDATION
 import src.prefixes as prefixes
 
+babel_loggers = {}
 def get_logger(name=None, level=logging.INFO):
     """
     Get a logger with the specified name.
@@ -25,13 +26,18 @@ def get_logger(name=None, level=logging.INFO):
     The LoggingUtil is inconsistently used, and we don't want rolling logs anyway -- just logging everything to STDOUT
     so that Snakemake can capture it is fine. However, we
     """
+
     if name is None:
         # TODO: what we really want to get here is the Snakemake job we're currently in, but that's tricky.
         name = f"{__name__} ({__file__})"
 
+    global babel_loggers
+    if name in babel_loggers:
+        return babel_loggers[name]
+
     # Set up a logger.
-    logger = logging.getLogger(name)
-    logger.setLevel(level)
+    babel_logger = logging.getLogger(name)
+    babel_logger.setLevel(level)
 
     # Set up a formatter. We want to use UTC time.
     formatter = logging.Formatter('%(levelname)s %(name)s [%(asctime)s]: %(message)s')
@@ -40,9 +46,11 @@ def get_logger(name=None, level=logging.INFO):
     # Set up a stream handler for STDERR.
     stream_handler = logging.StreamHandler(sys.stderr)
     stream_handler.setFormatter(formatter)
-    logger.addHandler(stream_handler)
+    babel_logger.addHandler(stream_handler)
 
-    return logger
+    babel_loggers[name] = babel_logger
+
+    return babel_logger
 
 #loggers = {}
 class LoggingUtil(object):

--- a/src/util.py
+++ b/src/util.py
@@ -18,39 +18,28 @@ from src.LabeledID import LabeledID
 from src.prefixes import OMIM, OMIMPS, UMLS, SNOMEDCT, KEGGPATHWAY, KEGGREACTION, NCIT, ICD10, ICD10CM, ICD11FOUNDATION
 import src.prefixes as prefixes
 
-babel_loggers = {}
-def get_logger(name=None, level=logging.INFO):
+def get_logger(name, loglevel=logging.INFO):
     """
     Get a logger with the specified name.
 
-    The LoggingUtil is inconsistently used, and we don't want rolling logs anyway -- just logging everything to STDOUT
-    so that Snakemake can capture it is fine. However, we
+    The LoggingUtil is inconsistently used, and we don't want rolling logs anyway -- just logging everything to STDERR
+    so that Snakemake can capture it is fine. However, we do want every logger to be configured identically and without
+    duplicated handlers.
     """
 
-    if name is None:
-        # TODO: what we really want to get here is the Snakemake job we're currently in, but that's tricky.
-        name = f"{__name__} ({__file__})"
-
-    global babel_loggers
-    if name in babel_loggers:
-        return babel_loggers[name]
-
-    # Set up a logger.
-    babel_logger = logging.getLogger(name)
-    babel_logger.setLevel(level)
-
-    # Set up a formatter. We want to use UTC time.
+    # Set up the root handler for a logger. Ideally we would call this in one central location, but I'm not sure
+    # what they would be for Snakemake. basicConfig() should be safe to call from multiple threads after
     formatter = logging.Formatter('%(levelname)s %(name)s [%(asctime)s]: %(message)s')
     formatter.converter = gmtime
 
-    # Set up a stream handler for STDERR.
     stream_handler = logging.StreamHandler(sys.stderr)
     stream_handler.setFormatter(formatter)
-    babel_logger.addHandler(stream_handler)
+    logging.basicConfig(level=logging.INFO, handlers=[stream_handler])
 
-    babel_loggers[name] = babel_logger
-
-    return babel_logger
+    # Set up a logger for the specified loglevel and return it.
+    logger = logging.getLogger(name)
+    logger.setLevel(loglevel)
+    return logger
 
 #loggers = {}
 class LoggingUtil(object):

--- a/src/util.py
+++ b/src/util.py
@@ -1,6 +1,8 @@
 import logging
 import json
 import os
+import sys
+from time import gmtime
 
 import curies
 import yaml
@@ -15,6 +17,31 @@ from humanfriendly import format_size
 from src.LabeledID import LabeledID
 from src.prefixes import OMIM, OMIMPS, UMLS, SNOMEDCT, KEGGPATHWAY, KEGGREACTION, NCIT, ICD10, ICD10CM, ICD11FOUNDATION
 import src.prefixes as prefixes
+
+def get_logger(name=None, level=logging.INFO):
+    """
+    Get a logger with the specified name.
+
+    The LoggingUtil is inconsistently used, and we don't want rolling logs anyway -- just logging everything to STDOUT
+    so that Snakemake can capture it is fine. However, we
+    """
+    if name is None:
+        name = f"{__name__} ({__file__})"
+
+    # Set up a logger.
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+
+    # Set up a formatter. We want to use UTC time.
+    formatter = logging.Formatter('%(levelname)s %(name)s [%(asctime)s]: %(message)s')
+    formatter.converter = gmtime
+
+    # Set up a stream handler for STDERR.
+    stream_handler = logging.StreamHandler(sys.stderr)
+    stream_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)
+
+    return logger
 
 #loggers = {}
 class LoggingUtil(object):

--- a/src/util.py
+++ b/src/util.py
@@ -314,16 +314,22 @@ class DataStructure:
         return namedtuple(type_name, d.keys())(**d)
 
 
+# Cache the config.yaml so we don't need to load it every time get_config() is called.
+config_yaml = None
 def get_config():
     """
     Retrieve the configuration data from the 'config.yaml' file.
 
     :return: The configuration data loaded from the 'config.yaml' file.
     """
+    global config_yaml
+    if config_yaml is not None:
+        return config_yaml
+
     cname = os.path.join(os.path.dirname(__file__),'..', 'config.yaml')
     with open(cname,'r') as yaml_file:
-        data = yaml.safe_load(yaml_file)
-    return data
+        config_yaml = yaml.safe_load(yaml_file)
+    return config_yaml
 
 
 def get_biolink_model_toolkit(biolink_version):

--- a/src/util.py
+++ b/src/util.py
@@ -26,6 +26,7 @@ def get_logger(name=None, level=logging.INFO):
     so that Snakemake can capture it is fine. However, we
     """
     if name is None:
+        # TODO: what we really want to get here is the Snakemake job we're currently in, but that's tricky.
         name = f"{__name__} ({__file__})"
 
     # Set up a logger.

--- a/src/util.py
+++ b/src/util.py
@@ -28,13 +28,15 @@ def get_logger(name, loglevel=logging.INFO):
     """
 
     # Set up the root handler for a logger. Ideally we would call this in one central location, but I'm not sure
-    # what they would be for Snakemake. basicConfig() should be safe to call from multiple threads after
-    formatter = logging.Formatter('%(levelname)s %(name)s [%(asctime)s]: %(message)s', "%Y-%m-%dT%H:%M:%S%z")
-    formatter.converter = gmtime
+    # what they would be for Snakemake. basicConfig() should be safe to call from multiple threads after Python 3.2, but
+    # we might as well check.
+    if not logging.getLogger().hasHandlers():
+        formatter = logging.Formatter('%(levelname)s %(name)s [%(asctime)s]: %(message)s', "%Y-%m-%dT%H:%M:%S%z")
+        formatter.converter = gmtime
 
-    stream_handler = logging.StreamHandler(sys.stderr)
-    stream_handler.setFormatter(formatter)
-    logging.basicConfig(level=logging.INFO, handlers=[stream_handler])
+        stream_handler = logging.StreamHandler(sys.stderr)
+        stream_handler.setFormatter(formatter)
+        logging.basicConfig(level=logging.INFO, handlers=[stream_handler])
 
     # Set up a logger for the specified loglevel and return it.
     logger = logging.getLogger(name)


### PR DESCRIPTION
This PR fixes the slowdown issue by loading config.yaml only once (the first time get_config() is loaded).

It also begins the process of moving away from the overly complicated LoggingUtil.* code and replacing that with `util.get_logger(__name__)`, which just returns a Logger for the current code.

It also improves the output of the `write_compendia()` logging from PR #477, adds a temporary directory under `babel_downloads/`, and fixes some (probably unrelated) bugs in synonym lookups.