### PR TITLE
Babel v1.12.0

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,10 +12,16 @@ rxnorm_version: "07072025"
 drugbank_version: "5-1-13"
 
 #
+# PROTEINS
+#
+
+# Chris Bizon prepared a list of UMLS/UniProtKB mappings which we download and use.
+UMLS_UniProtKB_download_raw_url: "https://raw.githubusercontent.com/cbizon/UMLS_UniProtKB/refs/heads/main/outputs/UMLS_UniProtKB.tsv"
+
+#
 # The rest of these configs need to be cleaned up.
 #
 
-UMLS_UniProtKB_download_raw_url: "https://raw.githubusercontent.com/cbizon/UMLS_UniProtKB/refs/heads/main/outputs/UMLS_UniProtKB.tsv"
 
 ncbi_files:
   - gene2ensembl.gz

--- a/kubernetes/babel.k8s.yaml
+++ b/kubernetes/babel.k8s.yaml
@@ -32,9 +32,11 @@ spec:
       requests:
         memory: "500G"
         cpu: "4"
+        ephemeral-storage: "1G"
       limits:
         memory: "500G"
         cpu: "4"
+        ephemeral-storage: "1G"
   volumes:
     - name: babel-downloads
       persistentVolumeClaim:

--- a/scripts/rsync-to-server.sh
+++ b/scripts/rsync-to-server.sh
@@ -6,4 +6,4 @@
 # SYNOPSIS
 #   bash rsync-to-server.sh username@ssh.server.org:/location/to/write/to
 
-rsync -avP --exclude 'babel_outputs/duckdb' babel_outputs/ "$1"
+rsync -avP --exclude '/duckdb/duckdbs/' babel_outputs/ "$1"

--- a/scripts/rsync-to-server.sh
+++ b/scripts/rsync-to-server.sh
@@ -6,4 +6,4 @@
 # SYNOPSIS
 #   bash rsync-to-server.sh username@ssh.server.org:/location/to/write/to
 
-rsync -avP babel_output/ --exclude 'babel_outputs/duckdb' "$1"
+rsync -avP --exclude 'babel_outputs/duckdb' babel_outputs/ "$1"

--- a/scripts/rsync-to-server.sh
+++ b/scripts/rsync-to-server.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+#
+# rsync-to-server.sh - use rsync to copy the necessary files to another server.
+#
+# SYNOPSIS
+#   bash rsync-to-server.sh username@ssh.server.org:/location/to/write/to
+
+rsync -avP babel_output/ --exclude 'babel_outputs/duckdb' "$1"

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -421,9 +421,9 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
     if properties_jsonl_gz_files:
         for properties_jsonl_gz_file in properties_jsonl_gz_files:
             logger.info(f"Loading properties from {properties_jsonl_gz_file}...")
-            property_list.add_properties_jsonl_gz(properties_jsonl_gz_file)
-            logger.info(f"Loaded {properties_jsonl_gz_file}")
-    logger.info(f"All property files loaded: {get_memory_usage_summary()}")
+            count_loaded = property_list.add_properties_jsonl_gz(properties_jsonl_gz_file)
+            logger.info(f"Loaded {count_loaded} unique properties from {properties_jsonl_gz_file}")
+    logger.info(f"All property files loaded (total unique properties: {len(property_list)}: {get_memory_usage_summary()}")
 
     property_source_count = defaultdict(int)
 
@@ -467,10 +467,9 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
                     for ac in additional_curies:
                         if ac.curie not in slist:
                             identifier_list.append(ac.curie)
-                            for source in ac.sources:
-                                property_source_count[source] += 1
+                            property_source_count[ac.source] += 1
 
-            node = node_factory.create_node(input_identifiers=slist, node_type=node_type,labels = labels, extra_prefixes = extra_prefixes)
+            node = node_factory.create_node(input_identifiers=identifier_list, node_type=node_type,labels = labels, extra_prefixes = extra_prefixes)
             if node is None:
                 # This usually happens because every CURIE in the node is not in the id_prefixes list for that node_type.
                 # Something to fix at some point, but we don't want to break the pipeline for this, so

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -585,14 +585,20 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
 
                     if iid in curie_labels:
                         id_info['l'] = curie_labels[iid]
