### PR TITLE
Update factories to DuckDB

### DIFF
--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -641,6 +641,10 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
         combined_from_filenames=metadata_yamls,
     )
 
+    # Close all the factories.
+    taxon_factory.close()
+
+
 def glom(conc_set, newgroups, unique_prefixes=['INCHIKEY'],pref='HP',close={}):
     """We want to construct sets containing equivalent identifiers.
     conc_set is a dictionary where the values are these equivalent identifier sets and

--- a/src/node.py
+++ b/src/node.py
@@ -245,6 +245,7 @@ class TSVDuckDBLoader:
         conn.execute(f"CREATE TABLE {prefix} AS SELECT curie1, curie2 FROM read_csv($tsv_filename, header=false, sep='\\t', column_names=['curie1', 'curie2'])", {
             'tsv_filename': tsv_filename,
         })
+        conn.execute(f"CREATE INDEX curie1_idx ON {prefix}(curie1)")
         conn.commit()
         self.duckdb_filenames[prefix] = duckdb_filename
         self.duckdbs[prefix] = conn
@@ -269,7 +270,7 @@ class TSVDuckDBLoader:
                     continue
 
             # Query the DuckDB.
-            query = f"SELECT DISTINCT curie1, curie2 FROM {prefix} WHERE curie1 = ?"
+            query = f"SELECT curie1, curie2 FROM {prefix} WHERE curie1 = ?"
             for curie in curies:
                 query_result = self.duckdbs[prefix].execute(query, [curie]).fetchall()
                 if not query_result:

--- a/src/node.py
+++ b/src/node.py
@@ -174,19 +174,19 @@ class TaxonFactory:
                     if curie not in taxa_per_prefix:
                         taxa_per_prefix[curie] = list()
                     if taxon_id not in taxa_per_prefix[curie]:
-                        taxa_per_prefix[curie].add(taxon_id)
+                        taxa_per_prefix[curie].append(taxon_id)
                         taxon_count += 1
         self.taxa[prefix] = taxa_per_prefix
         logger.info(f'Loaded {taxon_count:,} taxon-CURIE mappings for {prefix}: {get_memory_usage_summary()}')
 
     def get_taxa(self, node):
-        node_taxa = defaultdict(set)
+        node_taxa = dict(set)
         for ident in node['identifiers']:
             thisid = ident['identifier']
             pref = thisid.split(':', 1)[0]
             if pref not in self.taxa:
                 self.load_taxa(pref)
-            node_taxa[thisid].update(self.taxa[pref][thisid])
+            node_taxa[thisid] = set(self.taxa[pref][thisid])
         return node_taxa
 
 

--- a/src/node.py
+++ b/src/node.py
@@ -257,12 +257,12 @@ class TSVDuckDBLoader:
         curies_grouped_by_prefix = itertools.groupby(curies_sorted_by_prefix, key=lambda curie: Text.get_prefix(curie))
         for prefix, curies_group in curies_grouped_by_prefix:
             curies = list(curies_group)
-            logger.info(f"Looking up {prefix} for {curies} curies")
+            logger.debug(f"Looking up {prefix} for {curies} curies")
             if prefix not in self.duckdbs:
-                logger.info(f"No DuckDB for {prefix} found, attempting to load it.")
+                logger.debug(f"No DuckDB for {prefix} found, attempting to load it.")
                 if not self.load_prefix(prefix):
                     # Nothing to load.
-                    logger.warning(f"No DuckDB for {prefix} found, so can't query it for {curies}")
+                    logger.debug(f"No DuckDB for {prefix} found, so can't query it for {curies}")
                     for curie in curies:
                         results[curie] = set()
                     continue

--- a/src/node.py
+++ b/src/node.py
@@ -241,8 +241,8 @@ class TSVDuckDBLoader:
 
         # Set up a DuckDB instance.
         logger.info(f"Loading {prefix} into {duckdb_filename}...")
-        conn = duckdb.connect(duckdb_filename)
-        conn.execute(f"CREATE TABLE {prefix} AS SELECT curie1, curie2 FROM read_csv($tsv_filename, header=false, sep='\\t', column_names=['curie1', 'curie2'])", {
+        conn = duckdb.connect(":memory:")
+        conn.execute(f"CREATE TABLE {prefix} AS SELECT curie1, curie2 FROM read_csv($tsv_filename, header=false, sep='\\t', column_names=['curie1', 'curie2']) ORDER BY curie1", {
             'tsv_filename': tsv_filename,
         })
         conn.execute(f"CREATE INDEX curie1_idx ON {prefix}(curie1)")

--- a/src/node.py
+++ b/src/node.py
@@ -245,6 +245,7 @@ class TSVDuckDBLoader:
         conn.execute(f"CREATE TABLE {prefix} AS SELECT curie1, curie2 FROM read_csv($tsv_filename, header=false, sep='\\t', column_names=['curie1', 'curie2'])", {
             'tsv_filename': tsv_filename,
         })
+        conn.commit()
         self.duckdb_filenames[prefix] = duckdb_filename
         self.duckdbs[prefix] = conn
         logger.info(f"Loaded {prefix} into {duckdb_filename}")

--- a/src/node.py
+++ b/src/node.py
@@ -278,7 +278,7 @@ class TSVDuckDBLoader:
                     continue
 
                 for row in query_result:
-                    curie1 = row[0]
+                    curie1 = curie
                     curie2 = row[1]
                     results[curie1].add(curie2)
 

--- a/src/node.py
+++ b/src/node.py
@@ -242,7 +242,7 @@ class TSVDuckDBLoader:
         # Set up a DuckDB instance.
         logger.info(f"Loading {prefix} into {duckdb_filename}...")
         conn = duckdb.connect(":memory:")
-        conn.execute(f"CREATE TABLE {prefix} AS SELECT curie1, curie2 FROM read_csv($tsv_filename, header=false, sep='\\t', column_names=['curie1', 'curie2']) ORDER BY curie1", {
+        conn.execute(f"CREATE TABLE {prefix} AS SELECT UPPER(curie1_in) AS curie1, curie2 FROM read_csv($tsv_filename, header=false, sep='\\t', column_names=['curie1_in', 'curie2']) ORDER BY curie1", {
             'tsv_filename': tsv_filename,
         })
         conn.execute(f"CREATE INDEX curie1_idx ON {prefix}(curie1)")
@@ -272,7 +272,7 @@ class TSVDuckDBLoader:
             # Query the DuckDB.
             query = f"SELECT curie1, curie2 FROM {prefix} WHERE curie1 = ?"
             for curie in curies:
-                query_result = self.duckdbs[prefix].execute(query, [curie]).fetchall()
+                query_result = self.duckdbs[prefix].execute(query, [curie.upper()]).fetchall()
                 if not query_result:
                     results[curie] = set()
                     continue

--- a/src/node.py
+++ b/src/node.py
@@ -180,10 +180,10 @@ class TaxonFactory:
         logger.info(f'Loaded {taxon_count:,} taxon-CURIE mappings for {prefix}: {get_memory_usage_summary()}')
 
     def get_taxa(self, node):
-        node_taxa = dict(set)
+        node_taxa = dict[str, set]
         for ident in node['identifiers']:
             thisid = ident['identifier']
-            pref = thisid.split(':', 1)[0]
+            pref = Text.get_prefix(thisid)
             if pref not in self.taxa:
                 self.load_taxa(pref)
             node_taxa[thisid] = set(self.taxa[pref][thisid])
@@ -416,7 +416,7 @@ class NodeFactory:
                                 continue
                         self.common_labels[x[0]] = x[1]
                         count_common_file_labels += 1
-                logger.info(f"Loaded {count_common_file_labels} common labels from {common_labels_path}: {get_memory_usage_summary()}")
+                logger.info(f"Loaded {count_common_file_labels:,} common labels from {common_labels_path}: {get_memory_usage_summary()}")
 
         #Originally we needed to clean up the identifer lists, because there would be both labeledids and
         # string ids and we had to reconcile them.


### PR DESCRIPTION
This PR updates the *Factory methods in node.py to use DuckDB instead. This both dramatically speeds up file loads and queries. But will it also reduce memory usage?

WIP

Should be merged after PR #478.