### PR TITLE
Fix chemical properties

### DIFF
--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -16,7 +16,7 @@ from humanfriendly import format_timespan
 
 from src.metadata.provenance import write_combined_metadata
 from src.node import NodeFactory, SynonymFactory, DescriptionFactory, InformationContentFactory, TaxonFactory
-from src.properties import PropertyList, HAS_ADDITIONAL_ID
+from src.properties import PropertyList, HAS_ALTERNATIVE_ID
 from src.util import Text, get_config, get_memory_usage_summary, get_logger
 from src.LabeledID import LabeledID
 from collections import defaultdict
@@ -462,7 +462,7 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
             identifier_list = []
             for iid in slist:
                 identifier_list.append(iid)
-                additional_curies = property_list.get_all(iid, HAS_ADDITIONAL_ID)
+                additional_curies = property_list.get_all(iid, HAS_ALTERNATIVE_ID)
                 if additional_curies:
                     for ac in additional_curies:
                         if ac.curie not in slist:

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -472,7 +472,11 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
 
             node = node_factory.create_node(input_identifiers=slist, node_type=node_type,labels = labels, extra_prefixes = extra_prefixes)
             if node is None:
-                raise RuntimeError(f"Could not create node for ({slist}, {node_type}, {labels}, {extra_prefixes}): returned None.")
+                # This usually happens because every CURIE in the node is not in the id_prefixes list for that node_type.
+                # Something to fix at some point, but we don't want to break the pipeline for this, so
+                # we emit a warning and skip this clique.
+                logger.warning(f"Could not create node for ({slist}, {node_type}, {labels}, {extra_prefixes}): returned None.")
+                continue
             else:
                 count_cliques += 1
                 count_eq_ids += len(slist)

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -610,7 +610,7 @@ def get_wikipedia_relationships(outfile, metadata_yaml):
         concord_filename=outfile,
     )
 
-def build_untyped_compendia(concordances, identifiers,unichem_partial, untyped_concord, type_file, metadata_yaml, input_metadata_yamls):
+def build_untyped_compendia(concordances, identifiers, unichem_partial, untyped_concord, type_file, metadata_yaml, input_metadata_yamls):
     """:concordances: a list of files from which to read relationships
        :identifiers: a list of files from which to read identifiers and optional categories"""
     dicts = read_partial_unichem(unichem_partial)

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -8,7 +8,7 @@ import requests
 import ast
 import gzip
 
-from src.properties import Property, HAS_ADDITIONAL_ID
+from src.properties import Property, HAS_ALTERNATIVE_ID
 from src.metadata.provenance import write_concord_metadata, write_combined_metadata
 from src.ubergraph import UberGraph
 from src.prefixes import MESH, CHEBI, UNII, DRUGBANK, INCHIKEY, PUBCHEMCOMPOUND,GTOPDB, KEGGCOMPOUND, DRUGCENTRAL, CHEMBLCOMPOUND, UMLS, RXCUI
@@ -497,7 +497,7 @@ def make_chebi_relations(sdf,dbx,outfile,propfile_gz,metadata_yaml):
                 for secondary_id in secondary_ids:
                     propf.write(Property(
                         curie = cid,
-                        predicate = HAS_ADDITIONAL_ID,
+                        predicate = HAS_ALTERNATIVE_ID,
                         value = secondary_id,
                         sources = [f'Listed as a CHEBI secondary ID in the ChEBI SDF file ({sdf})']
                     ).to_json_line())

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -499,7 +499,7 @@ def make_chebi_relations(sdf,dbx,outfile,propfile_gz,metadata_yaml):
                         curie = cid,
                         predicate = HAS_ALTERNATIVE_ID,
                         value = secondary_id,
-                        sources = [f'Listed as a CHEBI secondary ID in the ChEBI SDF file ({sdf})']
+                        source = f'Listed as a CHEBI secondary ID in the ChEBI SDF file ({sdf})'
                     ).to_json_line())
             if kk in props:
                 outf.write(f'{cid}\txref\t{KEGGCOMPOUND}:{props[kk]}\n')

