### PR TITLE
Add GeneProtein conflated synonyms

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -289,6 +289,9 @@ chemical_outputs:
 drugchemicalconflated_synonym_outputs:
   - DrugChemicalConflated.txt
 
+geneproteinconflated_synonym_outputs:
+  - GeneProteinConflated.txt
+
 taxon_labels:
   - NCBITaxon
   - MESH

--- a/src/snakefiles/geneprotein.snakefile
+++ b/src/snakefiles/geneprotein.snakefile
@@ -26,20 +26,18 @@ rule geneprotein_conflation:
 rule geneprotein_conflated_synonyms:
     input:
         geneprotein_conflations=[config['output_directory']+'/conflation/GeneProtein.txt'],
-        gene_outputs=expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['gene_outputs']),
-        protein_outputs=expand("{od}/synonyms/{ap}", od = config['output_directory'], ap = config['protein_outputs'])
-    output:
-        geneprotein_conflated_synonyms=temp(config['output_directory']+'/synonyms/GeneProteinConflated.txt')
-    run:
-        synonymconflation.conflate_synonyms(input.gene_outputs + input.protein_outputs, input.geneprotein_conflations, output.geneprotein_conflated_synonyms)
-
-rule geneprotein_conflated_synonyms_gz:
-    input:
-        geneprotein_conflated_synonyms=config['output_directory']+'/synonyms/GeneProteinConflated.txt'
+        gene_compendia=expand("{od}/compendia/{ap}", od = config['output_directory'], ap = config['gene_outputs']),
+        protein_compendia=expand("{od}/compendia/{ap}", od = config['output_directory'], ap = config['protein_outputs']),
+        gene_synonyms_gz=expand("{od}/synonyms/{ap}.gz", od = config['output_directory'], ap = config['gene_outputs']),
+        protein_synonyms_gz=expand("{od}/synonyms/{ap}.gz", od = config['output_directory'], ap = config['protein_outputs'])
     output:
         geneprotein_conflated_synonyms_gz=config['output_directory']+'/synonyms/GeneProteinConflated.txt.gz'
     run:
-        gzip_files(input.geneprotein_conflated_synonyms)
+        synonymconflation.conflate_synonyms(
+            input.gene_synonyms_gz + input.protein_synonyms_gz,
+            input.gene_compendia + input.protein_compendia,
+            input.geneprotein_conflations,
+            output.geneprotein_conflated_synonyms_gz)
 
 rule geneprotein:
     input:

--- a/src/snakefiles/util.py
+++ b/src/snakefiles/util.py
@@ -62,6 +62,7 @@ def get_all_synonyms(config):
         config['cell_line_outputs'] +
         config['genefamily_outputs'] +
         config['drugchemicalconflated_synonym_outputs'] +
+        config['geneproteinconflated_synonym_outputs'] +
         config['umls_outputs'] +
         config['macromolecularcomplex_outputs'] +
         # Publication.txt is empty, but it's still created, so it needs to be here.
@@ -87,6 +88,7 @@ def get_all_synonyms_except_drugchemicalconflated(config):
             config['cell_line_outputs'] +
             config['genefamily_outputs'] +
             # config['drugchemicalconflated_synonym_outputs'] +
+            config['geneproteinconflated_synonym_outputs'] +
             config['umls_outputs'] +
             config['macromolecularcomplex_outputs']
     )
@@ -110,6 +112,7 @@ def get_all_synonyms_with_drugchemicalconflated(config):
             config['cell_line_outputs'] +
             config['genefamily_outputs'] +
             config['drugchemicalconflated_synonym_outputs'] +
+            config['geneproteinconflated_synonym_outputs'] +
             config['umls_outputs'] +
             config['macromolecularcomplex_outputs']
     )

--- a/src/synonyms/synonymconflation.py
+++ b/src/synonyms/synonymconflation.py
@@ -213,7 +213,7 @@ def conflate_synonyms(synonym_files_gz, compendia_files, conflation_file, output
                         if 'taxa' in synonym:
                             if 'taxa' not in final_conflation:
                                 final_conflation['taxa'] = set()
-                            final_conflation.update(synonym['taxa'])
+                            final_conflation['taxa'].update(synonym['taxa'])
 
             # Convert the taxa into a list.
             final_conflation['taxa'] = sorted(final_conflation['taxa'])


### PR DESCRIPTION
This PR adds a new output: `synonyms/GeneProteinConflated.txt`, based on the GeneProtein conflation and the Gene and Protein outputs. It should be pretty similar to the first attempt (PR #185). Also fixes a bug in synonym conflating with taxa that we'd never run into because we'd only conflated DrugChemicals before.

Closes https://github.com/TranslatorSRI/NameResolution/issues/191.