### PR TITLE
Rename project from 'babel' to 'babel-pipeline'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "babel"
+name = "babel-pipeline"
 version = "1.14"
 description = "Babel creates cliques of equivalent identifiers across many biomedical vocabularies. "
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -170,7 +170,7 @@ wheels = [
 ]
 
 [[package]]
-name = "babel"
+name = "babel-pipeline"
 version = "1.14"
 source = { virtual = "." }
 dependencies = [


### PR DESCRIPTION
The project name 'babel' collided with the python-babel i18n PyPI package, causing Dependabot to flag CVE-2021-42771 (a python-babel path traversal vulnerability) against this project's own lockfile entry (https://github.com/NCATSTranslator/Babel/security/dependabot/25). 'babel-pipeline' is not taken on PyPI.