--- a/src/metadata/provenance.py
+++ b/src/metadata/provenance.py
@@ -1,5 +1,6 @@
 import logging
 import os.path
+import traceback
 from collections import defaultdict
 from datetime import datetime
 
@@ -58,6 +59,10 @@ def write_concord_metadata(filename, *, name, concord_filename, url='', descript
 def write_combined_metadata(filename, typ, name, *, sources=None, url='', description='', counts=None, combined_from_filenames:list[str]=None, also_combined_from=None):
     combined_from = {}
     if combined_from_filenames is not None:
+        if isinstance(combined_from_filenames, str):
+            logging.warning(f"write_combined_metadata() got a single string for combined_from_files ('{combined_from_filenames}'), converting to a single item list, at: "
+                            f"{''.join(traceback.format_stack())}")
+            combined_from_filenames = [combined_from_filenames]
         for metadata_yaml in combined_from_filenames:
             with open(metadata_yaml, 'r') as metaf:
                 metadata_block = yaml.safe_load(metaf)

--- a/src/metadata/provenance.py
+++ b/src/metadata/provenance.py
@@ -55,7 +55,7 @@ def write_concord_metadata(filename, *, name, concord_filename, url='', descript
 
     write_metadata(filename, 'concord', name, url=url, description=description, sources=sources, counts=counts)
 
-def write_combined_metadata(filename, typ, name, *, sources=None, url='', description='', counts=None, combined_from_filenames=None, also_combined_from=None):
+def write_combined_metadata(filename, typ, name, *, sources=None, url='', description='', counts=None, combined_from_filenames:list[str]=None, also_combined_from=None):
     combined_from = {}
     if combined_from_filenames is not None:
         for metadata_yaml in combined_from_filenames:

--- a/src/properties.py
+++ b/src/properties.py
@@ -17,13 +17,14 @@ from dataclasses import dataclass, field
 # SUPPORTED PROPERTIES
 #
 
-# HAS_ADDITIONAL_ID indicates
-#   - Used by write_compendia() to
-HAS_ADDITIONAL_ID = 'http://www.geneontology.org/formats/oboInOwl#hasAlternativeId'
+# HAS_ALTERNATIVE_ID indicates that CURIE has an alternative ID that should be included in the clique, but NOT
+# treated as part of the clique for the purposes of choosing the clique leader. This is used for e.g. ChEBI secondary
+# IDs or other deprecated identifiers.
+HAS_ALTERNATIVE_ID = 'http://www.geneontology.org/formats/oboInOwl#hasAlternativeId'
 
 # Properties currently supported in the property store in one set for validation.
 supported_predicates = {
-    HAS_ADDITIONAL_ID,
+    HAS_ALTERNATIVE_ID,
 }
 
 #
@@ -173,10 +174,10 @@ class PropertyList:
 if __name__ == '__main__':
     pl = PropertyList()
     ps = set[Property]()
-    ps.add(Property('A', HAS_ADDITIONAL_ID, 'B'))
-    ps.add(Property('A', HAS_ADDITIONAL_ID, 'C'))
-    ps.add(Property('A', HAS_ADDITIONAL_ID, 'D'))
-    ps.add(Property('A', HAS_ADDITIONAL_ID, 'C'))
+    ps.add(Property('A', HAS_ALTERNATIVE_ID, 'B'))
+    ps.add(Property('A', HAS_ALTERNATIVE_ID, 'C'))
+    ps.add(Property('A', HAS_ALTERNATIVE_ID, 'D'))
+    ps.add(Property('A', HAS_ALTERNATIVE_ID, 'C'))
     pl.add_properties(ps)
     print(pl.properties)
     assert len(pl.properties) == 3

--- a/src/properties.py
+++ b/src/properties.py
@@ -41,11 +41,12 @@ class Property:
     curie: str
     predicate: str
     value: str
-    sources: tuple[str] = field(default_factory=tuple)
+    source: str = ""    # TODO: making this a list would be better, but that would make a Property non-frozen, which
+                        # would make it harder to uniquify.
 
     @staticmethod
     def valid_keys():
-        return ['curie', 'predicate', 'value', 'sources']
+        return ['curie', 'predicate', 'value', 'source']
 
     def __post_init__(self):
         """
@@ -70,10 +71,6 @@ class Property:
             raise ValueError(f'Unexpected keys in dictionary to be converted to Property ({unexpected_keys}): {json.dumps(prop_dict, sort_keys=True, indent=2)}')
 
         prop = Property(**prop_dict)
-        if source is not None:
-            # Add the source to the end of the sources list.
-            prop.sources.append(source)
-
         return prop
 
     # TODO: we should have some validation code in here so people don't make nonsense properties, which means
@@ -89,11 +86,11 @@ class Property:
             'curie': self.curie,
             'predicate': self.predicate,
             'value': self.value,
-            'sources': list(self.sources),
+            'source': list(self.source),
         }) + '\n'
 
 #
-# The PropertyList object can be used to load and query properties from multiple sources.
+# The PropertyList object can be used to load and query properties from a particular source.
 #
 # We could write them into a DuckDB file as we load them so they can overflow onto disk as needed, but that's overkill
 # for right now, so we'll just load them all into memory.
@@ -174,7 +171,7 @@ class PropertyList:
 if __name__ == '__main__':
     pl = PropertyList()
     ps = set[Property]()
-    ps.add(Property('A', HAS_ALTERNATIVE_ID, 'B', sources=['E', 'F']))
+    ps.add(Property('A', HAS_ALTERNATIVE_ID, 'B', source='E and F'))
     ps.add(Property('A', HAS_ALTERNATIVE_ID, 'C'))
     ps.add(Property('A', HAS_ALTERNATIVE_ID, 'D'))
     ps.add(Property('A', HAS_ALTERNATIVE_ID, 'C'))

--- a/src/properties.py
+++ b/src/properties.py
@@ -86,7 +86,7 @@ class Property:
             'curie': self.curie,
             'predicate': self.predicate,
             'value': self.value,
-            'source': list(self.source),
+            'source': self.source,
         }) + '\n'
 
 #

--- a/src/properties.py
+++ b/src/properties.py
@@ -174,7 +174,7 @@ class PropertyList:
 if __name__ == '__main__':
     pl = PropertyList()
     ps = set[Property]()
-    ps.add(Property('A', HAS_ALTERNATIVE_ID, 'B'))
+    ps.add(Property('A', HAS_ALTERNATIVE_ID, 'B', sources=['E', 'F']))
     ps.add(Property('A', HAS_ALTERNATIVE_ID, 'C'))
     ps.add(Property('A', HAS_ALTERNATIVE_ID, 'D'))
     ps.add(Property('A', HAS_ALTERNATIVE_ID, 'C'))

--- a/src/properties.py
+++ b/src/properties.py
@@ -31,7 +31,7 @@ supported_predicates = {
 # and write these properties.
 #
 
-@dataclass
+@dataclass(frozen=True)
 class Property:
     """
     A property value for a CURIE.
@@ -40,7 +40,7 @@ class Property:
     curie: str
     predicate: str
     value: str
-    sources: list[str] = field(default_factory=list[str])
+    sources: tuple[str] = field(default_factory=tuple)
 
     @staticmethod
     def valid_keys():
@@ -88,7 +88,7 @@ class Property:
             'curie': self.curie,
             'predicate': self.predicate,
             'value': self.value,
-            'sources': self.sources,
+            'sources': list(self.sources),
         }) + '\n'
 
 #
