### PR TITLE
Gate scheduled Tests workflow to the main repo only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
+    # Skip scheduled runs on forks; only run them in the main repo.
+    if: github.event_name != 'schedule' || github.repository == 'NCATSTranslator/Babel'
     permissions:
       contents: read
     steps:
@@ -21,7 +23,10 @@ jobs:
 
   network-tests:
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    # Run on manual dispatch anywhere, but only on schedule in the main repo (not forks).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'schedule' && github.repository == 'NCATSTranslator/Babel')
     permissions:
       contents: read
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
-    # Skip scheduled runs on forks; only run them in the main repo.
+    # Scheduled runs are gated to the main repo; non-schedule triggers run everywhere.
     if: github.event_name != 'schedule' || github.repository == 'NCATSTranslator/Babel'
     permissions:
       contents: read

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -109,6 +109,10 @@ the main risk is that a regression introduced mid-sprint goes undetected until r
 tests: `pytest --network -m "unit or network or slow"`). This runs on GitHub Actions and is
 always-on with no maintenance cost.
 
+The scheduled run is gated to the main repo (`NCATSTranslator/Babel`) via a job-level `if` check
+in `test.yml`, so it does not run on forks. Fork owners can still trigger it manually with
+`workflow_dispatch`.
+
 Consider adding during active sprints:
 
 - A weekly job on the self-hosted HPC runner that runs `pytest --pipeline --regenerate` once a


### PR DESCRIPTION
Scheduled (cron) workflows run on the default branch of every fork with Actions enabled, so the weekly Tests run was firing in forks too. Add a job-level `if` check on `github.repository` to both jobs so the schedule trigger only runs in NCATSTranslator/Babel. workflow_dispatch and pull_request still run everywhere, so fork owners can trigger manually.

Document the behavior in the "Weekly — GitHub Actions" section of docs/Testing.md.