### PR TITLE
Remove UMLS prefix hack for biolink:BiologicalProcess

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,7 @@ build:
   branch: babel-1.15
 
 # Versions that need to be updated on every release.
-biolink_version: "4.3.6"
+biolink_version: "4.4.0-rc1"
 umls_version: "2025AB"
 rxnorm_version: "12012025"
 drugbank_version: "5-1-13"

--- a/src/node.py
+++ b/src/node.py
@@ -438,13 +438,6 @@ class NodeFactory:
         logger.info(f"NodeFactory({self.label_dir}, {self.biolink_version}).get_prefixes({input_type}) called")
         j = self.toolkit.get_element(input_type)
         prefs = j["id_prefixes"]
-        # biolink doesnt yet include UMLS as a valid prefix for biological process. There is a PR here:
-        # https://github.com/biolink/biolink-model/pull/1541
-        # once that's merged and makes its way to BMT, we can remove the following hack:
-        ### HACK ###
-        if input_type == "biolink:BiologicalProcess":
-            prefs.append("UMLS")
-        ### END HACK ###
         if len(prefs) == 0:
             raise RuntimeError(f"No Biolink prefixes for {input_type}")
         # The pref are in a particular order, but apparently they can have dups (ugh)

--- a/tests/test_node_factory.py
+++ b/tests/test_node_factory.py
@@ -69,6 +69,29 @@ def test_taxon_prefixes(node_factory):
 
 
 @pytest.mark.network
+def test_biological_process_prefixes(node_factory):
+    """Verify that the Biolink Model (version in config.yaml) natively includes UMLS as a
+    valid prefix for biolink:BiologicalProcess.
+
+    NodeFactory.get_prefixes() previously appended UMLS manually as a workaround for an
+    older Biolink Model version that was missing it.  Issue #413
+    (https://github.com/NCATSTranslator/Babel/issues/413) tracked the upstream fix.
+    This test queries the Biolink Model Toolkit directly (bypassing NodeFactory post-
+    processing) to confirm that UMLS is present in the model itself.
+    """
+    from src.categories import BIOLOGICAL_PROCESS
+
+    # Query the toolkit directly, bypassing NodeFactory.get_prefixes() post-processing.
+    raw_prefixes = node_factory.toolkit.get_element(BIOLOGICAL_PROCESS)["id_prefixes"]
+
+    assert pref.UMLS in raw_prefixes, (
+        f"UMLS is not in the biolink:BiologicalProcess id_prefixes in the current Biolink Model. "
+        f"Full list: {raw_prefixes}. "
+        f"See https://github.com/NCATSTranslator/Babel/issues/413"
+    )
+
+
+@pytest.mark.network
 def test_normalization(node_factory):
     """Basic normalization - do we pick the right identifier?  Note that the identifiers are made up."""
     node = node_factory.create_node(["MESH:D012034", "CHEBI:1234"], "biolink:SmallMolecule")


### PR DESCRIPTION
Biolink 4.4.0-rc1 natively includes UMLS as a valid prefix for biolink:BiologicalProcess (see issue #413), so the manual append in NodeFactory.get_prefixes() is no longer needed. A new network test verifies this directly against the Biolink Model Toolkit so future model bumps can't silently regress it. Closes #413.

Also bumps Biolink Model to the latest, [`v4.4.0-rc1`](https://github.com/biolink/biolink-model/releases/tag/v4.4.0-rc1).