### PR TITLE
Add support for UMLS level 0 subset

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -15,7 +15,7 @@ drugbank_version: "5-1-13"
 # UMLS
 #
 umls:
-  subset: "level-0"
+  subset: "full"
   # Replace with "level-0" to get only the level 0 subset (https://www.nlm.nih.gov/research/umls/licensedcontent/umlsknowledgesources.html).
   # subset: "level-0"
 

--- a/config.yaml
+++ b/config.yaml
@@ -15,7 +15,7 @@ drugbank_version: "5-1-13"
 # UMLS
 #
 umls:
-  subset: "full"
+  subset: "level-0"
   # Replace with "level-0" to get only the level 0 subset (https://www.nlm.nih.gov/research/umls/licensedcontent/umlsknowledgesources.html).
   # subset: "level-0"
 

--- a/config.yaml
+++ b/config.yaml
@@ -12,6 +12,14 @@ rxnorm_version: "07072025"
 drugbank_version: "5-1-13"
 
 #
+# UMLS
+#
+umls:
+  subset: "full"
+  # Replace with "level-0" to get only the level 0 subset (https://www.nlm.nih.gov/research/umls/licensedcontent/umlsknowledgesources.html).
+  # subset: "level-0"
+
+#
 # PROTEINS
 #
 

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -671,7 +671,7 @@ def write_compendium(metadata_yamls, synonym_list, ofname, node_type, labels=Non
 
                     # Cliques with more identifiers might be better than cliques with smaller identifiers.
                     # So let's try to incorporate that here.
-                    # Note that this includes all the alternative IDs.
+                    # Note that this includes all the alternative IDs.kl
                     document["clique_identifier_count"] = len(nw["identifiers"])
 
                     # We want to see if we can use the CURIE suffix to sort concepts with similar identifiers.

--- a/src/datahandlers/umls.py
+++ b/src/datahandlers/umls.py
@@ -293,12 +293,13 @@ def read_umls_priority():
     return prid
 
 
-def download_umls(umls_version, download_dir):
+def download_umls(umls_version, umls_subset, download_dir):
     """
     Download the latest UMLS into the specified download directory. In addition to downloading
     and unzipping UMLS, this will move the files we use into the main directory.
 
     :param umls_version: The version of UMLS to download (e.g. `2023AA`).
+    :param umls_subset: The subset of UMLS to download (e.g. `full`, `level-0`).
     :param download_dir: The directory to download UMLS to (e.g. `babel_downloads/UMLS`)
     """
     umls_api_key = os.environ.get("UMLS_API_KEY")
@@ -307,12 +308,16 @@ def download_umls(umls_version, download_dir):
         print("See instructions at https://documentation.uts.nlm.nih.gov/rest/authentication.html")
         exit(1)
 
+    # Check umls_subset.
+    if umls_subset not in ["full", "level-0"]:
+        raise ValueError(f"The umls_subset parameter must be one of 'full' or 'level-0', but got: {umls_subset}.")
+
     # Download umls-{umls_version}-metathesaurus-full.zip
     # As described at https://documentation.uts.nlm.nih.gov/automating-downloads.html
     umls_url = "https://uts-ws.nlm.nih.gov/download"
     req = requests.get(
         umls_url,
-        {"url": f"https://download.nlm.nih.gov/umls/kss/{umls_version}/umls-{umls_version}-metathesaurus-full.zip", "apiKey": umls_api_key},
+        {"url": f"https://download.nlm.nih.gov/umls/kss/{umls_version}/umls-{umls_version}-metathesaurus-{umls_subset}.zip", "apiKey": umls_api_key},
         stream=True,
     )
     if not req.ok:

--- a/src/datahandlers/umls.py
+++ b/src/datahandlers/umls.py
@@ -315,19 +315,20 @@ def download_umls(umls_version, umls_subset, download_dir):
     # Download umls-{umls_version}-metathesaurus-full.zip
     # As described at https://documentation.uts.nlm.nih.gov/automating-downloads.html
     umls_url = "https://uts-ws.nlm.nih.gov/download"
+    filename = f"umls-{umls_version}-metathesaurus-{umls_subset}.zip"
     req = requests.get(
         umls_url,
-        {"url": f"https://download.nlm.nih.gov/umls/kss/{umls_version}/umls-{umls_version}-metathesaurus-{umls_subset}.zip", "apiKey": umls_api_key},
+        {"url": f"https://download.nlm.nih.gov/umls/kss/{umls_version}/{filename}", "apiKey": umls_api_key},
         stream=True,
     )
     if not req.ok:
-        print(f"Unable to download UMLS from ${umls_url}: ${req}")
+        print(f"Unable to download UMLS from {umls_url}: {req}")
         exit(1)
 
     # Write file to {download_dir}/umls-{umls_version}-metathesaurus-full.zip
-    logging.info(f"Downloading umls-{umls_version}-metathesaurus-full.zip to {download_dir}")
+    logging.info(f"Downloading {filename} to {download_dir}")
     os.makedirs(download_dir, exist_ok=True)
-    umls_download_zip = os.path.join(download_dir, f"umls-{umls_version}-metathesaurus-full.zip")
+    umls_download_zip = os.path.join(download_dir, filename)
     with open(umls_download_zip, "wb") as fd:
         for chunk in req.iter_content(chunk_size=128):
             fd.write(chunk)

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -185,7 +185,7 @@ rule download_umls:
         config["download_directory"] + "/UMLS/MRSTY.RRF",
         config["download_directory"] + "/UMLS/MRREL.RRF",
     run:
-        umls.download_umls(config["umls_version"], config['umls']['subset'], config["download_directory"] + "/UMLS")
+        umls.download_umls(config["umls_version"], config["umls"]["subset"], config["download_directory"] + "/UMLS")
 
 
 rule get_umls_labels_and_synonyms:

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -185,7 +185,7 @@ rule download_umls:
         config["download_directory"] + "/UMLS/MRSTY.RRF",
         config["download_directory"] + "/UMLS/MRREL.RRF",
     run:
-        umls.download_umls(config["umls_version"], config["download_directory"] + "/UMLS")
+        umls.download_umls(config["umls_version"], config['umls']['subset'], config["download_directory"] + "/UMLS")
 
 
 rule get_umls_labels_and_synonyms:


### PR DESCRIPTION
Specifically, you can now choose the subset you want (from https://www.nlm.nih.gov/research/umls/licensedcontent/umlsknowledgesources.html), but there's only really two subsets you can use: `full` and `level-0`.

Close #115.