+                    else:
+                        id_info['l'] = ''
 
                     if id_info['i'] in descs:
                         # Sort descriptions from the shortest to the longest.
                         id_info['d'] = list(sorted(descs[id_info['i']], key=lambda x: len(x)))
+                    else:
+                        id_info['d'] = []
 
                     if id_info['i'] in taxa:
                         # Sort taxa by CURIE suffix.
                         id_info['t'] = list(sorted(taxa[id_info['i']], key=get_numerical_curie_suffix))
+                    else:
+                        id_info['t'] = []
 
                     nw['identifiers'].append(id_info)
 

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -423,7 +423,9 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
             logger.info(f"Loading properties from {properties_jsonl_gz_file}...")
             count_loaded = property_list.add_properties_jsonl_gz(properties_jsonl_gz_file)
             logger.info(f"Loaded {count_loaded} unique properties from {properties_jsonl_gz_file}")
-    logger.info(f"All {len(properties_jsonl_gz_files)} property files loaded ({property_list.count_unique()} total unique properties): {get_memory_usage_summary()}")
+        logger.info(f"All {len(properties_jsonl_gz_files)} property files loaded ({property_list.count_unique()} total unique properties): {get_memory_usage_summary()}")
+    else:
+        logger.info("No property files provided or loaded.")
 
     property_source_count = defaultdict(int)
 

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -467,8 +467,8 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
                 additional_curies = property_list.get_all(iid, HAS_ALTERNATIVE_ID)
                 if additional_curies:
                     for ac in additional_curies:
-                        if ac.curie not in slist:
-                            identifier_list.append(ac.curie)
+                        if ac.value not in slist:
+                            identifier_list.append(ac.value)
                             property_source_count[ac.source] += 1
 
             node = node_factory.create_node(input_identifiers=identifier_list, node_type=node_type,labels = labels, extra_prefixes = extra_prefixes)

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -423,7 +423,7 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
             logger.info(f"Loading properties from {properties_jsonl_gz_file}...")
             count_loaded = property_list.add_properties_jsonl_gz(properties_jsonl_gz_file)
             logger.info(f"Loaded {count_loaded} unique properties from {properties_jsonl_gz_file}")
-    logger.info(f"All property files loaded (total unique properties: {property_list.count_unique()}: {get_memory_usage_summary()}")
+    logger.info(f"All {len(properties_jsonl_gz_files)} property files loaded ({property_list.count_unique()} total unique properties): {get_memory_usage_summary()}")
 
     property_source_count = defaultdict(int)
 

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -423,7 +423,7 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
             logger.info(f"Loading properties from {properties_jsonl_gz_file}...")
             count_loaded = property_list.add_properties_jsonl_gz(properties_jsonl_gz_file)
             logger.info(f"Loaded {count_loaded} unique properties from {properties_jsonl_gz_file}")
-    logger.info(f"All property files loaded (total unique properties: {len(property_list)}: {get_memory_usage_summary()}")
+    logger.info(f"All property files loaded (total unique properties: {property_list.count_unique()}: {get_memory_usage_summary()}")
 
     property_source_count = defaultdict(int)
 

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -458,7 +458,7 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
                 time_remaining_seconds = (time_elapsed_seconds / count_slist * remaining_slist)
                 logger.info(f" - Estimated time remaining: {format_timespan(time_remaining_seconds)}")
 
-            node = node_factory.create_node(input_identifiers=identifier_list, node_type=node_type,labels = labels, extra_prefixes = extra_prefixes)
+            node = node_factory.create_node(input_identifiers=slist, node_type=node_type,labels = labels, extra_prefixes = extra_prefixes)
             if node is None:
                 # This usually happens because every CURIE in the node is not in the id_prefixes list for that node_type.
                 # Something to fix at some point, but we don't want to break the pipeline for this, so

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -562,14 +562,14 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
                         # or str objects (consisting of an unlabeled CURIE).
                         ac_labelled = node_factory.apply_labels(input_identifiers=additional_curies, labels=labels)
 
-                        for ac, label in zip(additional_curies, list(ac_labelled)):
+                        for prop, label in zip(props, ac_labelled):
                             additional_curie = Text.get_curie(label)
                             if additional_curie not in current_curies:
                                 identifier_list.append(additional_curie)
                                 current_curies.add(additional_curie)
 
                                 # Track the property sources we used.
