### PR TITLE
Update GitHub org from TranslatorSRI to NCATSTranslator for Babel, NodeNormalization, and NameResolution

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@
 # to the GitHub Packages repository. It is triggered when a new package is released.
 #
 # Based on the NameRes release.yaml file at
-# https://github.com/TranslatorSRI/NameResolution/blob/a4f72e3c283dcb40a7280b55650dae63c5625e82/.github/workflows/release.yml
+# https://github.com/NCATSTranslator/NameResolution/blob/a4f72e3c283dcb40a7280b55650dae63c5625e82/.github/workflows/release.yml
 
 name: 'Release a new version to Github Packages'
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Each semantic type (such as
 requires specialized processing, but in each case, a JSON-formatted compendium
 is written to disk. This compendium can be used directly, but it can also be
 served by the
-[Node Normalization service](https://github.com/TranslatorSRI/NodeNormalization)
+[Node Normalization service](https://github.com/NCATSTranslator/NodeNormalization)
 or another frontend.
 
 In certain contexts, differentiating between some related concepts doesn't make
@@ -85,12 +85,12 @@ There are several ways of accessing Babel cliques:
   normalized to the same preferred identifier, and the API will return all the
   secondary identifiers, Biolink type, description and other useful information.
   You can find out more about this frontend on
-  [its GitHub repository](https://github.com/TranslatorSRI/NodeNormalization).
+  [its GitHub repository](https://github.com/NCATSTranslator/NodeNormalization).
 - The NCATS Translator project also provides the
   [Name Lookup (Name Resolution)](https://name-lookup.transltr.io/) frontends
   for searching for concepts by labels or synonyms. You can find out more about
   this frontend at
-  [its GitHub repository](https://github.com/TranslatorSRI/NameResolution).
+  [its GitHub repository](https://github.com/NCATSTranslator/NameResolution).
 - Play around with the [Babel Downloads](./docs/Downloads.md) (in a
   [custom format](./docs/DataFormats.md)), which are currently available in
   JSONL, [Apache Parquet](https://parquet.apache.org/) or
@@ -99,7 +99,7 @@ There are several ways of accessing Babel cliques:
 ### What is the Node Normalization service (NodeNorm)?
 
 The Node Normalization service, Node Normalizer or
-[NodeNorm](https://github.com/TranslatorSRI/NodeNormalization) is an NCATS
+[NodeNorm](https://github.com/NCATSTranslator/NodeNormalization) is an NCATS
 Translator web service to normalize identifiers by returning a single preferred
 identifier for any identifier provided.
 
@@ -113,19 +113,19 @@ other APIs intended primarily for Translator users.
 
 You can find out more about NodeNorm at its
 [Swagger interface](https://nodenormalization-sri.renci.org/docs) or
-[in this Jupyter Notebook](https://github.com/TranslatorSRI/NodeNormalization/blob/master/documentation/NodeNormalization.ipynb).
+[in this Jupyter Notebook](https://github.com/NCATSTranslator/NodeNormalization/blob/master/documentation/NodeNormalization.ipynb).
 
 ### What is the Name Resolver (NameRes)?
 
 The Name Resolver, Name Lookup or
-[NameRes](https://github.com/TranslatorSRI/NameResolution) is an NCATS
+[NameRes](https://github.com/NCATSTranslator/NameResolution) is an NCATS
 Translator web service for looking up preferred identifiers by search text.
 Although it is primarily designed to be used to power NCATS Translator's
 autocomplete text fields, it has also been used for named-entity linkage.
 
 You can find out more about NameRes at its
 [Swagger interface](https://name-resolution-sri.renci.org/docs) or
-[in this Jupyter Notebook](https://github.com/TranslatorSRI/NameResolution/blob/master/documentation/NameResolution.ipynb).
+[in this Jupyter Notebook](https://github.com/NCATSTranslator/NameResolution/blob/master/documentation/NameResolution.ipynb).
 
 ## Understanding Babel outputs
 
@@ -157,7 +157,7 @@ choice — see [Testing Strategy](./docs/Testing.md).
 ## Contact information
 
 You can find out more about Babel by
-[opening an issue on this repository](https://github.com/TranslatorSRI/Babel/issues),
+[opening an issue on this repository](https://github.com/NCATSTranslator/Babel/issues),
 contacting one of the
 [Translator DOGSLED PIs](https://ncats.nih.gov/research/research-activities/translator/projects)
 or contacting the

--- a/input_data/manual_concords/disease.txt
+++ b/input_data/manual_concords/disease.txt
@@ -3,12 +3,12 @@
 #
 # OPIOID USE DISORDER
 #
-# As per https://github.com/TranslatorSRI/Babel/issues/265, we would like to combine
+# As per https://github.com/NCATSTranslator/Babel/issues/265, we would like to combine
 # a bunch of opioid use order cliques.
 
 # Opioid dependence (which we combine incorrectly with opiate dependence following MONDO)
 MONDO:0005530	xref	UMLS:C4324621
-# This combination is as per https://github.com/TranslatorSRI/Babel/issues/270
+# This combination is as per https://github.com/NCATSTranslator/Babel/issues/270
 UMLS:C4324621	xref	EFO:0010702
 
 # For these UMLS terms, we rather imprecisely connect them with:
@@ -112,7 +112,7 @@ MONDO:0007079	oio:closeMatch	UMLS:C4536264
 # See https://github.com/NCATSTranslator/Tests/issues/92
 MONDO:0005799	xref	MESH:D006725
 
-# These pairs were reported by Gwenlyn in https://github.com/TranslatorSRI/Babel/issues/333
+# These pairs were reported by Gwenlyn in https://github.com/NCATSTranslator/Babel/issues/333
 MONDO:0007540	oio:closeMatch	DOID:10017
 HP:0003124	oio:closeMatch	NCIT:C37967
 EFO:1001393	oio:closeMatch	UMLS:C0031094

--- a/releases/2025jan23.md
+++ b/releases/2025jan23.md
@@ -1,8 +1,8 @@
 # Babel 2025jan23
 
 - Babel: [2025jan23](https://stars.renci.org/var/babel_outputs/2025jan23/)
-  ([tagged 2025jan23](https://github.com/TranslatorSRI/Babel/releases/tag/2025jan23),
-  [Babel v1.9.1](https://github.com/TranslatorSRI/Babel/releases/tag/v1.9.1))
+  ([tagged 2025jan23](https://github.com/NCATSTranslator/Babel/releases/tag/2025jan23),
+  [Babel v1.9.1](https://github.com/NCATSTranslator/Babel/releases/tag/v1.9.1))
   - [CURIE summary](./summaries/2025jan23.json)
   - [Prefix report](./prefix_reports/2025jan23.json)
 
@@ -11,19 +11,19 @@ Previous release: [Translator "Hammerhead" November 2024](./TranslatorHammerhead
 
 ## New features
 
-- Added a check for duplicate CURIEs [#342](https://github.com/TranslatorSRI/Babel/pull/342).
+- Added a check for duplicate CURIEs [#342](https://github.com/NCATSTranslator/Babel/pull/342).
 - Added some additional manual concords for Disease/Phenotype cliques and DrugChemical
-  conflation [#360](https://github.com/TranslatorSRI/Babel/pull/360).
+  conflation [#360](https://github.com/NCATSTranslator/Babel/pull/360).
 - Replace use of `has_tradename` with `tradename_of` in RxNorm
-  ([#377](https://github.com/TranslatorSRI/Babel/pull/377)).
-- Added processes from UMLS ([#395](https://github.com/TranslatorSRI/Babel/pull/395)).
-- Improved EFO relationships ([#396](https://github.com/TranslatorSRI/Babel/pull/396)).
+  ([#377](https://github.com/NCATSTranslator/Babel/pull/377)).
+- Added processes from UMLS ([#395](https://github.com/NCATSTranslator/Babel/pull/395)).
+- Improved EFO relationships ([#396](https://github.com/NCATSTranslator/Babel/pull/396)).
 - Delete DuckDB files and keep only Parquet files
-  ([#397](https://github.com/TranslatorSRI/Babel/pull/397)).
+  ([#397](https://github.com/NCATSTranslator/Babel/pull/397)).
 - Incorporate UMLS_UniProtKB mappings from <https://github.com/cbizon/UMLS_UniProtKB>
-  ([#361](https://github.com/TranslatorSRI/Babel/pull/361)).
-- Improved prefix report ([#363](https://github.com/TranslatorSRI/Babel/pull/363)).
-- Add support for icd11foundation in EFO ([#380](https://github.com/TranslatorSRI/Babel/pull/380)).
+  ([#361](https://github.com/NCATSTranslator/Babel/pull/361)).
+- Improved prefix report ([#363](https://github.com/NCATSTranslator/Babel/pull/363)).
+- Add support for icd11foundation in EFO ([#380](https://github.com/NCATSTranslator/Babel/pull/380)).
 
 ## Updates
 
@@ -46,8 +46,8 @@ Previous release: [Translator "Hammerhead" November 2024](./TranslatorHammerhead
   calculates the column index by name, with ValueErrors thrown if the column name is missing.
 - Filtered out `.nfs*` files from the file list tests, which appear sometimes on Sterling as a NFS
   file issues.
-- Fixed bug in anatomy generation ([#404](https://github.com/TranslatorSRI/Babel/pull/404)).
-- Fix some issues in EFO ([#402](https://github.com/TranslatorSRI/Babel/pull/402)).
+- Fixed bug in anatomy generation ([#404](https://github.com/NCATSTranslator/Babel/pull/404)).
+- Fix some issues in EFO ([#402](https://github.com/NCATSTranslator/Babel/pull/402)).
 - Other minor fixes.
 
 ## Summary

--- a/releases/2025jan23.md
+++ b/releases/2025jan23.md
@@ -23,7 +23,8 @@ Previous release: [Translator "Hammerhead" November 2024](./TranslatorHammerhead
 - Incorporate UMLS_UniProtKB mappings from <https://github.com/cbizon/UMLS_UniProtKB>
   ([#361](https://github.com/NCATSTranslator/Babel/pull/361)).
 - Improved prefix report ([#363](https://github.com/NCATSTranslator/Babel/pull/363)).
-- Add support for icd11foundation in EFO ([#380](https://github.com/NCATSTranslator/Babel/pull/380)).
+- Add support for icd11foundation in EFO
+  ([#380](https://github.com/NCATSTranslator/Babel/pull/380)).
 
 ## Updates
 

--- a/releases/2025mar31.md
+++ b/releases/2025mar31.md
@@ -1,8 +1,8 @@
 # Babel 2025mar31
 
 - Babel: [2025mar31](https://stars.renci.org/var/babel_outputs/2025mar31/)
-  ([tagged 2025mar31](https://github.com/TranslatorSRI/Babel/releases/tag/2025mar31),
-  [Babel v1.10.0](https://github.com/TranslatorSRI/Babel/releases/tag/v1.10.0))
+  ([tagged 2025mar31](https://github.com/NCATSTranslator/Babel/releases/tag/2025mar31),
+  [Babel v1.10.0](https://github.com/NCATSTranslator/Babel/releases/tag/v1.10.0))
   - [CURIE summary](./summaries/2025mar31.json)
   - [Prefix report](./prefix_reports/2025mar31.json)
 
@@ -12,19 +12,19 @@ Previous release: [Translator "Hammerhead" November 2024](./TranslatorHammerhead
 ## New features
 
 - Added CellLine as a type and CellLineOntology (CLO) to Babel
-  ([#419](https://github.com/TranslatorSRI/Babel/pull/419)).
-- Added FMA to anatomical entity ([#420](https://github.com/TranslatorSRI/Babel/pull/420)).
+  ([#419](https://github.com/NCATSTranslator/Babel/pull/419)).
+- Added FMA to anatomical entity ([#420](https://github.com/NCATSTranslator/Babel/pull/420)).
 - Improve DrugChemical conflation leader using information content values
-  ([#362](https://github.com/TranslatorSRI/Babel/pull/362)).
+  ([#362](https://github.com/NCATSTranslator/Babel/pull/362)).
 - Added a PubMed download verifier to identify malformed PubMed files (
-  [#432](https://github.com/TranslatorSRI/Babel/pull/432),
-  [#433](https://github.com/TranslatorSRI/Babel/pull/433),
-  [#426](https://github.com/TranslatorSRI/Babel/pull/426)).
+  [#432](https://github.com/NCATSTranslator/Babel/pull/432),
+  [#433](https://github.com/NCATSTranslator/Babel/pull/433),
+  [#426](https://github.com/NCATSTranslator/Babel/pull/426)).
 - Gzip all the synonym files to save disk space
-  ([#405](https://github.com/TranslatorSRI/Babel/pull/405),
-  [#434](https://github.com/TranslatorSRI/Babel/pull/434)).
+  ([#405](https://github.com/NCATSTranslator/Babel/pull/405),
+  [#434](https://github.com/NCATSTranslator/Babel/pull/434)).
 - Added an in-file config for DrugChemicalSmaller.txt.gz
-  ([#418](https://github.com/TranslatorSRI/Babel/pull/418)).
+  ([#418](https://github.com/NCATSTranslator/Babel/pull/418)).
 
 ## Updates
 
@@ -33,7 +33,7 @@ Previous release: [Translator "Hammerhead" November 2024](./TranslatorHammerhead
 ## Bugfixes
 
 - Added one manual DrugChemical conflation
-  ([#371](https://github.com/TranslatorSRI/Babel/pull/371)).
+  ([#371](https://github.com/NCATSTranslator/Babel/pull/371)).
 
 ## Summary
 

--- a/releases/2025sep1.md
+++ b/releases/2025sep1.md
@@ -40,9 +40,9 @@ Previous release: [2025mar31](./2025mar31.md)
     (<https://github.com/NCATSTranslator/Babel/issues/512>).
 - [MAJOR] Added an identifier-based property store (
   [PR #473](https://github.com/NCATSTranslator/Babel/pull/473),
-  [PR #483](https://github.com/NCATSTranslator/Babel/pull/483)). This is implemented as a JSON-ND file
-  that can be serialized into Property dataclasses in Python, and a PropertyList that can be loaded
-  from multiple JSON-ND files. Property files will be tracked by Snakemake and provided to
+  [PR #483](https://github.com/NCATSTranslator/Babel/pull/483)). This is implemented as a JSON-ND
+  file that can be serialized into Property dataclasses in Python, and a PropertyList that can be
+  loaded from multiple JSON-ND files. Property files will be tracked by Snakemake and provided to
   write_compendia().
   - [MAJOR] This allows us to add secondary identifiers to ChEBI, and will allow us to add
     additional secondary identifiers in the future.

--- a/releases/2025sep1.md
+++ b/releases/2025sep1.md
@@ -1,8 +1,8 @@
 # Babel 2025sep1
 
 - Babel: [2025sep1](https://stars.renci.org/var/babel_outputs/2025sep1/)
-  ([tagged 2025sep1](https://github.com/TranslatorSRI/Babel/releases/tag/2025sep1),
-  [Babel v1.13](https://github.com/TranslatorSRI/Babel/releases/tag/v1.13))
+  ([tagged 2025sep1](https://github.com/NCATSTranslator/Babel/releases/tag/2025sep1),
+  [Babel v1.13](https://github.com/NCATSTranslator/Babel/releases/tag/v1.13))
   - [CURIE summary](./summaries/2025sep1.json)
   - [Prefix report](./prefix_reports/2025sep1.json)
 
@@ -13,19 +13,19 @@ Previous release: [2025mar31](./2025mar31.md)
 
 - [MAJOR] @uhbrar discovered that some information content values appeared odd, and @gaurav realized
   this was because the information content comparison was being carried out as a string, not as
-  number. Fixed in [PR #467](https://github.com/TranslatorSRI/Babel/pull/467).
+  number. Fixed in [PR #467](https://github.com/NCATSTranslator/Babel/pull/467).
   - This was actually made in [Babel v1.11](./v1.11.md) but that isn't a real release and this is a
     major enough bugfix that I'll include it here as well.
 - [MAJOR]
   - Added a UMLS/MeSH/DrugBank concord for proteins
-    ([PR #495](https://github.com/TranslatorSRI/Babel/pull/495)).
+    ([PR #495](https://github.com/NCATSTranslator/Babel/pull/495)).
 - KEGG.COMPOUND xrefs in ChEBI can sometimes be a list instead of an individual identifier
   (7a53ce62f17663a582b27ac659ddaf95a325b5c7).
 
 ## Updates
 
 - [MAJOR] Improved DrugChemical conflation order
-  ([PR #506](https://github.com/TranslatorSRI/Babel/pull/506)).
+  ([PR #506](https://github.com/NCATSTranslator/Babel/pull/506)).
   - Previously, we would attempt to pick the best DrugChemical clique leader we could, and then
     use that to determine the prefix order. Unfortunately, this sometimes meant that a clique that
     contained e.g. SmallMolecule and ChemicalEntity could become typed as a ChemicalEntity if the
@@ -37,10 +37,10 @@ Previous release: [2025mar31](./2025mar31.md)
         2. Clique size (largest --> smallest)
         3. Numerical suffix (smallest -> largest)
   - There is at least one hopefully non-critical bug with this at present
-    (<https://github.com/TranslatorSRI/Babel/issues/512>).
+    (<https://github.com/NCATSTranslator/Babel/issues/512>).
 - [MAJOR] Added an identifier-based property store (
-  [PR #473](https://github.com/TranslatorSRI/Babel/pull/473),
-  [PR #483](https://github.com/TranslatorSRI/Babel/pull/483)). This is implemented as a JSON-ND file
+  [PR #473](https://github.com/NCATSTranslator/Babel/pull/473),
+  [PR #483](https://github.com/NCATSTranslator/Babel/pull/483)). This is implemented as a JSON-ND file
   that can be serialized into Property dataclasses in Python, and a PropertyList that can be loaded
   from multiple JSON-ND files. Property files will be tracked by Snakemake and provided to
   write_compendia().
@@ -48,20 +48,20 @@ Previous release: [2025mar31](./2025mar31.md)
     additional secondary identifiers in the future.
 - Replace in-memory TaxonFactory with an SQLite-based factory that attempts to stay in-memory, but
   will write to disk if it runs out of memory (
-  [PR #482](https://github.com/TranslatorSRI/Babel/pull/482)).
+  [PR #482](https://github.com/NCATSTranslator/Babel/pull/482)).
   - This is implemented as a generic TSVSQLiteLoader, so hopefully we can eventually replace
     SynonymFactory and maybe DescriptionFactory with this method as well.
 - Improved logging and memory tracking within the Babel build -- far from complete and not ready to
   be used to produce a memory map of the entire build, but better than nothing (
-  [PR #477](https://github.com/TranslatorSRI/Babel/pull/477)).
+  [PR #477](https://github.com/NCATSTranslator/Babel/pull/477)).
   - Also actually fixed the bug that was causing the slowdown, which was that the config.yaml file
     was being repeatedly reloaded during write_compendia() and elsewhere (
-    [PR #478](https://github.com/TranslatorSRI/Babel/pull/478)).
+    [PR #478](https://github.com/NCATSTranslator/Babel/pull/478)).
 
 ## New features
 
 - [MAJOR] We now generate a GeneProteinConflated.txt.gz synonyms file
-  ([PR #486](https://github.com/TranslatorSRI/Babel/pull/486)) so that NameRes can be loaded with
+  ([PR #486](https://github.com/NCATSTranslator/Babel/pull/486)) so that NameRes can be loaded with
   GeneProtein conflation turned on.
 
 ## Summary

--- a/releases/TranslatorDecember2023.md
+++ b/releases/TranslatorDecember2023.md
@@ -1,6 +1,6 @@
 # Babel Translator December 2023 Release
 
 - Babel: [2023nov5](https://stars.renci.org/var/babel_outputs/2023nov5/) (roughly Babel
-  [v1.3.0](https://github.com/TranslatorSRI/Babel/releases/tag/v1.3.0))
+  [v1.3.0](https://github.com/NCATSTranslator/Babel/releases/tag/v1.3.0))
 
 Next release: [May 2024](TranslatorMay2024.md)

--- a/releases/TranslatorFuguJuly2024.md
+++ b/releases/TranslatorFuguJuly2024.md
@@ -1,7 +1,7 @@
 # Babel Translator "Fugu" July 2024 Release
 
 * Babel: [2024jul13](https://stars.renci.org/var/babel_outputs/2024jul13/) (approx
-  [Babel 2024jul13](https://github.com/TranslatorSRI/Babel/releases/tag/2024jul13))
+  [Babel 2024jul13](https://github.com/NCATSTranslator/Babel/releases/tag/2024jul13))
   * [CURIE summary](./summaries/2024jul13.json)
 
 Next release: [TranslatorGuppyAugust2024](./TranslatorGuppyAugust2024.md)

--- a/releases/TranslatorGuppyAugust2024.md
+++ b/releases/TranslatorGuppyAugust2024.md
@@ -1,7 +1,7 @@
 # Babel Translator "Guppy" August 2024 Release
 
 * Babel: [2024aug18](https://stars.renci.org/var/babel_outputs/2024aug18/) (approx
-  [Babel 1.8.0](https://github.com/TranslatorSRI/Babel/releases/tag/v1.8.0))
+  [Babel 1.8.0](https://github.com/NCATSTranslator/Babel/releases/tag/v1.8.0))
   * [CURIE summary](./summaries/2024aug18.json)
 
 Next release: [Translator "Hammerhead" November 2024](./TranslatorHammerheadNovember2024.md)
@@ -12,12 +12,12 @@ Previous release: [TranslatorFuguJuly2024](./TranslatorFuguJuly2024.md)
 * Added support for generating DuckDB and Parquet files from the compendium and synonym files,
   allowing us to run queries such as looking for all the identically labeled cliques across
   all the compendia. Increased Babel Outputs file size to support DuckDB.
-* Added labels from DrugBank (<https://github.com/TranslatorSRI/Babel/pull/335>).
-* Improved cell anatomy concords using Wikidata (<https://github.com/TranslatorSRI/Babel/pull/329>).
+* Added labels from DrugBank (<https://github.com/NCATSTranslator/Babel/pull/335>).
+* Improved cell anatomy concords using Wikidata (<https://github.com/NCATSTranslator/Babel/pull/329>).
 * Added manual concords for the DrugChemical conflation
-  (<https://github.com/TranslatorSRI/Babel/pull/337>).
+  (<https://github.com/NCATSTranslator/Babel/pull/337>).
 * Wrote a script for comparing between two summary files
-  (<https://github.com/TranslatorSRI/Babel/pull/320>).
+  (<https://github.com/NCATSTranslator/Babel/pull/320>).
 * Added timestamping as an option to Wget.
 * Reorganized primary label determination so that we can include it in compendia files as well.
   * This isn't currently used by the loader, but might be in the future. For now, this is only
@@ -25,7 +25,7 @@ Previous release: [TranslatorFuguJuly2024](./TranslatorFuguJuly2024.md)
 
 ## Bugfixes
 
-* Added additional ENSEMBL datasets to skip (<https://github.com/TranslatorSRI/Babel/pull/297>).
+* Added additional ENSEMBL datasets to skip (<https://github.com/NCATSTranslator/Babel/pull/297>).
 * Fixed a bug in recognizing the end of file when reading the PubChem ID and SMILES files.
 * Fixed the lack of `clique_identifier_count` in leftover UMLS output.
 * Fixed unraised exception in Ensembl BioMart download.

--- a/releases/TranslatorGuppyAugust2024.md
+++ b/releases/TranslatorGuppyAugust2024.md
@@ -13,7 +13,8 @@ Previous release: [TranslatorFuguJuly2024](./TranslatorFuguJuly2024.md)
   allowing us to run queries such as looking for all the identically labeled cliques across
   all the compendia. Increased Babel Outputs file size to support DuckDB.
 * Added labels from DrugBank (<https://github.com/NCATSTranslator/Babel/pull/335>).
-* Improved cell anatomy concords using Wikidata (<https://github.com/NCATSTranslator/Babel/pull/329>).
+* Improved cell anatomy concords using Wikidata
+  (<https://github.com/NCATSTranslator/Babel/pull/329>).
 * Added manual concords for the DrugChemical conflation
   (<https://github.com/NCATSTranslator/Babel/pull/337>).
 * Wrote a script for comparing between two summary files

--- a/releases/TranslatorHammerheadNovember2024.md
+++ b/releases/TranslatorHammerheadNovember2024.md
@@ -1,8 +1,8 @@
 # Babel Translator "Hammerhead" November 2024 Release
 
 - Babel: [2024oct24](https://stars.renci.org/var/babel_outputs/2024oct24/)
-  ([tagged 2024oct24](https://github.com/TranslatorSRI/Babel/releases/tag/2024oct24),
-  approx [Babel 1.8.0](https://github.com/TranslatorSRI/Babel/releases/tag/v1.8.0))
+  ([tagged 2024oct24](https://github.com/NCATSTranslator/Babel/releases/tag/2024oct24),
+  approx [Babel 1.8.0](https://github.com/NCATSTranslator/Babel/releases/tag/v1.8.0))
   - [CURIE summary](./summaries/2024oct24.json)
 
 Next release: [Babel 2025jan23](./2025jan23.md)
@@ -10,7 +10,7 @@ Previous release: [Translator Guppy August 2024](./TranslatorGuppyAugust2024.md)
 
 ## New features
 
-- Added taxon information to proteins ([#349](https://github.com/TranslatorSRI/Babel/pull/349))
+- Added taxon information to proteins ([#349](https://github.com/NCATSTranslator/Babel/pull/349))
 
 ## Bugfixes
 
@@ -21,4 +21,4 @@ Previous release: [Translator Guppy August 2024](./TranslatorGuppyAugust2024.md)
 - Upgraded RxNorm to 09032024.
 - Changed NCBIGene download from FTP to HTTP.
 - Increased DRUG_CHEMICAL_SMALLER_MAX_LABEL_LENGTH (introduced in
-  [#330](https://github.com/TranslatorSRI/Babel/pull/330)) from 30 to 40.
+  [#330](https://github.com/NCATSTranslator/Babel/pull/330)) from 30 to 40.

--- a/releases/TranslatorMay2024.md
+++ b/releases/TranslatorMay2024.md
@@ -1,7 +1,7 @@
 # Babel Translator May 2024 Release
 
 * Babel: [2024mar24](https://stars.renci.org/var/babel_outputs/2024mar24/) (approx
-  [Babel v1.5.0](https://github.com/TranslatorSRI/Babel/releases/tag/v1.5.0))
+  [Babel v1.5.0](https://github.com/NCATSTranslator/Babel/releases/tag/v1.5.0))
   * [CURIE summary](./summaries/2024mar24.json)
 
 Next release: [Translator "Fugu" July 2024](TranslatorFuguJuly2024.md)
@@ -11,22 +11,22 @@ Next release: [Translator "Fugu" July 2024](TranslatorFuguJuly2024.md)
 * [New identifiers] 36.9 million PubMed IDs (e.g. `PMID:25061375`) have been added as
   `biolink:JournalArticle`, as well as the mappings to PMC (e.g. `PMC:PMC4109484`) and DOIs (e.g.
   `doi:10.3897/zookeys.420.7089`) that are included in PubMed. Details in
-  [TranslatorSRI/Babel#227](https://github.com/TranslatorSRI/Babel/pull/227).
+  [NCATSTranslator/Babel#227](https://github.com/NCATSTranslator/Babel/pull/227).
 * Fixed type determination for DrugChemical conflation. Details in
-  [TranslatorSRI/Babel#266](https://github.com/TranslatorSRI/Babel/pull/266).
+  [NCATSTranslator/Babel#266](https://github.com/NCATSTranslator/Babel/pull/266).
 * Synonym files now include the clique identifier count (the number of identifiers in each clique)
   in synonyms file.
 * Minor fixes.
 
 ## Releases since [December 2023](TranslatorDecember2023)
 
-* [Babel v1.5.0](https://github.com/TranslatorSRI/Babel/releases/tag/v1.5.0):
+* [Babel v1.5.0](https://github.com/NCATSTranslator/Babel/releases/tag/v1.5.0):
   * Normalize DrugChemical conflation IDs by @gaurav in #250
   * Fix DrugChemical conflation typing by @gaurav in #266
   * Add PubMed IDs by @gaurav in #227
   * Added clique identifier count to synonyms by @gaurav in #228
   * Minor fixes
-* [Babel v1.4.0](https://github.com/TranslatorSRI/Babel/releases/tag/v1.4.0):
+* [Babel v1.4.0](https://github.com/NCATSTranslator/Babel/releases/tag/v1.4.0):
   * Upgraded Biolink Model to v4.1.6.
   * Upgraded RxNorm to 03042024.
   * Upgraded Dockerfile to Python 3.12.

--- a/releases/v1.11.md
+++ b/releases/v1.11.md
@@ -1,6 +1,6 @@
 # Babel v1.11
 
-- Babel: [Babel v1.11](https://github.com/TranslatorSRI/Babel/releases/tag/v1.11)
+- Babel: [Babel v1.11](https://github.com/NCATSTranslator/Babel/releases/tag/v1.11)
 
 Next release: [2025sep1](./2025sep1.md)
 Previous release: [2025mar31](./2025mar31.md)
@@ -9,16 +9,16 @@ Previous release: [2025mar31](./2025mar31.md)
 
 - [MAJOR] @uhbrar discovered that some information content values appeared odd, and @gaurav realized
   this was because the information content comparison was being carried out as a string, not as
-  number. Fixed in [PR #467](https://github.com/TranslatorSRI/Babel/pull/467).
-- Minor fixes ([PR #474](https://github.com/TranslatorSRI/Babel/pull/474),
-  [PR #475](https://github.com/TranslatorSRI/Babel/pull/475),
-  [PR #476](https://github.com/TranslatorSRI/Babel/pull/476)).
+  number. Fixed in [PR #467](https://github.com/NCATSTranslator/Babel/pull/467).
+- Minor fixes ([PR #474](https://github.com/NCATSTranslator/Babel/pull/474),
+  [PR #475](https://github.com/NCATSTranslator/Babel/pull/475),
+  [PR #476](https://github.com/NCATSTranslator/Babel/pull/476)).
 
 ## New features
 
 - [MAJOR] Added metadata files to all concords (next to each output as `metadata-[concord].yaml`)
   and compendia (`babel_outputs/metadata/[compendia].txt.yaml`) (
-  [PR #459](https://github.com/TranslatorSRI/Babel/pull/459)).
+  [PR #459](https://github.com/NCATSTranslator/Babel/pull/459)).
   - Compendia metadata files are combined from the individual concords being combined. Snakemake
     tracks which metadata files go into which compendia.
   - Helper code allows the prefixes in each concord to be summarized.
@@ -27,37 +27,37 @@ Previous release: [2025mar31](./2025mar31.md)
   - For now, these files are pretty inconsistently structured, but hopefully we'll structure them
     better in the future.
 - Add a semantic type blocklist to UMLS, which allow us to exclude proteins from chemical (
-  [PR #444](https://github.com/TranslatorSRI/Babel/pull/444),
-  [PR #469](https://github.com/TranslatorSRI/Babel/pull/469)).
+  [PR #444](https://github.com/NCATSTranslator/Babel/pull/444),
+  [PR #469](https://github.com/NCATSTranslator/Babel/pull/469)).
 - Centralize Ubergraph label/synonym downloads so we don't overwrite them from other sources (
-  [PR #438](https://github.com/TranslatorSRI/Babel/pull/438),
-  [PR #470](https://github.com/TranslatorSRI/Babel/pull/470)).
+  [PR #438](https://github.com/NCATSTranslator/Babel/pull/438),
+  [PR #470](https://github.com/NCATSTranslator/Babel/pull/470)).
 - Replaced config.json with config.yaml
-  ([PR #460](https://github.com/TranslatorSRI/Babel/pull/460)).
-- Detect duplicate clique leaders ([PR #431](https://github.com/TranslatorSRI/Babel/pull/431)).
+  ([PR #460](https://github.com/NCATSTranslator/Babel/pull/460)).
+- Detect duplicate clique leaders ([PR #431](https://github.com/NCATSTranslator/Babel/pull/431)).
 - Fix BioMart downloads with more than ~10 attributes
-  ([PR #458](https://github.com/TranslatorSRI/Babel/pull/458)).
+  ([PR #458](https://github.com/NCATSTranslator/Babel/pull/458)).
 - CHEMBL labels that are identical to the CHEMBL ID are now removed
-  ([PR #446](https://github.com/TranslatorSRI/Babel/pull/446)).
-- Added Translator documentation ([PR #292](https://github.com/TranslatorSRI/Babel/pull/292)).
+  ([PR #446](https://github.com/NCATSTranslator/Babel/pull/446)).
+- Added Translator documentation ([PR #292](https://github.com/NCATSTranslator/Babel/pull/292)).
 
 ## Updates
 
 - When working with InChiKeys from UNICHEM, we previously removed any xrefs where two identifiers
   were mapped to the same InChiKey. On delving into this, @bizon realized that we only needed to do
   this for UNII, KEGG.COMPOUND and DrugCentral CURIEs (
-  [PR #508](https://github.com/TranslatorSRI/Babel/pull/508)).
+  [PR #508](https://github.com/NCATSTranslator/Babel/pull/508)).
 - Improved NCBIGene label, synonyms and descriptions
-  ([PR #436](https://github.com/TranslatorSRI/Babel/pull/436)).
-- Expanded NCBITaxon synonyms ([PR #425](https://github.com/TranslatorSRI/Babel/pull/425)).
+  ([PR #436](https://github.com/NCATSTranslator/Babel/pull/436)).
+- Expanded NCBITaxon synonyms ([PR #425](https://github.com/NCATSTranslator/Babel/pull/425)).
 - Improved how we access Biolink Model Toolkit
-  ([PR #465](https://github.com/TranslatorSRI/Babel/pull/465)).
+  ([PR #465](https://github.com/NCATSTranslator/Babel/pull/465)).
 - Replace renci-python-image with the GitHub Packages version
-  ([PR #464](https://github.com/TranslatorSRI/Babel/pull/464)).
+  ([PR #464](https://github.com/NCATSTranslator/Babel/pull/464)).
 - Added database sizes to previous release notes
-  ([PR #442](https://github.com/TranslatorSRI/Babel/pull/442)).
-- Cleaned up redundant code ([PR #472](https://github.com/TranslatorSRI/Babel/pull/472)).
-- Minor updates ([PR #455](https://github.com/TranslatorSRI/Babel/pull/455/files)).
+  ([PR #442](https://github.com/NCATSTranslator/Babel/pull/442)).
+- Cleaned up redundant code ([PR #472](https://github.com/NCATSTranslator/Babel/pull/472)).
+- Minor updates ([PR #455](https://github.com/NCATSTranslator/Babel/pull/455/files)).
 
 ## Summary
 

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -914,7 +914,7 @@ def create_typed_sets(eqsets, types):
                     # everything we're _sure_ is a biolink:MolecularMixture into a separate clique, and leave all
                     # the other identifiers as a biolink:SmallMolecule.
                     #
-                    # First reported in https://github.com/TranslatorSRI/Babel/issues/83
+                    # First reported in https://github.com/NCATSTranslator/Babel/issues/83
                     molecular_mixture_ids = set()
                     all_other_ids = set()
                     for eq_id in equivalent_ids:

--- a/src/createcompendia/gene.py
+++ b/src/createcompendia/gene.py
@@ -70,7 +70,7 @@ def build_gene_ensembl_relationships(ensembl_dir, outfile, metadata_yaml):
                                     # If the ENSEMBL ID is a version string (e.g. ENSEMBL:ENSP00000263368.3),
                                     # then we should indicate that this is identical to the non-versioned string
                                     # as well.
-                                    # See https://github.com/TranslatorSRI/Babel/issues/72 for details.
+                                    # See https://github.com/NCATSTranslator/Babel/issues/72 for details.
                                     res = re.match(r"^([A-Z]+\d+)\.\d+", gene_id)
                                     if res:
                                         ensembl_id_without_version = res.group(1)
@@ -197,7 +197,7 @@ def build_gene_ncbi_ensembl_relationships(infile, ncbi_idfile, outfile, metadata
             # If the ENSEMBL ID is a version string (e.g. ENSEMBL:ENSP00000263368.3),
             # then we should indicate that this is identical to the non-versioned string
             # as well.
-            # See https://github.com/TranslatorSRI/Babel/issues/72 for details.
+            # See https://github.com/NCATSTranslator/Babel/issues/72 for details.
             res = re.match(r"^([A-Z]+\d+)\.\d+", x[2])
             if res:
                 ensembl_id_without_version = res.group(1)

--- a/src/createcompendia/leftover_umls.py
+++ b/src/createcompendia/leftover_umls.py
@@ -29,7 +29,7 @@ def write_leftover_umls(metadata_yaml, compendia, umls_labels_filename, mrconso,
     Search for "leftover" UMLS concepts, i.e. those that are defined and valid in MRCONSO but are not
     mapped to a concept in Babel.
 
-    As described in https://github.com/TranslatorSRI/NodeNormalization/issues/119#issuecomment-1154751451
+    As described in https://github.com/NCATSTranslator/NodeNormalization/issues/119#issuecomment-1154751451
 
     :param compendia: A list of compendia to collect.
     :param umls_labels_filename: The filename of the UMLS labels file to use for this compendium (e.g. 'babel_downloads/UMLS/labels').
@@ -223,7 +223,7 @@ def write_leftover_umls(metadata_yaml, compendia, umls_labels_filename, mrconso,
                         synonyms_by_id[id] = set()
                     synonyms_by_id[id].add(synonym)
 
-                    # We don't record the synonym relation (https://github.com/TranslatorSRI/Babel/pull/113#issuecomment-1516450124),
+                    # We don't record the synonym relation (https://github.com/NCATSTranslator/Babel/pull/113#issuecomment-1516450124),
                     # so we don't need to write that out now.
 
         logger.info(f"Collected synonyms for {len(synonyms_by_id)} UMLS IDs into the leftover UMLS synonyms file.")

--- a/src/createcompendia/protein.py
+++ b/src/createcompendia/protein.py
@@ -166,7 +166,7 @@ def build_protein_uniprotkb_ensemble_relationships(infile, outfile, metadata_yam
                 # If the ENSEMBL ID is a version string (e.g. ENSEMBL:ENSP00000263368.3),
                 # then we should indicate that this is identical to the non-versioned string
                 # as well.
-                # See https://github.com/TranslatorSRI/Babel/issues/72 for details.
+                # See https://github.com/NCATSTranslator/Babel/issues/72 for details.
                 res = re.match(r"^([A-Z]+\d+)\.\d+", x[2])
                 if res:
                     ensembl_id_without_version = res.group(1)

--- a/src/createcompendia/publications.py
+++ b/src/createcompendia/publications.py
@@ -84,7 +84,7 @@ def verify_pubmed_download_against_md5(pubmed_filename, md5_filename):
 def verify_pubmed_downloads(pubmed_directories, done_filename, pubmed_base="https://ftp.ncbi.nlm.nih.gov/pubmed/"):
     """
     download_pubmed() does a good job of downloading all the PubMed files, but every once in a while the download
-    is corrupted (https://github.com/TranslatorSRI/Babel/issues/352). Luckily, PubMed also gives up `.md5` files
+    is corrupted (https://github.com/NCATSTranslator/Babel/issues/352). Luckily, PubMed also gives up `.md5` files
     for all the downloaded files, so we can use those to verify each file. If a file is incorrect, we can re-download
     it using the more reliable HTTPS URL.
 
@@ -140,7 +140,7 @@ def parse_pubmed_into_tsvs(baseline_dir, updatefiles_dir, titles_file, status_fi
         # Track PubMed article statuses. In theory the final PubMed entry should have all the dates, which should
         # tell us the final status of a publication, but really we just want to know if the article has ever been
         # marked as retracted, so instead we track every status that has ever been attached to any article. We
-        # don't have a way of tracking properties yet (https://github.com/TranslatorSRI/Babel/issues/155), so for now
+        # don't have a way of tracking properties yet (https://github.com/NCATSTranslator/Babel/issues/155), so for now
         # we write this out in JSON to the status_file.
         pmid_status = defaultdict(set)
 

--- a/src/datahandlers/chembl.py
+++ b/src/datahandlers/chembl.py
@@ -81,7 +81,7 @@ class ChemblRDF:
                 chemblid = iterm[:-1].split("/")[-1]
                 label = parse_rdf_literal(ilabel)
 
-                # Sometimes the CHEMBL label is identical to the chemblid. We don't want those (https://github.com/TranslatorSRI/Babel/issues/430).
+                # Sometimes the CHEMBL label is identical to the chemblid. We don't want those (https://github.com/NCATSTranslator/Babel/issues/430).
                 if label == chemblid:
                     label = ''
 

--- a/src/datahandlers/ncbigene.py
+++ b/src/datahandlers/ncbigene.py
@@ -104,7 +104,7 @@ def pull_ncbigene_labels_synonyms_and_taxa(gene_info_filename, labels_filename, 
 
             # Figure out the label. We would ideally go with:
             #   {Symbol_from_nomenclature_authority || Symbol}: {Full_name_from_nomenclature_authority}
-            # But falling back cleanly. As per https://github.com/TranslatorSRI/Babel/issues/429
+            # But falling back cleanly. As per https://github.com/NCATSTranslator/Babel/issues/429
             best_symbol = get_ncbigene_field(row, header, "Symbol_from_nomenclature_authority")
             if not best_symbol:
                 # Fallback to the "Symbol" field.

--- a/src/datahandlers/ncbitaxon.py
+++ b/src/datahandlers/ncbitaxon.py
@@ -40,7 +40,7 @@ def make_labels_and_synonyms(infile, labelfile, synfile, propfilegz):
 
             name_class = parts[3]
             # name_class can be one of the following values (counts from May 1, 2023 release of NCBITaxon,
-            # possibly -- from https://github.com/TranslatorSRI/NameResolution/issues/71#issuecomment-1618909473):
+            # possibly -- from https://github.com/NCATSTranslator/NameResolution/issues/71#issuecomment-1618909473):
             #      25 	genbank acronym             <no examples in Mar 13, 2025>
             #     230 	blast name                  "false scorpions"
             #     667 	in-part                     "Nucleopolyhedrovirus"

--- a/src/datahandlers/reactome.py
+++ b/src/datahandlers/reactome.py
@@ -49,7 +49,7 @@ def write_ids(infile, idfile):
 def parse_element_for_ids(e, lfile):
     oid = e["stId"]
     rtype = e["type"]
-    # For CellDevelopmentStep, see discussion at https://github.com/TranslatorSRI/Babel/issues/277
+    # For CellDevelopmentStep, see discussion at https://github.com/NCATSTranslator/Babel/issues/277
     btypes = {
         "Pathway": PATHWAY,
         "TopLevelPathway": PATHWAY,

--- a/src/datahandlers/umls.py
+++ b/src/datahandlers/umls.py
@@ -75,7 +75,7 @@ def write_umls_ids(mrsty, category_map, umls_output, prefix=UMLS, blocklist_umls
     #   C0000005|T121|A1.4.1.1.1|Pharmacologic Substance|AT17575038|256|
     #   C0000005|T130|A1.4.1.1.4|Indicator, Reagent, or Diagnostic Aid|AT17634323|256|
     #   C0000039|T109|A1.4.1.2.1|Organic Chemical|AT45562015|256|
-    # (see https://github.com/TranslatorSRI/Babel/issues/200#issuecomment-1789550364 for another example and
+    # (see https://github.com/NCATSTranslator/Babel/issues/200#issuecomment-1789550364 for another example and
     #  https://www.ncbi.nlm.nih.gov/books/NBK9685/table/ch03.Tf/ for column information.)
     #
     # This means that we can't blacklist UMLS types by just skipping those lines: instead, we will need to load

--- a/src/exporters/kgx.py
+++ b/src/exporters/kgx.py
@@ -1,7 +1,7 @@
 # Once we generate the compendium files, we need to convert them into the
 # Knowledge Graph Exchange (KGX, https://github.com/biolink/kgx) format.
 # This file provides code for doing that, based on the code from
-# https://github.com/TranslatorSRI/NodeNormalization/blob/68096b2f16e6c2eedb699178ace71cea98dc794f/node_normalizer/loader.py#L70-L208
+# https://github.com/NCATSTranslator/NodeNormalization/blob/68096b2f16e6c2eedb699178ace71cea98dc794f/node_normalizer/loader.py#L70-L208
 import gzip
 import hashlib
 import json
@@ -20,7 +20,7 @@ def convert_compendium_to_kgx(compendium_filename, kgx_nodes_filename, kgx_edges
     """
     Convert a compendium file to KGX (https://github.com/biolink/kgx) format.
 
-    Based on the code in https://github.com/TranslatorSRI/NodeNormalization/blob/68096b2f16e6c2eedb699178ace71cea98dc794f/node_normalizer/loader.py#L70-L208
+    Based on the code in https://github.com/NCATSTranslator/NodeNormalization/blob/68096b2f16e6c2eedb699178ace71cea98dc794f/node_normalizer/loader.py#L70-L208
 
     :param compendium_filename: The compendium file to convert.
     :param kgx_nodes_gz_filename: The KGX nodes gzipped file to write out.

--- a/src/reports/duckdb_reports.py
+++ b/src/reports/duckdb_reports.py
@@ -105,7 +105,7 @@ def generate_curie_report(parquet_root, duckdb_filename, curie_report_json, duck
     """
     Generate a report about all the prefixes within this system.
 
-    See thoughts at https://github.com/TranslatorSRI/Babel/issues/359
+    See thoughts at https://github.com/NCATSTranslator/Babel/issues/359
 
     :param parquet_root: The root directory for the Parquet files. We expect these to have subdirectories named
         e.g. `filename=AnatomicalEntity/Clique.parquet`, etc.
@@ -195,7 +195,7 @@ def generate_clique_leaders_report(parquet_root, duckdb_filename, by_clique_repo
     """
     Generate a report about all the prefixes within this system, grouped by filename.
 
-    See thoughts at https://github.com/TranslatorSRI/Babel/issues/359
+    See thoughts at https://github.com/NCATSTranslator/Babel/issues/359
 
     :param parquet_root: The root directory for the Parquet files. We expect these to have subdirectories named
         e.g. `filename=AnatomicalEntity/Clique.parquet`, etc.

--- a/src/snakefiles/duckdb.snakefile
+++ b/src/snakefiles/duckdb.snakefile
@@ -77,7 +77,7 @@ rule export_synonyms_to_duckdb:
         )
 
 
-# TODO: convert all conflations to Parquet via DuckDB (https://github.com/TranslatorSRI/Babel/issues/378).
+# TODO: convert all conflations to Parquet via DuckDB (https://github.com/NCATSTranslator/Babel/issues/378).
 
 
 # Create `babel_outputs/duckdb/done` once all the files have been converted.

--- a/src/snakefiles/leftover_umls.snakefile
+++ b/src/snakefiles/leftover_umls.snakefile
@@ -4,7 +4,7 @@ import src.snakefiles.util as util
 
 ##
 ## This Snakefile implements the algorithm proposed in
-## https://github.com/TranslatorSRI/NodeNormalization/issues/119#issuecomment-1154751451
+## https://github.com/NCATSTranslator/NodeNormalization/issues/119#issuecomment-1154751451
 ##
 ## 1. Once all the other targets have been generated, we make a list of every UMLS term
 ##    that has been mapped in all the output compendia files.

--- a/tests/datahandlers/test_ensembl.py
+++ b/tests/datahandlers/test_ensembl.py
@@ -55,7 +55,7 @@ def test_pull_ensembl(tmp_path):
     output_dir = pull_ensembl_test_dir / "download"
     os.makedirs(output_dir)
 
-    # Pull a single ENSEMBL file to that. This should trigger https://github.com/TranslatorSRI/Babel/issues/193
+    # Pull a single ENSEMBL file to that. This should trigger https://github.com/NCATSTranslator/Babel/issues/193
     single_query_report = pull_ensembl(output_dir, output_dir / "download_complete", ["choffmanni_gene_ensembl", "hgfemale_gene_ensembl"])
 
     # uamericanus_gene_ensembl should be downloadable as a single file in the above example, but we're going to


### PR DESCRIPTION
Babel, NodeNormalization, and NameResolution have moved to the NCATSTranslator GitHub organization. Update all references across docs, source, and release notes. babel-validation remains in TranslatorSRI and is left unchanged. Closes #661.