@@ -169,3 +169,14 @@ class PropertyList:
                 props_to_add.add(Property.from_dict(json.loads(line), source=filename_gz))
 
         return self.add_properties(props_to_add)
+
+if __name__ == '__main__':
+    pl = PropertyList()
+    ps = set[Property]()
+    ps.add(Property('A', HAS_ADDITIONAL_ID, 'B'))
+    ps.add(Property('A', HAS_ADDITIONAL_ID, 'C'))
+    ps.add(Property('A', HAS_ADDITIONAL_ID, 'D'))
+    ps.add(Property('A', HAS_ADDITIONAL_ID, 'C'))
+    pl.add_properties(ps)
+    print(pl.properties)
+    assert len(pl.properties) == 3

--- a/src/reports/compendia_per_file_reports.py
+++ b/src/reports/compendia_per_file_reports.py
@@ -36,8 +36,10 @@ def assert_files_in_directory(dir, expected_files, report_file):
     # These shouldn't interfere with these tests.
     file_list = filter(lambda fn: not fn.startswith('.nfs'), all_file_list)
 
-    assert set(file_list) == set(expected_files), f"Expected files in directory {dir} to be equal to {expected_files} but found {set(file_list)}: " + \
-        f"{set(file_list) - set(expected_files)} added, {set(expected_files) - set(file_list)} missing."
+    file_list_set = set(file_list)
+    expected_files_set = set(expected_files)
+    assert file_list_set == expected_files_set, f"Expected files in directory {dir} to be equal to {expected_files_set} but found {file_list_set}: " + \
+        f"{file_list_set - expected_files_set} added, {expected_files_set - file_list_set} missing."
 
     # If we passed, write the output to the check_file.
     with open(report_file, "w") as f:

--- a/src/reports/compendia_per_file_reports.py
+++ b/src/reports/compendia_per_file_reports.py
@@ -36,7 +36,7 @@ def assert_files_in_directory(dir, expected_files, report_file):
     # These shouldn't interfere with these tests.
     file_list = filter(lambda fn: not fn.startswith('.nfs'), all_file_list)
 
-    assert set(file_list) == set(expected_files), f"Expected files in directory {dir} to be equal to {expected_files} but found {file_list}: " + \
+    assert set(file_list) == set(expected_files), f"Expected files in directory {dir} to be equal to {expected_files} but found {set(file_list)}: " + \
         f"{set(file_list) - set(expected_files)} added, {set(expected_files) - set(file_list)} missing."
 
     # If we passed, write the output to the check_file.

--- a/src/reports/compendia_per_file_reports.py
+++ b/src/reports/compendia_per_file_reports.py
@@ -20,28 +20,28 @@ def get_datetime_as_string():
     return datetime.now().isoformat()
 
 
-def assert_files_in_directory(dir, files, report_file):
+def assert_files_in_directory(dir, expected_files, report_file):
     """
     Asserts that the list of files in a given directory are the list of files provided.
 
     :param dir: The directory to check files in.
-    :param files: The files to compare the list against.
+    :param expected_files: The files to compare the list against.
     :param report_file: Write a report to this file. We assume that this file is not intended
         to be read, but is created so that we can check this assertion has been checked.
     """
 
-    logging.info(f"Expect files in directory {dir} to be equal to {files}")
     all_file_list = os.listdir(dir)
 
     # On Sterling, we sometimes have `.nfs*` files that represent NFS cached files that weren't properly deleted.
     # These shouldn't interfere with these tests.
     file_list = filter(lambda fn: not fn.startswith('.nfs'), all_file_list)
 
-    assert set(file_list) == set(files)
+    assert set(file_list) == set(expected_files), f"Expected files in directory {dir} to be equal to {expected_files} but found {file_list}: " + \
+        f"{set(file_list) - set(expected_files)} added, {set(expected_files) - set(file_list)} missing."
 
     # If we passed, write the output to the check_file.
     with open(report_file, "w") as f:
-        f.write(f"Confirmed that {dir} contains only the files {files} at {get_datetime_as_string()}\n")
+        f.write(f"Confirmed that {dir} contains only the files {expected_files} at {get_datetime_as_string()}\n")
 
 
 def generate_content_report_for_compendium(compendium_path, report_path):