-                                property_source_count[ac.source] += 1
+                                property_source_count[prop.source] += 1
 
                                 if isinstance(label, LabeledID) and label.label:
                                     curie_labels[additional_curie] = label.label

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -553,8 +553,11 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
                         curie_labels[iid] = nid['label']
 
                     # Are there any additional CURIEs for this CURIE?
-                    additional_curies = property_list.get_all(iid, HAS_ALTERNATIVE_ID)
-                    if additional_curies:
+                    props = property_list.get_all(iid, HAS_ALTERNATIVE_ID)
+                    if props:
+                        # Get just the additional CURIEs.
+                        additional_curies = [prop.value for prop in props]
+
                         # ac_labelled will be a list that consists of either LabeledID (if the CURIE could be labeled)
                         # or str objects (consisting of an unlabeled CURIE).
                         ac_labelled = node_factory.apply_labels(input_identifiers=additional_curies, labels=labels)

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -8,6 +8,7 @@ import requests
 import ast
 import gzip
 
+from src import util
 from src.properties import Property, HAS_ALTERNATIVE_ID
 from src.metadata.provenance import write_concord_metadata, write_combined_metadata
 from src.ubergraph import UberGraph
@@ -20,6 +21,9 @@ from src.babel_utils import write_compendium, glom, get_prefixes, read_identifie
 
 import src.datahandlers.mesh as mesh
 import src.datahandlers.umls as umls
+from src.util import get_memory_usage_summary
+
+logger = util.get_logger(__name__)
 
 def get_type_from_smiles(smiles):
     if '.' in smiles:
@@ -678,12 +682,18 @@ def build_compendia(type_file, untyped_compendia_file, properties_jsonl_gz_files
         for line in inf:
             x = line.strip().split('\t')
             types[x[0]] = x[1]
+    logger.info(f'Loaded {len(types)} types from {type_file}: {get_memory_usage_summary()}')
+
     untyped_sets = set()
     with open(untyped_compendia_file,'r') as inf:
         for line in inf:
             s = ast.literal_eval(line.strip())
             untyped_sets.add(frozenset(s))
+    logger.info(f'Loaded {len(untyped_sets)} untyped sets from {untyped_compendia_file}: {get_memory_usage_summary()}')
+
     typed_sets = create_typed_sets(untyped_sets, types)
+    logger.info(f'Created {len(typed_sets)} typed sets from {len(untyped_sets)} untyped sets: {get_memory_usage_summary()}')
+
     for biotype, sets in typed_sets.items():
         baretype = biotype.split(':')[-1]
         if biotype == DRUG:

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -333,11 +333,20 @@ def combine_unichem(concordances,output):
         print(infile)
         print('loading',infile)
         pairs = []
+        prefix_to_check = None
         with open(infile,'r') as inf:
             for line in inf:
                 x = line.strip().split('\t')
                 pairs.append( ([x[0], x[2]]) )
-        newpairs = remove_overused_xrefs(pairs)
+                # Get the prefix from the first row to determine if we need to remove overused xrefs
+                if prefix_to_check is None:
+                    prefix_to_check = x[0].split(':')[0] + ':'
+        
+        # Only remove overused xrefs for specific prefixes
+        if prefix_to_check in [UNII, KEGGCOMPOUND, DRUGCENTRAL]:
+            newpairs = remove_overused_xrefs(pairs)
+        else:
+            newpairs = pairs
         setpairs = [ set(x) for x in newpairs ]
         glom(dicts, setpairs, unique_prefixes=[INCHIKEY])
     chem_sets = set([frozenset(x) for x in dicts.values()])

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -502,7 +502,12 @@ def make_chebi_relations(sdf,dbx,outfile,propfile_gz,metadata_yaml):
                         source = f'Listed as a CHEBI secondary ID in the ChEBI SDF file ({sdf})'
                     ).to_json_line())
             if kk in props:
