### PR TITLE
Improve BabelTest fields in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bad-preferred-name.yml
+++ b/.github/ISSUE_TEMPLATE/bad-preferred-name.yml
@@ -68,6 +68,7 @@ body:
         If you have time, a BabelTest entry helps us write an automated test for this issue.
         You can add multiple entries, one per line.
         See [available BabelTest formats](https://github.com/NCATSTranslator/Babel/blob/master/docs/Triage.md#adding-automated-tests-to-issues).
+      render: text
       value: "{{BabelTest|HasPreferredName|curie|correct}}"
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bad-preferred-name.yml
+++ b/.github/ISSUE_TEMPLATE/bad-preferred-name.yml
@@ -72,3 +72,10 @@ body:
       value: "{{BabelTest|HasPreferredName|curie|correct}}"
     validations:
       required: false
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Any additional context, evidence, or background relevant to this issue.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bad-preferred-name.yml
+++ b/.github/ISSUE_TEMPLATE/bad-preferred-name.yml
@@ -67,7 +67,7 @@ body:
       description: >
         If you have time, a BabelTest entry helps us write an automated test for this issue.
         You can add multiple entries, one per line.
-        See [available BabelTest formats](https://github.com/NCATSTranslator/Babel/blob/master/docs/Triage.md#adding-automated-tests-to-issues).
+        See [available BabelTest formats](https://github.com/NCATSTranslator/Babel/blob/main/docs/Triage.md#adding-automated-tests-to-issues).
       render: text
       value: "{{BabelTest|HasPreferredName|curie|correct}}"
     validations:

--- a/.github/ISSUE_TEMPLATE/bad-preferred-name.yml
+++ b/.github/ISSUE_TEMPLATE/bad-preferred-name.yml
@@ -66,7 +66,8 @@ body:
       label: BabelTest entry (optional)
       description: >
         If you have time, a BabelTest entry helps us write an automated test for this issue.
-        Format: `{{BabelTest|HasPreferredName|curie|correct}}`
-      placeholder: "{{BabelTest|HasPreferredName|curie|correct}}"
+        You can add multiple entries, one per line.
+        See [available BabelTest formats](https://github.com/NCATSTranslator/Babel/blob/master/docs/Triage.md#adding-automated-tests-to-issues).
+      value: "{{BabelTest|HasPreferredName|curie|correct}}"
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/identifiers-should-be-merged.yml
+++ b/.github/ISSUE_TEMPLATE/identifiers-should-be-merged.yml
@@ -56,3 +56,10 @@ body:
       value: "{{BabelTest|ResolvesWith|curie1|curie2|curie3}}"
     validations:
       required: false
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Any additional context, evidence, or background relevant to this issue.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/identifiers-should-be-merged.yml
+++ b/.github/ISSUE_TEMPLATE/identifiers-should-be-merged.yml
@@ -50,7 +50,8 @@ body:
       label: BabelTest entry (optional)
       description: >
         If you have time, a BabelTest entry helps us write an automated test for this issue.
-        Format: `{{BabelTest|ResolvesWith|curie1|curie2|curie3}}`
-      placeholder: "{{BabelTest|ResolvesWith|curie1|curie2|curie3}}"
+        You can add multiple entries, one per line.
+        See [available BabelTest formats](https://github.com/NCATSTranslator/Babel/blob/master/docs/Triage.md#adding-automated-tests-to-issues).
+      value: "{{BabelTest|ResolvesWith|curie1|curie2|curie3}}"
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/identifiers-should-be-merged.yml
+++ b/.github/ISSUE_TEMPLATE/identifiers-should-be-merged.yml
@@ -52,6 +52,7 @@ body:
         If you have time, a BabelTest entry helps us write an automated test for this issue.
         You can add multiple entries, one per line.
         See [available BabelTest formats](https://github.com/NCATSTranslator/Babel/blob/master/docs/Triage.md#adding-automated-tests-to-issues).
+      render: text
       value: "{{BabelTest|ResolvesWith|curie1|curie2|curie3}}"
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/identifiers-should-be-merged.yml
+++ b/.github/ISSUE_TEMPLATE/identifiers-should-be-merged.yml
@@ -51,7 +51,7 @@ body:
       description: >
         If you have time, a BabelTest entry helps us write an automated test for this issue.
         You can add multiple entries, one per line.
-        See [available BabelTest formats](https://github.com/NCATSTranslator/Babel/blob/master/docs/Triage.md#adding-automated-tests-to-issues).
+        See [available BabelTest formats](https://github.com/NCATSTranslator/Babel/blob/main/docs/Triage.md#adding-automated-tests-to-issues).
       render: text
       value: "{{BabelTest|ResolvesWith|curie1|curie2|curie3}}"
     validations:

--- a/.github/ISSUE_TEMPLATE/identifiers-should-be-split.yml
+++ b/.github/ISSUE_TEMPLATE/identifiers-should-be-split.yml
@@ -57,7 +57,8 @@ body:
       label: BabelTest entry (optional)
       description: >
         If you have time, a BabelTest entry helps us write an automated test for this issue.
-        Format: `{{BabelTest|DoesNotResolveWith|curie|curie1|curie2}}`
-      placeholder: "{{BabelTest|DoesNotResolveWith|curie|curie1|curie2}}"
+        You can add multiple entries, one per line.
+        See [available BabelTest formats](https://github.com/NCATSTranslator/Babel/blob/master/docs/Triage.md#adding-automated-tests-to-issues).
+      value: "{{BabelTest|DoesNotResolveWith|curie|curie1|curie2}}"
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/identifiers-should-be-split.yml
+++ b/.github/ISSUE_TEMPLATE/identifiers-should-be-split.yml
@@ -63,3 +63,10 @@ body:
       value: "{{BabelTest|DoesNotResolveWith|curie|curie1|curie2}}"
     validations:
       required: false
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Any additional context, evidence, or background relevant to this issue.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/identifiers-should-be-split.yml
+++ b/.github/ISSUE_TEMPLATE/identifiers-should-be-split.yml
@@ -58,7 +58,7 @@ body:
       description: >
         If you have time, a BabelTest entry helps us write an automated test for this issue.
         You can add multiple entries, one per line.
-        See [available BabelTest formats](https://github.com/NCATSTranslator/Babel/blob/master/docs/Triage.md#adding-automated-tests-to-issues).
+        See [available BabelTest formats](https://github.com/NCATSTranslator/Babel/blob/main/docs/Triage.md#adding-automated-tests-to-issues).
       render: text
       value: "{{BabelTest|DoesNotResolveWith|curie|curie1|curie2}}"
     validations:

--- a/.github/ISSUE_TEMPLATE/identifiers-should-be-split.yml
+++ b/.github/ISSUE_TEMPLATE/identifiers-should-be-split.yml
@@ -59,6 +59,7 @@ body:
         If you have time, a BabelTest entry helps us write an automated test for this issue.
         You can add multiple entries, one per line.
         See [available BabelTest formats](https://github.com/NCATSTranslator/Babel/blob/master/docs/Triage.md#adding-automated-tests-to-issues).
+      render: text
       value: "{{BabelTest|DoesNotResolveWith|curie|curie1|curie2}}"
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/wrong-biolink-type.yml
+++ b/.github/ISSUE_TEMPLATE/wrong-biolink-type.yml
@@ -62,7 +62,8 @@ body:
       label: BabelTest entry (optional)
       description: >
         If you have time, a BabelTest entry helps us write an automated test for this issue.
-        Format: `{{BabelTest|ResolvesWithType|biolink_type|curie}}`
-      placeholder: "{{BabelTest|ResolvesWithType|biolink_type|curie}}"
+        You can add multiple entries, one per line.
+        See [available BabelTest formats](https://github.com/NCATSTranslator/Babel/blob/master/docs/Triage.md#adding-automated-tests-to-issues).
+      value: "{{BabelTest|ResolvesWithType|biolink_type|curie}}"
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/wrong-biolink-type.yml
+++ b/.github/ISSUE_TEMPLATE/wrong-biolink-type.yml
@@ -68,3 +68,10 @@ body:
       value: "{{BabelTest|ResolvesWithType|biolink_type|curie}}"
     validations:
       required: false
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Any additional context, evidence, or background relevant to this issue.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/wrong-biolink-type.yml
+++ b/.github/ISSUE_TEMPLATE/wrong-biolink-type.yml
@@ -63,7 +63,7 @@ body:
       description: >
         If you have time, a BabelTest entry helps us write an automated test for this issue.
         You can add multiple entries, one per line.
-        See [available BabelTest formats](https://github.com/NCATSTranslator/Babel/blob/master/docs/Triage.md#adding-automated-tests-to-issues).
+        See [available BabelTest formats](https://github.com/NCATSTranslator/Babel/blob/main/docs/Triage.md#adding-automated-tests-to-issues).
       render: text
       value: "{{BabelTest|ResolvesWithType|biolink_type|curie}}"
     validations:

--- a/.github/ISSUE_TEMPLATE/wrong-biolink-type.yml
+++ b/.github/ISSUE_TEMPLATE/wrong-biolink-type.yml
@@ -64,6 +64,7 @@ body:
         If you have time, a BabelTest entry helps us write an automated test for this issue.
         You can add multiple entries, one per line.
         See [available BabelTest formats](https://github.com/NCATSTranslator/Babel/blob/master/docs/Triage.md#adding-automated-tests-to-issues).
+      render: text
       value: "{{BabelTest|ResolvesWithType|biolink_type|curie}}"
     validations:
       required: false


### PR DESCRIPTION
Pre-fill BabelTest textarea fields with their template strings (via `value` instead of `placeholder`) so users only need to edit the placeholder words rather than typing the whole template from scratch. Update descriptions to note that multiple entries are allowed and link to the Triage.md docs listing available BabelTest formats.