### PR TITLE
Improve Biolink type reporting

### DIFF
--- a/src/reports/duckdb_reports.py
+++ b/src/reports/duckdb_reports.py
@@ -157,7 +157,7 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json, pr
             split_part(curie, ':', 1) AS curie_prefix,
             COUNT(curie) AS curie_count,
             COUNT(DISTINCT curie) AS curie_distinct_count,
-            COUNT(DISTINCT clique_leader) AS clique_distinct_count,
+            COUNT(DISTINCT edges.clique_leader) AS clique_distinct_count,
             STRING_AGG(edges.filename, '||' ORDER BY edges.filename ASC) AS filenames,
             STRING_AGG(DISTINCT cliques.biolink_type, '||' ORDER BY cliques.biolink_type ASC) AS biolink_types
         FROM

--- a/src/reports/duckdb_reports.py
+++ b/src/reports/duckdb_reports.py
@@ -159,7 +159,7 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json, pr
             COUNT(DISTINCT curie) AS curie_distinct_count,
             COUNT(DISTINCT edges.clique_leader) AS clique_distinct_count,
             STRING_AGG(edges.filename, '||' ORDER BY edges.filename ASC) AS filenames,
-            STRING_AGG(DISTINCT cliques.biolink_type, '||' ORDER BY cliques.biolink_type ASC) AS biolink_types
+            STRING_AGG(cliques.biolink_type, '||' ORDER BY cliques.biolink_type ASC) AS biolink_types
         FROM
             edges
         JOIN
@@ -229,7 +229,7 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json, pr
         for biolink_type in biolink_types:
             if biolink_type not in by_clique_results[clique_leader_prefix]['by_biolink_type']:
                 by_clique_results[clique_leader_prefix]['by_biolink_type'][biolink_type] = 0
-            by_clique_results[clique_leader_prefix]['by_biolink_type'][biolink_type] += 1
+            by_clique_results[clique_leader_prefix]['by_biolink_type'][biolink_type] += clique_count
 
         for curie_prefix in curie_prefix_counts.keys():
             by_clique_results[clique_leader_prefix]['by_file'][filename][curie_prefix] += curie_prefix_counts[curie_prefix]

--- a/src/reports/duckdb_reports.py
+++ b/src/reports/duckdb_reports.py
@@ -189,7 +189,7 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json, pr
     # Step 2. Generate a by-clique summary.
     clique_summary = db.sql("""
         SELECT
-            cliques.filename AS filename,
+            cliques.filename AS clique_filename,
             split_part(cliques.clique_leader, ':', 1) AS clique_leader_prefix,
             COUNT(DISTINCT cliques.clique_leader) AS clique_count,
             STRING_AGG(split_part(edges.curie, ':', 1), '||' ORDER BY curie ASC) AS curie_prefixes,
@@ -199,9 +199,9 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json, pr
         JOIN
             cliques ON cliques.clique_leader = edges.clique_leader
         GROUP BY
-            filename, clique_leader_prefix
+            clique_filename, clique_leader_prefix
         ORDER BY
-            filename ASC, clique_leader_prefix ASC
+            clique_filename ASC, clique_leader_prefix ASC
     """)
     rows = clique_summary.fetchall()
 