-                outf.write(f'{cid}\txref\t{KEGGCOMPOUND}:{props[kk]}\n')
+                # This is apparently a list now sometimes?
+                kegg_ids = props[kk]
+                if not isinstance(kegg_ids, list):
+                    kegg_ids = [kegg_ids]
+                for kegg_id in kegg_ids:
+                    outf.write(f'{cid}\txref\t{KEGGCOMPOUND}:{kegg_id}\n')
             if pk in props:
                 #Apparently there's a lot of structure here?
                 database_links = props[pk]

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -21,7 +21,7 @@ from src.babel_utils import write_compendium, glom, get_prefixes, read_identifie
 
 import src.datahandlers.mesh as mesh
 import src.datahandlers.umls as umls
-from src.util import get_memory_usage_summary
+from src.util import get_memory_usage_summary, Text
 
 logger = util.get_logger(__name__)
 
@@ -328,25 +328,35 @@ def read_inchikeys(struct_file):
     return inchikeys
 
 def combine_unichem(concordances,output):
+    PREFIXES_TO_REMOVE_OVERUSED_XREFS = [UNII, KEGGCOMPOUND, DRUGCENTRAL]
+
     dicts = {}
     for infile in concordances:
         print(infile)
         print('loading',infile)
         pairs = []
-        prefix_to_check = None
+
+        # We will want to only remove overused xrefs for specific prefixes.
+        # UniChem files should only have a single prefix in the first column,
+        # but out of paranoia we'll double-check that.
+        prefixes_in_file = set()
+
         with open(infile,'r') as inf:
             for line in inf:
                 x = line.strip().split('\t')
                 pairs.append( ([x[0], x[2]]) )
                 # Get the prefix from the first row to determine if we need to remove overused xrefs
-                if prefix_to_check is None:
-                    prefix_to_check = x[0].split(':')[0] + ':'
-        
+                prefixes_in_file.add(Text.get_prefix(x[0]))
+
+        # Was there more than one prefix in the first column?
+        if len(prefixes_in_file) != 1:
+            raise RuntimeError(f"More than one prefix found in {infile}: {prefixes_in_file}. All UNICHEM files should have only one prefix.")
+        prefix_to_check = prefixes_in_file.pop()
+
         # Only remove overused xrefs for specific prefixes
-        if prefix_to_check in [UNII, KEGGCOMPOUND, DRUGCENTRAL]:
+        newpairs = pairs
+        if prefix_to_check in PREFIXES_TO_REMOVE_OVERUSED_XREFS:
             newpairs = remove_overused_xrefs(pairs)
-        else:
-            newpairs = pairs
         setpairs = [ set(x) for x in newpairs ]
         glom(dicts, setpairs, unique_prefixes=[INCHIKEY])
     chem_sets = set([frozenset(x) for x in dicts.values()])

--- a/src/exporters/kgx.py
+++ b/src/exporters/kgx.py
@@ -9,7 +9,7 @@ import os
 from itertools import combinations
 
 import logging
-from src.util import LoggingUtil
+from src.util import LoggingUtil, get_memory_usage_summary
 
 # Default logger for this file.
 logger = LoggingUtil.init_logging(__name__, level=logging.INFO)