--- a/src/snakefiles/chemical.snakefile
+++ b/src/snakefiles/chemical.snakefile
@@ -230,7 +230,9 @@ rule chemical_compendia:
     input:
         typesfile    = config['intermediate_directory'] + '/chemicals/partials/types',
         untyped_file = config['intermediate_directory'] + '/chemicals/partials/untyped_compendium',
-        metadata_yamls = config['intermediate_directory'] + '/chemicals/partials/metadata-untyped_compendium.yaml',
+        metadata_yamls = [
+            config['intermediate_directory'] + '/chemicals/partials/metadata-untyped_compendium.yaml'
+        ],
         properties_jsonl_gz = [
             config['intermediate_directory'] + '/chemicals/properties/get_chebi_concord.jsonl.gz'
         ],

--- a/src/snakefiles/drugchemical.snakefile
+++ b/src/snakefiles/drugchemical.snakefile
@@ -59,11 +59,12 @@ rule drugchemical_conflation:
             input.chemical_compendia,
             input.icrdf_filename,
             output.outfile,
-            input_metadata_yamls={
-                'RXNORM': input.rxnorm_metadata,
-                'UMLS': input.umls_metadata,
-                'PUBCHEM_RXNORM': input.pubchem_metadata,
-            }, output_metadata_yaml=output.metadata_yaml)
+            input_metadata_yamls=[
+                input.rxnorm_metadata,
+                input.umls_metadata,
+                input.pubchem_metadata
+            ],
+            output_metadata_yaml=output.metadata_yaml)
 
 rule drugchemical_conflated_synonyms:
     input:

--- a/src/snakefiles/drugchemical.snakefile
+++ b/src/snakefiles/drugchemical.snakefile
@@ -48,7 +48,7 @@ rule drugchemical_conflation:
         icrdf_filename=config['download_directory']+'/icRDF.tsv',
     output:
         outfile=config['output_directory']+'/conflation/DrugChemical.txt',
-        metadata_yaml=config['output_directory']+'/conflation/metadata.yaml',
+        metadata_yaml=config['output_directory']+'/metadata/DrugChemical.yaml',
     run:
         drugchemical.build_conflation(
             input.drugchemical_manual_concord,

--- a/src/snakefiles/publications.snakefile
+++ b/src/snakefiles/publications.snakefile
@@ -57,7 +57,7 @@ rule generate_pubmed_compendia:
         metadata_yaml = config['intermediate_directory'] + '/publications/concords/metadata.yaml',
         icrdf_filename=config['download_directory'] + '/icRDF.tsv',
     output:
-        publication_compendium = config['output_directory'] + '/compendia/Publication.txt',
+        publication_compendium = temp(config['output_directory'] + '/compendia/Publication.txt'),
         # We generate an empty Publication Synonyms files, but we still need to generate one.
         publication_synonyms_gz = config['output_directory'] + '/synonyms/Publication.txt.gz',
     run:

--- a/src/snakefiles/publications.snakefile
+++ b/src/snakefiles/publications.snakefile
@@ -57,7 +57,7 @@ rule generate_pubmed_compendia:
         metadata_yaml = config['intermediate_directory'] + '/publications/concords/metadata.yaml',
         icrdf_filename=config['download_directory'] + '/icRDF.tsv',
     output:
-        publication_compendium = temp(config['output_directory'] + '/compendia/Publication.txt'),
+        publication_compendium = config['output_directory'] + '/compendia/Publication.txt',
         # We generate an empty Publication Synonyms files, but we still need to generate one.
         publication_synonyms_gz = config['output_directory'] + '/synonyms/Publication.txt.gz',
     run:


### PR DESCRIPTION
The code in PR #473 relies on a Property being hashable (so that it can be added to sets for uniqification), but we currently have a list of sources in there, which can't be easily hashed. This PR turns Property into a frozen dataclass, replaces the single source with a single source as a string, adds some example code for testing, and makes some incidental fixes to the metadata yaml files.

Closes #86. Closes #406. Closes #407.