--- a/src/reports/duckdb_reports.py
+++ b/src/reports/duckdb_reports.py
@@ -190,9 +190,9 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json, pr
     clique_summary = db.sql("""
         SELECT
             cliques.filename AS filename,
-            split_part(clique_leader, ':', 1) AS clique_leader_prefix,
-            COUNT(DISTINCT clique_leader) AS clique_count,
-            STRING_AGG(split_part(curie, ':', 1), '||' ORDER BY curie ASC) AS curie_prefixes,
+            split_part(cliques.clique_leader, ':', 1) AS clique_leader_prefix,
+            COUNT(DISTINCT cliques.clique_leader) AS clique_count,
+            STRING_AGG(split_part(edges.curie, ':', 1), '||' ORDER BY curie ASC) AS curie_prefixes,
             STRING_AGG(DISTINCT cliques.biolink_type, '||' ORDER BY cliques.biolink_type ASC) AS biolink_types
         FROM
             edges

--- a/src/reports/duckdb_reports.py
+++ b/src/reports/duckdb_reports.py
@@ -191,6 +191,8 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json, pr
             STRING_AGG(DISTINCT cliques.biolink_type, '||' ORDER BY cliques.biolink_type ASC) AS biolink_types
         FROM
             edges
+        JOIN
+            cliques ON cliques.clique_leader = edges.clique_leader
         GROUP BY
             filename, clique_leader_prefix
         ORDER BY

--- a/src/reports/duckdb_reports.py
+++ b/src/reports/duckdb_reports.py
@@ -189,7 +189,7 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json, pr
     # Step 2. Generate a by-clique summary.
     clique_summary = db.sql("""
         SELECT
-            filename,
+            cliques.filename AS filename,
             split_part(clique_leader, ':', 1) AS clique_leader_prefix,
             COUNT(DISTINCT clique_leader) AS clique_count,
             STRING_AGG(split_part(curie, ':', 1), '||' ORDER BY curie ASC) AS curie_prefixes,

--- a/src/reports/duckdb_reports.py
+++ b/src/reports/duckdb_reports.py
@@ -158,7 +158,6 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json, pr
             COUNT(curie) AS curie_count,
             COUNT(DISTINCT curie) AS curie_distinct_count,
             COUNT(DISTINCT edges.clique_leader) AS clique_distinct_count,
-            STRING_AGG(edges.filename, '||' ORDER BY edges.filename ASC) AS filenames,
             STRING_AGG(cliques.biolink_type, '||' ORDER BY cliques.biolink_type ASC) AS biolink_types
         FROM
             edges
@@ -175,14 +174,15 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json, pr
     for row in rows:
         curie_prefix = row[0]
 
-        filename_counts = Counter(row[4].split('||'))
-        biolink_types = Counter(row[5].split('||'))
+        # STRING_AGG(edges.filename, '||' ORDER BY edges.filename ASC) AS filenames,
+        # filename_counts = Counter(row[4].split('||'))
+        biolink_types = Counter(row[4].split('||'))
 
         by_curie_prefix_results[curie_prefix] = {
             'curie_count': row[1],
             'curie_distinct_count': row[2],
             'clique_distinct_count': row[3],
-            'filenames': filename_counts,
+            # 'filenames': filename_counts,
             'biolink_types': biolink_types
         }
 

--- a/src/reports/duckdb_reports.py
+++ b/src/reports/duckdb_reports.py
@@ -158,9 +158,12 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json, pr
             COUNT(curie) AS curie_count,
             COUNT(DISTINCT curie) AS curie_distinct_count,
             COUNT(DISTINCT clique_leader) AS clique_distinct_count,
-            STRING_AGG(edges.filename, '||' ORDER BY edges.filename ASC) AS filenames
+            STRING_AGG(edges.filename, '||' ORDER BY edges.filename ASC) AS filenames,
+            STRING_AGG(DISTINCT cliques.biolink_type, '||' ORDER BY cliques.biolink_type ASC) AS biolink_types
         FROM
             edges
+        JOIN
+            cliques ON cliques.clique_leader = edges.clique_leader
         GROUP BY
             curie_prefix
         ORDER BY
@@ -173,12 +176,14 @@ def generate_prefix_report(parquet_root, duckdb_filename, prefix_report_json, pr
         curie_prefix = row[0]
 
         filename_counts = Counter(row[4].split('||'))
+        biolink_types = Counter(row[5].split('||'))
 
         by_curie_prefix_results[curie_prefix] = {
             'curie_count': row[1],
             'curie_distinct_count': row[2],
             'clique_distinct_count': row[3],
             'filenames': filename_counts,
+            'biolink_types': biolink_types
         }
 
     # Step 2. Generate a by-clique summary.

--- a/src/snakefiles/duckdb.snakefile
+++ b/src/snakefiles/duckdb.snakefile
@@ -118,6 +118,19 @@ rule generate_prefix_report:
             output.prefix_report_json,
             output.prefix_report_tsv)
 
+rule generate_synonym_report:
+    input:
+        config['output_directory'] + '/duckdb/done',
+        config['output_directory'] + '/duckdb/compendia_done',
+    params:
+        parquet_dir = config['output_directory'] + '/duckdb/parquet/',
+    output:
+        duckdb_filename = temp(config['output_directory'] + '/duckdb/duckdbs/synonym_report.duckdb'),
+        synonym_report_json = config['output_directory'] + '/reports/duckdb/synonym_report.json'
+    run:
+        src.reports.duckdb_reports.generate_prefix_report(params.parquet_dir, output.duckdb_filename,
+            output.synonym_report_json)
+
 rule all_duckdb_reports:
     input:
         config['output_directory'] + '/duckdb/done',

--- a/src/snakefiles/duckdb.snakefile
+++ b/src/snakefiles/duckdb.snakefile
@@ -128,7 +128,7 @@ rule generate_synonym_report:
         duckdb_filename = temp(config['output_directory'] + '/duckdb/duckdbs/synonym_report.duckdb'),
         synonym_report_json = config['output_directory'] + '/reports/duckdb/synonym_report.json'
     run:
-        src.reports.duckdb_reports.generate_prefix_report(params.parquet_dir, output.duckdb_filename,
+        src.reports.duckdb_reports.generate_synonym_report(params.parquet_dir, output.duckdb_filename,
             output.synonym_report_json)
 
 rule all_duckdb_reports:

--- a/src/snakefiles/duckdb.snakefile
+++ b/src/snakefiles/duckdb.snakefile
@@ -138,6 +138,7 @@ rule all_duckdb_reports:
         duplicate_curies = config['output_directory'] + '/reports/duckdb/duplicate_curies.tsv',
         duplicate_clique_leaders_tsv = config['output_directory'] + '/reports/duckdb/duplicate_clique_leaders.tsv',
         prefix_report = config['output_directory'] + '/reports/duckdb/prefix_report.json',
+        synonym_report_json = config['output_directory'] + '/reports/duckdb/synonym_report.json',
     output:
         x = config['output_directory'] + '/reports/duckdb/done',
     shell:


### PR DESCRIPTION
WIP

- [ ] Fix case where the list of Biolink types is incomplete
  - We use `STRING_AGG(cliques.biolink_type, '||' ORDER BY cliques.biolink_type ASC) AS biolink_types` to get a list of all the Biolink types (and also double-check the CURIE count). This appears to work for every row except for UniProtKB.
  - [ ] It would be nice to highlight the cases where it doesn't work (i.e. where the number of Biolink types is not equal to the CURIE count).
  - [ ] There must be some way of counting this as a subquery.