### PR TITLE
Add pipeline tests for UMLS

### DIFF
--- a/src/datahandlers/umls.py
+++ b/src/datahandlers/umls.py
@@ -307,9 +307,7 @@ def download_umls(umls_version, umls_subset, download_dir):
     """
     umls_api_key = os.environ.get("UMLS_API_KEY")
     if not umls_api_key:
-        print("The environmental variable UMLS_API_KEY needs to be set to a valid UMLS API key.")
-        print("See instructions at https://documentation.uts.nlm.nih.gov/rest/authentication.html")
-        exit(1)
+        raise RuntimeError("The environmental variable UMLS_API_KEY needs to be set to a valid UMLS API key.\nSee instructions at https://documentation.uts.nlm.nih.gov/rest/authentication.html")
 
     # Check umls_subset.
     if umls_subset not in ["full", "level-0"]:
@@ -325,8 +323,7 @@ def download_umls(umls_version, umls_subset, download_dir):
         stream=True,
     )
     if not req.ok:
-        print(f"Unable to download UMLS from {umls_url}: {req}")
-        exit(1)
+        raise RuntimeError(f"Unable to download UMLS from {umls_url}: {req}")
 
     # Write file to {download_dir}/umls-{umls_version}-metathesaurus-full.zip
     logging.info(f"Downloading {filename} to {download_dir}")

--- a/tests/README.md
+++ b/tests/README.md
@@ -82,6 +82,15 @@ PYTHONPATH=. uv run pytest -n 4 -m unit                  # 4 workers, unit tests
   (the core correctness invariant); (4) the chemicals output excludes all D05/D08/D12.776
   descriptor terms, including "in-neither" subtrees like Polymers and Coenzymes.
 
+- **`pipeline/test_umls_pipeline.py`** (`pipeline`) — End-to-end tests for UMLS identifier
+  partitioning across all seven compendia that call `write_umls_ids()` (chemicals, protein,
+  anatomy, disease/phenotype, process/activity, taxon, gene). Requires `UMLS_API_KEY` to be
+  set; downloads `babel_downloads/UMLS/MRCONSO.RRF` and `MRSTY.RRF` automatically if absent,
+  skipping gracefully if the download fails or the key is unset. Nine tests: seven
+  parametrized non-empty checks (one per compendium), one mutual-exclusivity test asserting
+  no UMLS:CUI appears in more than one compendium, and one targeted test confirming chemicals
+  excludes all protein-assigned UMLS IDs (semantic type tree A1.4.1.2.1.7).
+
 ### Compendia
 
 - **`test_chemicals.py`** / **`test_uber.py`** (`network`, `xfail`) — Both test the

--- a/tests/pipeline/conftest.py
+++ b/tests/pipeline/conftest.py
@@ -74,14 +74,14 @@ def mesh_pipeline_outputs(mesh_nt, tmp_path_factory):
 
 @pytest.fixture(scope="session")
 def umls_rrf_files():
-    """Ensure MRCONSO.RRF and MRSTY.RRF are present; skip if UMLS_API_KEY unset or download fails."""
-    if not os.environ.get("UMLS_API_KEY"):
-        pytest.skip("UMLS_API_KEY not set; cannot download UMLS files")
-
+    """Ensure MRCONSO.RRF and MRSTY.RRF are present; skip if files are absent and download fails."""
     mrconso = make_local_name("MRCONSO.RRF", subpath="UMLS")
     mrsty = make_local_name("MRSTY.RRF", subpath="UMLS")
 
     if not os.path.exists(mrconso) or not os.path.exists(mrsty):
+        # UMLS_API_KEY is only required when the files are not yet cached.
+        if not os.environ.get("UMLS_API_KEY"):
+            pytest.skip("UMLS_API_KEY not set and UMLS files not cached; cannot download UMLS files")
         try:
             from src.datahandlers import umls as umls_handler
             from src.util import get_config

--- a/tests/pipeline/conftest.py
+++ b/tests/pipeline/conftest.py
@@ -65,3 +65,75 @@ def mesh_pipeline_outputs(mesh_nt, tmp_path_factory):
         "protein": prot_outfile,
         "excluded_tree_terms": excluded_tree_terms,
     }
+
+
+# ---------------------------------------------------------------------------
+# UMLS download fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def umls_rrf_files():
+    """Ensure MRCONSO.RRF and MRSTY.RRF are present; skip if UMLS_API_KEY unset or download fails."""
+    if not os.environ.get("UMLS_API_KEY"):
+        pytest.skip("UMLS_API_KEY not set; cannot download UMLS files")
+
+    mrconso = make_local_name("MRCONSO.RRF", subpath="UMLS")
+    mrsty = make_local_name("MRSTY.RRF", subpath="UMLS")
+
+    if not os.path.exists(mrconso) or not os.path.exists(mrsty):
+        try:
+            from src.datahandlers import umls as umls_handler
+            from src.util import get_config
+            cfg = get_config()
+            umls_handler.download_umls(
+                cfg["umls_version"],
+                cfg["umls"]["subset"],
+                cfg["download_directory"] + "/UMLS",
+            )
+        except Exception as e:
+            pytest.skip(f"Could not download UMLS: {e}")
+
+    return {"mrconso": mrconso, "mrsty": mrsty}
+
+
+# ---------------------------------------------------------------------------
+# UMLS processing fixture (depends on umls_rrf_files)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def umls_pipeline_outputs(umls_rrf_files, tmp_path_factory):
+    """Run write_umls_ids for all seven compendia; returns dict of output paths."""
+    from src.createcompendia import (
+        anatomy, diseasephenotype, gene,
+        processactivitypathway, taxon,
+    )
+    from src.util import get_config
+
+    mrconso = umls_rrf_files["mrconso"]
+    mrsty = umls_rrf_files["mrsty"]
+    cfg = get_config()
+    badumlsfile = os.path.join(cfg["input_directory"], "badumls")
+    outdir = tmp_path_factory.mktemp("umls_ids")
+
+    def out(name):
+        return str(outdir / f"{name}_UMLS")
+
+    chemicals.write_umls_ids(mrsty, out("chemicals"))
+    protein.write_umls_ids(mrsty, out("protein"))
+    anatomy.write_umls_ids(mrsty, out("anatomy"))
+    diseasephenotype.write_umls_ids(mrsty, out("diseasephenotype"), badumlsfile)
+    processactivitypathway.write_umls_ids(mrsty, out("processactivity"))
+    taxon.write_umls_ids(mrsty, out("taxon"))
+    gene.write_umls_ids(mrconso, mrsty, out("gene"))
+
+    return {
+        "chemicals":        out("chemicals"),
+        "protein":          out("protein"),
+        "anatomy":          out("anatomy"),
+        "diseasephenotype": out("diseasephenotype"),
+        "processactivity":  out("processactivity"),
+        "taxon":            out("taxon"),
+        "gene":             out("gene"),
+    }

--- a/tests/pipeline/conftest.py
+++ b/tests/pipeline/conftest.py
@@ -106,8 +106,11 @@ def umls_rrf_files():
 def umls_pipeline_outputs(umls_rrf_files, tmp_path_factory):
     """Run write_umls_ids for all seven compendia; returns dict of output paths."""
     from src.createcompendia import (
-        anatomy, diseasephenotype, gene,
-        processactivitypathway, taxon,
+        anatomy,
+        diseasephenotype,
+        gene,
+        processactivitypathway,
+        taxon,
     )
     from src.util import get_config
 

--- a/tests/pipeline/test_umls_pipeline.py
+++ b/tests/pipeline/test_umls_pipeline.py
@@ -1,0 +1,82 @@
+"""Pipeline tests for UMLS identifier partitioning across compendia (issue #675 extension).
+
+These tests verify that:
+1. Each compendium's write_umls_ids() produces non-empty output.
+2. No UMLS:CUI appears in more than one compendium output — the core invariant.
+3. Chemicals excludes UMLS IDs assigned to the protein compendium
+   (semantic type tree A1.4.1.2.1.7, Amino Acid/Peptide/Protein).
+
+All tests require UMLS_API_KEY to be set and network access for the initial
+download; they are skipped by default. Run with:
+    PYTHONPATH=. uv run pytest tests/pipeline/test_umls_pipeline.py --pipeline --no-cov -v
+"""
+import pytest
+
+
+COMPENDIUM_NAMES = [
+    "chemicals",
+    "protein",
+    "anatomy",
+    "diseasephenotype",
+    "processactivity",
+    "taxon",
+    "gene",
+]
+
+
+def _read_ids(path: str) -> set[str]:
+    """Read a TSV output file and return the set of CURIEs (first column)."""
+    ids = set()
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                ids.add(line.split("\t")[0])
+    return ids
+
+
+@pytest.mark.pipeline
+@pytest.mark.parametrize("name", COMPENDIUM_NAMES)
+def test_umls_ids_non_empty(umls_pipeline_outputs, name):
+    """Each compendium's write_umls_ids() must produce at least one identifier."""
+    ids = _read_ids(umls_pipeline_outputs[name])
+    assert len(ids) > 0, f"{name}.write_umls_ids() produced no output"
+
+
+@pytest.mark.pipeline
+def test_no_umls_id_in_multiple_compendia(umls_pipeline_outputs):
+    """Core correctness test: no UMLS:CUI may appear in more than one compendium.
+
+    If the same UMLS ID lands in two compendia, Node Normalization will see a
+    duplicate and normalization will be ambiguous or incorrect.
+    """
+    seen = {}       # id -> first compendium name
+    duplicates = {} # id -> list of all compendia it appeared in
+
+    for name in COMPENDIUM_NAMES:
+        for id_ in _read_ids(umls_pipeline_outputs[name]):
+            if id_ in seen:
+                duplicates.setdefault(id_, [seen[id_]]).append(name)
+            else:
+                seen[id_] = name
+
+    assert len(duplicates) == 0, (
+        f"Found {len(duplicates)} UMLS IDs in multiple compendia: "
+        f"{dict(list(duplicates.items())[:5])}"
+    )
+
+
+@pytest.mark.pipeline
+def test_chemicals_excludes_protein_semantic_tree(umls_pipeline_outputs):
+    """Chemicals must not contain any UMLS IDs that the protein compendium claimed.
+
+    Guards against amino-acid/peptide/protein entries (semantic type tree
+    A1.4.1.2.1.7) leaking into the chemical compendium.
+    """
+    chem_ids = _read_ids(umls_pipeline_outputs["chemicals"])
+    prot_ids = _read_ids(umls_pipeline_outputs["protein"])
+    overlap = chem_ids & prot_ids
+    assert len(overlap) == 0, (
+        f"Found {len(overlap)} IDs in both chemicals and protein UMLS outputs: "
+        f"{sorted(overlap)[:10]}"
+    )

--- a/tests/pipeline/test_umls_pipeline.py
+++ b/tests/pipeline/test_umls_pipeline.py
@@ -12,7 +12,6 @@ download; they are skipped by default. Run with:
 """
 import pytest
 
-
 COMPENDIUM_NAMES = [
     "chemicals",
     "protein",


### PR DESCRIPTION
Adds `pipeline` tests for UMLS, including comparison checks to see if the same UMLS ID ends up in different downstream tests. Pipeline tests are not run on GitHub Actions, and will only be run if pytest is run with the `--pipeline` option.

WIP: should be merged after PR #687. Might be redundant with https://github.com/NCATSTranslator/Babel/pull/692.

TODO:
- [ ] `Found 2 UMLS IDs in multiple compendia: {'UMLS:C5443442': ['chemicals', 'anatomy'], 'UMLS:C5443441': ['chemicals', 'anatomy']}`