### PR TITLE
Conditionally apply overused xref filtering in combine_unichem

### DIFF
--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -4,7 +4,6 @@ import jsonlines
 import requests
 import ast
 import gzip
-from gzip import GzipFile
 
 from src.ubergraph import UberGraph
 from src.prefixes import MESH, CHEBI, UNII, DRUGBANK, INCHIKEY, PUBCHEMCOMPOUND,GTOPDB, KEGGCOMPOUND, DRUGCENTRAL, CHEMBLCOMPOUND, UMLS, RXCUI

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -325,11 +325,20 @@ def combine_unichem(concordances,output):
         print(infile)
         print('loading',infile)
         pairs = []
+        prefix_to_check = None
         with open(infile,'r') as inf:
             for line in inf:
                 x = line.strip().split('\t')
                 pairs.append( ([x[0], x[2]]) )
-        newpairs = remove_overused_xrefs(pairs)
+                # Get the prefix from the first row to determine if we need to remove overused xrefs
+                if prefix_to_check is None:
+                    prefix_to_check = x[0].split(':')[0] + ':'
+        
+        # Only remove overused xrefs for specific prefixes
+        if prefix_to_check in [UNII, KEGGCOMPOUND, DRUGCENTRAL]:
+            newpairs = remove_overused_xrefs(pairs)
+        else:
+            newpairs = pairs
         setpairs = [ set(x) for x in newpairs ]
         glom(dicts, setpairs, unique_prefixes=[INCHIKEY])
     chem_sets = set([frozenset(x) for x in dicts.values()])


### PR DESCRIPTION
## Summary

• Modified `combine_unichem` function to only call `remove_overused_xrefs` for specific prefixes
• Now only applies filtering to UNII, KEGG.COMPOUND, and DrugCentral prefixes
• Preserves all cross-references for other prefixes like CHEBI without filtering

## Background

We analyzed all the UNICHEM mappings, and the code and results can be found here: https://github.com/cbizon/UniChemCheckup/

Based on this analysis, we determined that overused cross-reference filtering should only be applied to certain prefixes that showed problematic patterns, while maintaining complete mappings for others.

## Test plan

- [x] Verify the function correctly detects prefixes from input files
- [x] Confirm filtering is only applied to UNII, KEGG.COMPOUND, and DrugCentral
- [x] Ensure other prefixes bypass the filtering step