@@ -139,7 +139,7 @@ def convert_compendium_to_kgx(compendium_filename, kgx_nodes_filename, kgx_edges
 
                     # Count total lines
                     count_lines += line_counter
-                    logger.debug(f"Processed {count_lines} lines from {compendium_filename}")
+                    logger.debug(f"Processed {count_lines:,} lines from {compendium_filename}: {get_memory_usage_summary()}")
 
                     # reset the line counter for the next group
                     line_counter = 0
@@ -157,7 +157,7 @@ def convert_compendium_to_kgx(compendium_filename, kgx_nodes_filename, kgx_edges
 
             # Count total lines
             count_lines += line_counter
-            logger.info(f"Processed a total of {count_lines} lines from {compendium_filename}")
+            logger.info(f"Processed a total of {count_lines} lines from {compendium_filename}: {get_memory_usage_summary()}")
 
     logger.info(f"Converted {compendium_filename} to KGX: " +
                 f"wrote {count_nodes} nodes to {kgx_nodes_filename} and " +

--- a/src/node.py
+++ b/src/node.py
@@ -138,11 +138,10 @@ class DescriptionFactory:
         self.descriptions[prefix] = descs
         logger.info(f'Loaded {desc_count:,} descriptions for {prefix}')
 
-    def get_descriptions(self,node):
+    def get_descriptions(self, ids: list[str]):
         node_descriptions = defaultdict(set)
-        for ident in node['identifiers']:
-            thisid = ident['identifier']
-            pref = thisid.split(':', 1)[0]
+        for thisid in ids:
+            pref = Text.get_prefix(thisid)
             if pref not in self.descriptions:
                 self.load_descriptions(pref)
             node_descriptions[thisid].update( self.descriptions[pref][thisid] )
@@ -161,8 +160,7 @@ class TaxonFactory:
     def load_taxa(self, prefix):
         return self.tsvloader.load_prefix(prefix)
 
-    def get_taxa(self, node):
-        curies = list({ident['identifier'] for ident in node['identifiers']})
+    def get_taxa(self, curies: list[str]):
         return self.tsvloader.get_curies(curies)
 
     def close(self):

--- a/src/properties.py
+++ b/src/properties.py
@@ -117,7 +117,6 @@ class PropertyList:
         self._properties = set[Property]()
         self._properties_by_curie = defaultdict(set[Property])
 
-    @property
     def count_unique(self):
         """
         Return the number of unique Properties in this PropertyList.

--- a/src/properties.py
+++ b/src/properties.py
@@ -118,6 +118,10 @@ class PropertyList:
         self._properties_by_curie = defaultdict(set[Property])
 
     @property
+    def __sizeof__(self):
+        return len(self._properties)
+
+    @property
     def properties(self) -> set[Property]:
         return self._properties
 

--- a/src/properties.py
+++ b/src/properties.py
@@ -118,7 +118,12 @@ class PropertyList:
         self._properties_by_curie = defaultdict(set[Property])
 
     @property
-    def __sizeof__(self):
+    def count_unique(self):
+        """
+        Return the number of unique Properties in this PropertyList.
+
+        :return: The number of unique Properties in this PropertyList.
+        """
         return len(self._properties)
 
     @property

--- a/src/properties.py
+++ b/src/properties.py
@@ -139,6 +139,9 @@ class PropertyList:
         """
         props = self._properties_by_curie[curie]
 
+        if predicate is None:
+            return props
+
         if predicate not in supported_predicates:
             raise ValueError(f'Predicate {predicate} is not supported (supported predicates: {supported_predicates})')
 

--- a/src/snakefiles/duckdb.snakefile
+++ b/src/snakefiles/duckdb.snakefile
@@ -23,7 +23,7 @@ rule export_compendia_to_duckdb:
     input:
         compendium_file=config['output_directory'] + "/compendia/{filename}.txt",
     output:
-        duckdb_filename=temp(config['output_directory'] + "/duckdb/duckdbs/filename={filename}/compendium.duckdb"),
+        duckdb_filename=config['output_directory'] + "/duckdb/duckdbs/filename={filename}/compendium.duckdb",
         clique_parquet_file=config['output_directory'] + "/duckdb/parquet/filename={filename}/Clique.parquet",
     run:
         duckdb_exporters.export_compendia_to_parquet(input.compendium_file, output.clique_parquet_file, output.duckdb_filename)
@@ -47,7 +47,7 @@ rule export_synonyms_to_duckdb:
     input:
         synonyms_file=config['output_directory'] + "/synonyms/{filename}.txt.gz",
     output:
-        duckdb_filename=temp(config['output_directory'] + "/duckdb/duckdbs/filename={filename}/synonyms.duckdb"),
+        duckdb_filename=config['output_directory'] + "/duckdb/duckdbs/filename={filename}/synonyms.duckdb",
         synonyms_parquet_filename=config['output_directory'] + "/duckdb/parquet/filename={filename}/Synonyms.parquet",
     run:
         duckdb_exporters.export_synonyms_to_parquet(input.synonyms_file, output.duckdb_filename, output.synonyms_parquet_filename)

--- a/src/snakefiles/publications.snakefile
+++ b/src/snakefiles/publications.snakefile
@@ -57,7 +57,7 @@ rule generate_pubmed_compendia:
         metadata_yaml = config['intermediate_directory'] + '/publications/concords/metadata.yaml',
         icrdf_filename=config['download_directory'] + '/icRDF.tsv',
     output:
-        publication_compendium = temp(config['output_directory'] + '/compendia/Publication.txt'),
+        publication_compendium = config['output_directory'] + '/compendia/Publication.txt',
         # We generate an empty Publication Synonyms files, but we still need to generate one.
         publication_synonyms_gz = config['output_directory'] + '/synonyms/Publication.txt.gz',
     run:


### PR DESCRIPTION
Changes in this PR:
* Rewrote part of the HAS_ADDITIONAL_ID logic, so that we add it later in the process so that we can label the additional identifiers without them getting re-sorted by `node_factory.create_node()`.
* Modified the description factory so that it processes lists of identifiers instead of a node.
* Increased ephemeral storage for the Babel pod to 1G so we have a bit more spare capacity before we run out of ephemeral space.
* Made DuckDB files non-temporary (so we don't have to regenerate them if we rebuild something), but added an `rsync-to-server.sh` script that excludes the DuckDB files when rsyncing the Babel Outputs to a directory.
* KEGG.COMPOUND cross-references in ChEBI are now a list instead of a single ID, which need to be handled separately. Closes #493 (7a53ce62f17663a582b27ac659ddaf95a325b5c7).
* Added unique counts for property lists.
* Improved logging and memory usage for `createcompendia/chemicals.py`.
* Added memory usage logging for `exporters/kgx.py` and in other parts of `write_compendia()`.
* Added some comments to `config.yaml`.

Important bug fixes in this release:
* https://github.com/TranslatorSRI/Babel/pull/467: We were previously sorting information content values alphanumerically instead of numerically, which means we were returning `100` for many nodes that should have had a lower IC value. This is now fixed. Thanks to @uhbrar for catching this!

| Filename                      | 2025mar31   | 2025aug17   | Diff        | % Diff   |
| ----------------------------- | ----------- | ----------- | ----------- | -------- |
| Count of CURIEs in all files  | 677,806,537 | 688,567,091 | +10,760,554 | 1.59%    |
| Count of cliques in all files | 482,038,965 | 490,614,550 | +8,575,585  | 1.78%    |
| AnatomicalEntity              | 249,164     | 249,584     | +420        | 0.17%    |
| BiologicalProcess             | 68,110      | 67,929      | \-181       | \-0.27%  |
| Cell                          | 12,920      | 13,175      | +255        | 1.97%    |
| CellLine                      | 38,810      | 38,810      | 0           | 0.00%    |
| CellularComponent             | 14,676      | 14,696      | +20         | 0.14%    |
| ChemicalEntity                | 662,991     | 4,086,825   | +3,423,834  | 516.42%  |
| ChemicalMixture               | 529         | 527         | \-2         | \-0.38%  |
| ComplexMolecularMixture       | 286         | 276         | \-10        | \-3.50%  |
| Disease                       | 628,736     | 632,330     | +3,594      | 0.57%    |
| Drug                          | 359,131     | 360,953     | +1,822      | 0.51%    |
| Gene                          | 75,520,611  | 79,427,652  | +3,907,041  | 5.17%    |
| GeneFamily                    | 27,985      | 28,050      | +65         | 0.23%    |
| GrossAnatomicalStructure      | 15,655      | 15,709      | +54         | 0.34%    |
| MacromolecularComplex         | 1,258       | 1,258       | 0           | 0.00%    |
| MolecularActivity             | 203,862     | 206,636     | +2,774      | 1.36%    |
| MolecularMixture              | 21,150,406  | 21,758,582  | +608,176    | 2.88%    |
| OrganismTaxon                 | 3,455,969   | 3,543,867   | +87,898     | 2.54%    |
| Pathway                       | 52,815      | 53,125      | +310        | 0.59%    |
| PhenotypicFeature             | 480,603     | 483,108     | +2,505      | 0.52%    |
| Polypeptide                   | 188         | 167         | \-21        | \-11.17% |
| Protein                       | 274,887,335 | 275,407,170 | +519,835    | 0.19%    |
| Publication                   | 78,061,642  | 79,773,973  | +1,712,331  | 2.19%    |
| SmallMolecule                 | 221,021,085 | 221,504,843 | +483,758    | 0.22%    |
| umls                          | 891,770     | 897,846     | +6,076      | 0.68%    |