### PR TITLE
Add protein/chemical overlap report

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ This folder contains reference documentation for Babel, organized by audience.
 | [Understanding.md](./Understanding.md) | How Babel constructs cliques, chooses preferred identifiers and labels, sources descriptions and IC values, and what split/lumped cliques are. Also covers how to report incorrect cliques. |
 | [DataFormats.md](./DataFormats.md)     | Compendium, synonym, and conflation file format specification.                                                                                                                              |
 | [Conflation.md](./Conflation.md)       | What conflations are, how GeneProtein and DrugChemical conflation work, and when to use them.                                                                                               |
+| [reports/ProteinChemicalOverlap.md](./reports/ProteinChemicalOverlap.md) | The protein/chemical overlap report: cross-references that bridge the chemical/protein boundary, the candidate merges a DrugProtein conflation would apply, and how to read them.   |
 | [Downloads.md](./Downloads.md)         | Where to download published Babel outputs and which formats are available.                                                                                                                  |
 
 ## For pipeline operators — running and deploying

--- a/docs/reports/ProteinChemicalOverlap.md
+++ b/docs/reports/ProteinChemicalOverlap.md
@@ -1,0 +1,87 @@
+# Protein/Chemical overlap report
+
+Babel keeps the chemical compendia (`biolink:ChemicalEntity` and its subtypes — `SmallMolecule`,
+`Drug`, `MolecularMixture`, `ChemicalMixture`, `ComplexMolecularMixture`, `Polypeptide`) separate
+from the protein compendium (`biolink:Protein`). A large family of biomedical concepts straddles
+that boundary, though: complex chemicals that are proteins (human insulin), grouping concepts
+(hemoglobins, insulins), formulations, and amino-acid sequences. Many source vocabularies
+cross-reference a chemical identifier to a protein identifier as if they were the same thing, and
+deciding whether — and how — to combine those concepts is an open question for the Translator
+community (see Babel issues #706, #662, #667, #440, #513, #276).
+
+This report inventories exactly those crossings so the discussion can be grounded in the actual
+data. It is the empirical input to the "list of mappings that would be applied if we combined
+proteins and chemicals" called for in issue #706, and a generalization of the UMLS-only report
+proposed in issue #667.
+
+## What it computes
+
+The report streams the chemical and protein compendia and every concord (cross-reference) file used
+to build them. For each concord edge it asks: did the two endpoints land in *different* cliques, one
+on the chemical side and one on the protein side? Those boundary-crossing edges are the
+cross-references that *would* merge a chemical clique with a protein clique if we acted on them.
+
+Two discriminators are attached to every crossing to help triage it:
+
+- **`chem_has_inchikey`** — whether the chemical clique contains an `INCHIKEY` structure. A
+  structurally-defined small molecule that is cross-referenced to a protein is usually a *bug* (the
+  classic example is `CHEBI:24536` "Pepsin" actually being hexachlorocyclohexane). The genuine
+  "protein-as-chemical" cases (prothrombin, hemoglobin) characteristically have **no** InChIKey, so
+  this single flag separates "probably wrong" from "probably the real philosophical case."
+- **`prot_reaches_gene`** — whether the protein clique is GeneProtein-conflated. If it is, merging
+  it with a chemical would make that chemical normalize all the way to a *gene* — the confusing
+  downstream effect that motivated issue #662.
+
+## Outputs
+
+All files are written under `babel_outputs/reports/protein_chemical/`.
+
+### `bridges.tsv`
+
+One row per boundary-crossing concord edge — the raw evidence. Columns include the source concord
+and predicate that asserted the edge, the bridging subject/object CURIEs and which side the subject
+was on, and, for each side, the clique leader, label, Biolink type, and clique size, plus
+`chem_has_inchikey`, `prot_reaches_gene`, and whether the two leaders share a label (`label_match`).
+
+### `candidate_pairs.tsv`
+
+The bridges deduplicated to unique (chemical clique leader, protein clique leader) pairs, with the
+supporting sources, predicates, and example edges aggregated and a `support_edge_count`. This is the
+SSSOM-able list of mappings that a DrugProtein conflation (#440) would apply, sorted by how much
+evidence supports each pair.
+
+### `duplicate_curies.tsv`
+
+CURIEs that ended up in *both* a chemical clique and a protein clique — the same identifier
+duplicated across two cliques (#276/#513). This is scoped to CURIEs that are referenced by a
+concord, since those are the cross-reference-induced duplicates relevant here and that scope keeps
+the report's memory bounded. For the exhaustive across-the-whole-build duplicate list, query the
+DuckDB `Edge` table instead (one CURIE appearing under two `clique_leader`s).
+
+### `summary.tsv`
+
+Per-source counts — bridge edges, distinct candidate pairs, and the InChIKey and gene-reaching
+splits — with a `TOTAL` row. This is the quick overview: it shows at a glance which sources are
+asserting the most chemical/protein crossings and how many of those involve a structurally-defined
+chemical or a gene-conflated protein.
+
+## Running it
+
+The report is wired into the reports Snakefile and runs as part of the standard reports target once
+the compendia, conflations, and intermediate concords exist:
+
+```bash
+uv run snakemake -c all --rerun-incomplete babel_outputs/reports/protein_chemical/summary.tsv
+```
+
+Because it only needs the final compendia, the GeneProtein conflation, and the concord files (all of
+which persist as intermediate build artifacts), it can be run against a downloaded build without
+rerunning the pipeline — see the intermediate-file download note in `CLAUDE.md`.
+
+## Implementation
+
+`src/reports/protein_chemical_overlap.py` (rule `generate_protein_chemical_overlap_report` in
+`src/snakefiles/reports.snakefile`). The core function,
+`generate_protein_chemical_overlap_report()`, takes explicit compendium, concord, and output paths
+so it is straightforward to unit-test on small fixtures
+(`tests/reports/test_protein_chemical_overlap.py`).

--- a/docs/reports/ProteinChemicalOverlap.md
+++ b/docs/reports/ProteinChemicalOverlap.md
@@ -78,6 +78,45 @@ Because it only needs the final compendia, the GeneProtein conflation, and the c
 which persist as intermediate build artifacts), it can be run against a downloaded build without
 rerunning the pipeline — see the intermediate-file download note in `CLAUDE.md`.
 
+## Future work: conflation-chain impact simulator
+
+This report says *which* protein and chemical cliques a merge would combine. It does not say what
+the merge would *do* downstream — and that is the question that actually blocks consensus (see
+issues #662 and #654). If a chemical clique is merged into a protein clique, and that protein is
+already GeneProtein-conflated, then a chemical CURIE ends up normalizing all the way to a *gene*.
+The `prot_reaches_gene` column flags where this can happen, but it does not show the concrete
+result.
+
+A follow-up tool — a conflation-chain impact simulator (tracked in issue #829) — would close that
+gap. Given a candidate
+mapping (the `candidate_pairs.tsv` produced here, or a curated/filtered subset of it) plus the
+existing `GeneProtein.txt` and `DrugChemical.txt` conflations, it would simulate the *combined*
+effect of a hypothetical DrugProtein conflation layered on top of the conflations we already ship,
+and report, for a probe set of CURIEs, what each one normalizes to **before vs. after** the merge.
+
+The point is to make the scary cases concrete before anything ships. For example: `DRUGBANK:DB00062`
+"Albumin human" is a chemical today; after a DrugProtein merge it would join `UniProtKB:P02768`,
+which is GeneProtein-conflated to `NCBIGene:213` ALB — so a drug CURIE would resolve to a gene. A
+before/after table over the worked examples is the artifact a committee can actually vote on.
+
+### Sketch
+
+- **Inputs:** `candidate_pairs.tsv` (optionally filtered — e.g. drop `chem_has_inchikey` pairs as
+  likely bugs, or keep only `label_match` / high-`support_edge_count` pairs); `GeneProtein.txt`;
+  `DrugChemical.txt`; and a probe CURIE list (the worked examples from #440, #654, and gglusman's
+  set in #440 — prothrombin, hemoglobin, collagen, collagenase, pepsin, albumin, rituximab,
+  cetuximab).
+- **Output:** one row per probe CURIE — its current clique leader/type, and its post-merge clique
+  leader/type — with a flag when a chemical now reaches a gene, or when two previously distinct
+  concepts collapse into one.
+- **Directionality knob:** support both the protein-centric framing of #706 (the merged clique
+  presents as a `biolink:Protein` that contains chemical IDs) and the alternative of inverting the
+  GeneProtein order discussed in #654, so the committee can compare them on the same probes.
+- **Reuse:** `geneprotein.merge()` / `gpkey()` ordering, the DrugChemical conflation logic, and the
+  DuckDB `Edge` table for fast "which clique contains CURIE X" lookups. A curated probe set should
+  be promoted into the `ResolvesWith` / `DoesNotResolveWith` BabelTest fixture started in #513, so
+  every proposed option can be scored against the same canonical cases.
+
 ## Implementation
 
 `src/reports/protein_chemical_overlap.py` (rule `generate_protein_chemical_overlap_report` in

--- a/src/reports/protein_chemical_overlap.py
+++ b/src/reports/protein_chemical_overlap.py
@@ -1,0 +1,465 @@
+"""Protein/Chemical overlap report.
+
+Babel deliberately keeps the chemical compendia (``biolink:ChemicalEntity`` and its subtypes:
+SmallMolecule, Drug, MolecularMixture, ChemicalMixture, ComplexMolecularMixture, Polypeptide)
+separate from the protein compendium (``biolink:Protein``). But a large family of biomedical
+concepts straddles that boundary -- complex chemicals that are proteins (human insulin), grouping
+concepts (hemoglobins, insulins), formulations, and amino-acid sequences -- and many source
+vocabularies cross-reference a chemical identifier to a protein identifier as if they were the same
+thing.
+
+This report inventories exactly those crossings so they can be reviewed by the Translator community
+when deciding whether (and how) to combine proteins and chemicals (see Babel issues #706, #667,
+#440, #513, #276). It produces four files:
+
+* ``bridges`` -- one row per concord (cross-reference) edge whose two endpoints landed in different
+  cliques, one on the chemical side and one on the protein side. This is the raw evidence: the
+  cross-reference that *would* merge a chemical clique with a protein clique, attributed to the
+  source concord that asserts it.
+* ``candidate_pairs`` -- the bridges deduplicated to unique (chemical clique leader, protein clique
+  leader) pairs, with the supporting sources/predicates aggregated. This is the SSSOM-able list of
+  mappings that a DrugProtein conflation (#440) would apply.
+* ``duplicate_curies`` -- CURIEs that ended up in *both* a chemical clique and a protein clique (the
+  same identifier duplicated across two cliques, #276/#513). Scoped to CURIEs that are referenced by
+  a concord, since those are the cross-reference-induced duplicates relevant here and that scope
+  keeps the report's memory bounded; for the exhaustive across-the-whole-build duplicate list, query
+  the DuckDB ``Edge`` table instead (one CURIE in two ``clique_leader``\\ s).
+* ``summary`` -- per-source counts, split by the discriminators below, for a quick overview.
+
+Each candidate carries two discriminators that help triage the cases:
+
+* ``chem_has_inchikey`` -- whether the chemical clique contains an ``INCHIKEY`` structure. A real,
+  structurally-defined small molecule that is cross-referenced to a protein is usually a *bug* (e.g.
+  CHEBI:24536 "Pepsin" actually being hexachlorocyclohexane); the genuine "protein-as-chemical"
+  cases (prothrombin, hemoglobin) characteristically have *no* InChIKey.
+* ``prot_reaches_gene`` -- whether the protein clique is GeneProtein-conflated, i.e. merging it with
+  a chemical would make that chemical normalize all the way to a *gene* -- the confusing downstream
+  effect that motivated issue #662.
+"""
+
+import csv
+import os
+from collections import defaultdict
+from dataclasses import dataclass
+
+import jsonlines
+
+from src.prefixes import INCHIKEY, NCBIGENE, UNIPROTKB
+from src.util import get_logger
+
+logger = get_logger(__name__)
+
+INCHIKEY_PREFIX = INCHIKEY + ":"
+NCBIGENE_PREFIX = NCBIGENE + ":"
+UNIPROTKB_PREFIX = UNIPROTKB + ":"
+
+# How many example bridge edges to record per candidate pair.
+MAX_EXAMPLE_BRIDGES = 3
+
+
+@dataclass
+class CliqueInfo:
+    """The bits of a clique we need to describe a boundary crossing."""
+
+    leader: str
+    label: str
+    biolink_type: str
+    size: int
+    has_inchikey: bool
+
+
+def concord_source_label(path):
+    """Turn a concord file path into a short, stable provenance label.
+
+    ``.../intermediate/chemicals/concords/DrugCentral`` -> ``chemicals/DrugCentral``
+    ``.../intermediate/protein/concords/UNICHEM/UNICHEM_1_7`` -> ``protein/UNICHEM/UNICHEM_1_7``
+
+    Falls back to the basename if ``/concords/`` is not in the path.
+    """
+    norm = path.replace(os.sep, "/")
+    marker = "/concords/"
+    idx = norm.find(marker)
+    if idx == -1:
+        return os.path.basename(path)
+    after = norm[idx + len(marker) :]
+    before = norm[:idx]
+    group = before.rsplit("/", 1)[-1] if "/" in before else before
+    return f"{group}/{after}"
+
+
+def iter_concord_edges(concord_files):
+    """Yield ``(subject, predicate, object, source_label)`` for every triple in the concord files.
+
+    Skips metadata YAML sidecars and malformed (non-three-column) lines.
+    """
+    for path in concord_files:
+        if path.endswith(".yaml") or os.path.basename(path).startswith("metadata-"):
+            continue
+        source = concord_source_label(path)
+        with open(path) as inf:
+            for line_number, line in enumerate(inf, start=1):
+                line = line.rstrip("\n")
+                if not line:
+                    continue
+                parts = line.split("\t")
+                if len(parts) != 3:
+                    logger.warning(f"Skipping malformed concord line {path}:{line_number}: {line!r}")
+                    continue
+                subject, predicate, object_ = parts
+                yield subject, predicate, object_, source
+
+
+def collect_concord_curies(concord_files):
+    """Return the set of every CURIE mentioned on either side of any concord edge."""
+    curies = set()
+    for subject, _predicate, object_, _source in iter_concord_edges(concord_files):
+        curies.add(subject)
+        curies.add(object_)
+    return curies
+
+
+def load_clique_index(compendium_files, restrict_to):
+    """Stream the compendia and return ``{curie: CliqueInfo}`` for every CURIE in ``restrict_to``.
+
+    Memory is bounded by ``len(restrict_to)``, not by the (potentially enormous) compendia: we only
+    keep an entry for CURIEs that actually appear in a concord, since only those can take part in a
+    boundary crossing.
+    """
+    index = {}
+    for path in compendium_files:
+        logger.info(f"Indexing cliques from {path}")
+        with jsonlines.open(path) as reader:
+            for clique in reader:
+                identifiers = [entry["i"] for entry in clique["identifiers"]]
+                relevant = [curie for curie in identifiers if curie in restrict_to]
+                if not relevant:
+                    continue
+                info = CliqueInfo(
+                    leader=identifiers[0],
+                    label=clique.get("preferred_name") or clique["identifiers"][0].get("l") or "",
+                    biolink_type=clique.get("type", ""),
+                    size=len(identifiers),
+                    has_inchikey=any(curie.startswith(INCHIKEY_PREFIX) for curie in identifiers),
+                )
+                for curie in relevant:
+                    index[curie] = info
+    logger.info(f"Indexed {len(index):,} CURIEs from {len(compendium_files)} compendia.")
+    return index
+
+
+def load_geneprotein_proteins(geneprotein_conflation):
+    """Return the set of UniProtKB CURIEs conflated with a gene in the GeneProtein conflation.
+
+    These are the proteins for which a chemical/protein merge would make a chemical normalize all
+    the way to a gene (issue #662). The conflation file is JSONL, one group per line, each group a
+    list of CURIEs (NCBIGene first by construction).
+    """
+    proteins_reaching_gene = set()
+    if not geneprotein_conflation:
+        return proteins_reaching_gene
+    with jsonlines.open(geneprotein_conflation) as reader:
+        for group in reader:
+            if any(curie.startswith(NCBIGENE_PREFIX) for curie in group):
+                for curie in group:
+                    if curie.startswith(UNIPROTKB_PREFIX):
+                        proteins_reaching_gene.add(curie)
+    logger.info(f"Loaded {len(proteins_reaching_gene):,} gene-reaching proteins from {geneprotein_conflation}.")
+    return proteins_reaching_gene
+
+
+def _normalize_label(label):
+    return (label or "").strip().lower()
+
+
+def _curie_prefix(curie):
+    return curie.split(":", 1)[0] if ":" in curie else curie
+
+
+def _bool_str(value):
+    return "true" if value else "false"
+
+
+def _write_duplicate_curies(path, chem_index, prot_index):
+    """Write the CURIEs that appear in both a chemical clique and a protein clique."""
+    shared = sorted(set(chem_index) & set(prot_index))
+    with open(path, "w", newline="") as outf:
+        writer = csv.writer(outf, delimiter="\t", lineterminator="\n")
+        writer.writerow(
+            ["curie", "curie_prefix", "chem_leader", "chem_type", "chem_has_inchikey", "prot_leader", "prot_type"]
+        )
+        for curie in shared:
+            chem = chem_index[curie]
+            prot = prot_index[curie]
+            writer.writerow(
+                [
+                    curie,
+                    _curie_prefix(curie),
+                    chem.leader,
+                    chem.biolink_type,
+                    _bool_str(chem.has_inchikey),
+                    prot.leader,
+                    prot.biolink_type,
+                ]
+            )
+    return len(shared)
+
+
+def generate_protein_chemical_overlap_report(
+    chemical_compendia,
+    protein_compendia,
+    concord_files,
+    bridges_tsv,
+    candidate_pairs_tsv,
+    duplicate_curies_tsv,
+    summary_tsv,
+    geneprotein_conflation=None,
+):
+    """Generate the protein/chemical overlap report.
+
+    :param chemical_compendia: paths to the chemical-side compendia (ChemicalEntity.txt,
+        SmallMolecule.txt, Drug.txt, MolecularMixture.txt, ChemicalMixture.txt,
+        ComplexMolecularMixture.txt, Polypeptide.txt).
+    :param protein_compendia: paths to the protein-side compendia (Protein.txt).
+    :param concord_files: paths to every concord file used to build those compendia. Metadata YAML
+        sidecars are ignored automatically.
+    :param bridges_tsv: output -- one row per boundary-crossing concord edge.
+    :param candidate_pairs_tsv: output -- deduplicated (chem leader, prot leader) merge candidates.
+    :param duplicate_curies_tsv: output -- CURIEs present in both a chemical and a protein clique.
+    :param summary_tsv: output -- per-source summary counts.
+    :param geneprotein_conflation: optional GeneProtein.txt conflation, used to flag proteins whose
+        merge would reach a gene.
+    :return: a dict of summary counts (also useful for tests/logging).
+    """
+    for path in (bridges_tsv, candidate_pairs_tsv, duplicate_curies_tsv, summary_tsv):
+        os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+
+    logger.info("Collecting CURIEs referenced by concords...")
+    concord_curies = collect_concord_curies(concord_files)
+    logger.info(f"{len(concord_curies):,} distinct CURIEs referenced by {len(concord_files)} concord files.")
+
+    chem_index = load_clique_index(chemical_compendia, concord_curies)
+    prot_index = load_clique_index(protein_compendia, concord_curies)
+    gene_reaching_proteins = load_geneprotein_proteins(geneprotein_conflation)
+
+    duplicate_count = _write_duplicate_curies(duplicate_curies_tsv, chem_index, prot_index)
+    logger.info(f"Wrote {duplicate_count:,} duplicate CURIEs to {duplicate_curies_tsv}.")
+
+    # Accumulators for the deduplicated candidate pairs and the per-source summary.
+    pairs = {}
+    source_edge_count = defaultdict(int)
+    source_pairs = defaultdict(set)
+    source_with_inchikey = defaultdict(int)
+    source_without_inchikey = defaultdict(int)
+    source_reaches_gene = defaultdict(int)
+
+    bridge_edge_count = 0
+    with open(bridges_tsv, "w", newline="") as bridges_out:
+        writer = csv.writer(bridges_out, delimiter="\t", lineterminator="\n")
+        writer.writerow(
+            [
+                "source_concord",
+                "predicate",
+                "bridge_subject",
+                "bridge_object",
+                "subject_side",
+                "chem_curie",
+                "chem_leader",
+                "chem_leader_label",
+                "chem_type",
+                "chem_clique_size",
+                "chem_has_inchikey",
+                "prot_curie",
+                "prot_leader",
+                "prot_leader_label",
+                "prot_type",
+                "prot_clique_size",
+                "prot_reaches_gene",
+                "label_match",
+            ]
+        )
+
+        for subject, predicate, object_, source in iter_concord_edges(concord_files):
+            # Only edges that genuinely cross the chemical/protein boundary are of interest.
+            if subject in chem_index and object_ in prot_index:
+                chem_curie, prot_curie, subject_side = subject, object_, "chemical"
+            elif subject in prot_index and object_ in chem_index:
+                chem_curie, prot_curie, subject_side = object_, subject, "protein"
+            else:
+                continue
+
+            chem = chem_index[chem_curie]
+            prot = prot_index[prot_curie]
+            reaches_gene = prot.leader in gene_reaching_proteins
+            label_match = _normalize_label(chem.label) != "" and _normalize_label(chem.label) == _normalize_label(
+                prot.label
+            )
+
+            bridge_edge_count += 1
+            writer.writerow(
+                [
+                    source,
+                    predicate,
+                    subject,
+                    object_,
+                    subject_side,
+                    chem_curie,
+                    chem.leader,
+                    chem.label,
+                    chem.biolink_type,
+                    chem.size,
+                    _bool_str(chem.has_inchikey),
+                    prot_curie,
+                    prot.leader,
+                    prot.label,
+                    prot.biolink_type,
+                    prot.size,
+                    _bool_str(reaches_gene),
+                    _bool_str(label_match),
+                ]
+            )
+
+            # Per-source summary.
+            source_edge_count[source] += 1
+            source_pairs[source].add((chem.leader, prot.leader))
+            if chem.has_inchikey:
+                source_with_inchikey[source] += 1
+            else:
+                source_without_inchikey[source] += 1
+            if reaches_gene:
+                source_reaches_gene[source] += 1
+
+            # Deduplicated candidate pair.
+            key = (chem.leader, prot.leader)
+            agg = pairs.get(key)
+            if agg is None:
+                agg = {
+                    "chem_leader": chem.leader,
+                    "chem_label": chem.label,
+                    "chem_type": chem.biolink_type,
+                    "chem_size": chem.size,
+                    "chem_has_inchikey": chem.has_inchikey,
+                    "prot_leader": prot.leader,
+                    "prot_label": prot.label,
+                    "prot_type": prot.biolink_type,
+                    "prot_size": prot.size,
+                    "prot_reaches_gene": reaches_gene,
+                    "label_match": label_match,
+                    "edge_count": 0,
+                    "sources": set(),
+                    "predicates": set(),
+                    "example_bridges": [],
+                }
+                pairs[key] = agg
+            agg["edge_count"] += 1
+            agg["sources"].add(source)
+            agg["predicates"].add(predicate)
+            if len(agg["example_bridges"]) < MAX_EXAMPLE_BRIDGES:
+                agg["example_bridges"].append(f"{subject} {predicate} {object_}")
+
+    _write_candidate_pairs(candidate_pairs_tsv, pairs)
+    logger.info(f"Wrote {len(pairs):,} candidate pairs ({bridge_edge_count:,} bridge edges) to {candidate_pairs_tsv}.")
+
+    _write_summary(
+        summary_tsv,
+        source_edge_count,
+        source_pairs,
+        source_with_inchikey,
+        source_without_inchikey,
+        source_reaches_gene,
+    )
+
+    counts = {
+        "concord_curies": len(concord_curies),
+        "chemical_indexed": len(chem_index),
+        "protein_indexed": len(prot_index),
+        "duplicate_curies": duplicate_count,
+        "bridge_edges": bridge_edge_count,
+        "candidate_pairs": len(pairs),
+    }
+    logger.info(f"Protein/chemical overlap report complete: {counts}")
+    return counts
+
+
+def _write_candidate_pairs(path, pairs):
+    rows = sorted(pairs.values(), key=lambda agg: (-agg["edge_count"], agg["chem_leader"], agg["prot_leader"]))
+    with open(path, "w", newline="") as outf:
+        writer = csv.writer(outf, delimiter="\t", lineterminator="\n")
+        writer.writerow(
+            [
+                "chem_leader",
+                "chem_leader_label",
+                "chem_type",
+                "chem_clique_size",
+                "chem_has_inchikey",
+                "prot_leader",
+                "prot_leader_label",
+                "prot_type",
+                "prot_clique_size",
+                "prot_reaches_gene",
+                "label_match",
+                "support_edge_count",
+                "sources",
+                "predicates",
+                "example_bridges",
+            ]
+        )
+        for agg in rows:
+            writer.writerow(
+                [
+                    agg["chem_leader"],
+                    agg["chem_label"],
+                    agg["chem_type"],
+                    agg["chem_size"],
+                    _bool_str(agg["chem_has_inchikey"]),
+                    agg["prot_leader"],
+                    agg["prot_label"],
+                    agg["prot_type"],
+                    agg["prot_size"],
+                    _bool_str(agg["prot_reaches_gene"]),
+                    _bool_str(agg["label_match"]),
+                    agg["edge_count"],
+                    "|".join(sorted(agg["sources"])),
+                    "|".join(sorted(agg["predicates"])),
+                    "|".join(agg["example_bridges"]),
+                ]
+            )
+
+
+def _write_summary(
+    path,
+    source_edge_count,
+    source_pairs,
+    source_with_inchikey,
+    source_without_inchikey,
+    source_reaches_gene,
+):
+    with open(path, "w", newline="") as outf:
+        writer = csv.writer(outf, delimiter="\t", lineterminator="\n")
+        writer.writerow(
+            [
+                "source_concord",
+                "bridge_edges",
+                "distinct_candidate_pairs",
+                "edges_with_chem_inchikey",
+                "edges_without_chem_inchikey",
+                "edges_prot_reaches_gene",
+            ]
+        )
+        totals = [0, 0, 0, 0, 0]
+        for source in sorted(source_edge_count, key=lambda s: (-source_edge_count[s], s)):
+            row = [
+                source_edge_count[source],
+                len(source_pairs[source]),
+                source_with_inchikey[source],
+                source_without_inchikey[source],
+                source_reaches_gene[source],
+            ]
+            writer.writerow([source, *row])
+            for i, value in enumerate(row):
+                totals[i] += value
+        # The distinct-pairs total is across all sources (a pair can be supported by several sources).
+        all_pairs = set()
+        for source_pair_set in source_pairs.values():
+            all_pairs |= source_pair_set
+        totals[1] = len(all_pairs)
+        writer.writerow(["TOTAL", *totals])

--- a/src/snakefiles/reports.snakefile
+++ b/src/snakefiles/reports.snakefile
@@ -1,5 +1,6 @@
 from src.reports import report_tables
 from src.snakefiles.util import get_all_compendia, get_all_synonyms, get_all_gzipped
+import glob
 import os
 
 from src.reports.compendia_per_file_reports import (
@@ -7,6 +8,7 @@ from src.reports.compendia_per_file_reports import (
     generate_content_report_for_compendium,
     summarize_content_report_for_compendia,
 )
+from src.reports.protein_chemical_overlap import generate_protein_chemical_overlap_report
 
 # Some paths we will use at multiple times in these reports.
 compendia_path = config["output_directory"] + "/compendia"
@@ -150,6 +152,44 @@ rule generate_mapping_sources_table:
         report_tables.generate_mapping_sources_table(input.metadata_yaml_files, output.mapping_sources_table)
 
 
+# Inventory cross-references that bridge the chemical/protein boundary, so the Translator community
+# can review which protein and chemical cliques a merge would combine (issues #706, #667, #440).
+rule generate_protein_chemical_overlap_report:
+    input:
+        # Gate on every output (compendia, conflations) and intermediate concord having been built.
+        config["output_directory"] + "/reports/outputs_done",
+    output:
+        bridges=config["output_directory"] + "/reports/protein_chemical/bridges.tsv",
+        candidate_pairs=config["output_directory"] + "/reports/protein_chemical/candidate_pairs.tsv",
+        duplicate_curies=config["output_directory"] + "/reports/protein_chemical/duplicate_curies.tsv",
+        summary=config["output_directory"] + "/reports/protein_chemical/summary.tsv",
+    benchmark:
+        config["output_directory"] + "/benchmarks/generate_protein_chemical_overlap_report.tsv"
+    run:
+        chemical_compendia = [os.path.join(compendia_path, filename) for filename in config["chemical_outputs"]]
+        protein_compendia = [os.path.join(compendia_path, filename) for filename in config["protein_outputs"]]
+        concord_files = sorted(
+            path
+            for concord_dir in (
+                os.path.join(config["intermediate_directory"], "chemicals", "concords"),
+                os.path.join(config["intermediate_directory"], "protein", "concords"),
+            )
+            for path in glob.glob(os.path.join(concord_dir, "**"), recursive=True)
+            if os.path.isfile(path)
+        )
+        geneprotein_conflation = os.path.join(conflations_path, config["geneprotein_outputs"][0])
+        generate_protein_chemical_overlap_report(
+            chemical_compendia=chemical_compendia,
+            protein_compendia=protein_compendia,
+            concord_files=concord_files,
+            bridges_tsv=output.bridges,
+            candidate_pairs_tsv=output.candidate_pairs,
+            duplicate_curies_tsv=output.duplicate_curies,
+            summary_tsv=output.summary,
+            geneprotein_conflation=geneprotein_conflation,
+        )
+
+
 # Check that all the reports were built correctly.
 rule all_reports:
     input:
@@ -160,6 +200,7 @@ rule all_reports:
         config["output_directory"] + "/reports/tables/prefix_table.csv",
         config["output_directory"] + "/reports/tables/cliques_table.csv",
         config["output_directory"] + "/reports/tables/mapping_sources_table.csv",
+        config["output_directory"] + "/reports/protein_chemical/summary.tsv",
     output:
         x=config["output_directory"] + "/reports/reports_done",
     shell:

--- a/tests/reports/test_protein_chemical_overlap.py
+++ b/tests/reports/test_protein_chemical_overlap.py
@@ -1,0 +1,193 @@
+import csv
+import os
+
+import jsonlines
+import pytest
+
+from src.reports.protein_chemical_overlap import (
+    concord_source_label,
+    generate_protein_chemical_overlap_report,
+)
+
+
+def _clique(identifiers, biolink_type, preferred_name):
+    """Build a compendium clique line in the schema write_compendium() produces."""
+    return {
+        "type": biolink_type,
+        "ic": 100,
+        "identifiers": [{"i": curie, "l": label, "d": [], "t": []} for curie, label in identifiers],
+        "preferred_name": preferred_name,
+        "taxa": [],
+    }
+
+
+def _write_jsonl(path, rows):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with jsonlines.open(path, "w") as writer:
+        for row in rows:
+            writer.write(row)
+
+
+def _read_tsv(path):
+    with open(path) as inf:
+        return list(csv.DictReader(inf, delimiter="\t"))
+
+
+def test_concord_source_label():
+    assert concord_source_label("/x/intermediate/chemicals/concords/DrugCentral") == "chemicals/DrugCentral"
+    assert concord_source_label("/x/intermediate/protein/concords/UNICHEM/UNICHEM_1_7") == "protein/UNICHEM/UNICHEM_1_7"
+    assert concord_source_label("/some/other/file") == "file"
+
+
+@pytest.mark.unit
+def test_generate_protein_chemical_overlap_report(tmp_path):
+    # --- Chemical side ---------------------------------------------------------------------------
+    # Clique A: etanercept, no InChIKey, and it shares the CURIE UMLS:C0717758 with a protein clique
+    #           (a duplicate-across-cliques case, #276/#513).
+    # Clique B: "pepsin" but actually a structurally-defined small molecule (has an InChIKey) -- the
+    #           kind of crossing that is usually a *bug* (#440).
+    chemical_compendium = str(tmp_path / "compendia" / "ChemicalEntity.txt")
+    _write_jsonl(
+        chemical_compendium,
+        [
+            _clique(
+                [("CHEBI:4875", "etanercept"), ("DRUGBANK:DB00005", "Etanercept"), ("UMLS:C0717758", "etanercept")],
+                "biolink:ChemicalEntity",
+                "Etanercept",
+            ),
+            _clique(
+                [("CHEBI:24536", "Pepsin"), ("INCHIKEY:JLYXXMFPNIAWKQ-UHFFFAOYSA-N", "")],
+                "biolink:SmallMolecule",
+                "Pepsin",
+            ),
+        ],
+    )
+
+    # --- Protein side ----------------------------------------------------------------------------
+    # Clique P: pepsin A-5; also (deliberately) carries UMLS:C0717758 so it duplicates with clique A.
+    # Clique Q: belimumab target.
+    protein_compendium = str(tmp_path / "compendia" / "Protein.txt")
+    _write_jsonl(
+        protein_compendium,
+        [
+            _clique(
+                [("UniProtKB:P0DJD9", "Pepsin A-5"), ("UMLS:C0717758", "etanercept")],
+                "biolink:Protein",
+                "Pepsin A-5",
+            ),
+            _clique([("UniProtKB:Q9Y275", "TN13B")], "biolink:Protein", "TN13B"),
+        ],
+    )
+
+    # --- Concords --------------------------------------------------------------------------------
+    concord = str(tmp_path / "intermediate" / "chemicals" / "concords" / "DrugCentral")
+    os.makedirs(os.path.dirname(concord), exist_ok=True)
+    with open(concord, "w") as outf:
+        # Crossing edge 1: structurally-defined chemical -> protein (chem_has_inchikey True).
+        outf.write("CHEBI:24536\txref\tUniProtKB:P0DJD9\n")
+        # Crossing edge 2: chemical (via DrugBank member of clique A) -> protein (no InChIKey).
+        outf.write("DRUGBANK:DB00005\trelated_to\tUniProtKB:Q9Y275\n")
+        # Non-crossing: chem -> chem (same side), must be ignored.
+        outf.write("CHEBI:4875\txref\tDRUGBANK:DB00005\n")
+        # Endpoint not in any compendium, must be ignored.
+        outf.write("CHEBI:4875\txref\tFOOBAR:1\n")
+        # References UMLS:C0717758 (a member of both clique A and clique P) so it enters the concord
+        # CURIE set and is detected as a duplicate; the other endpoint is unknown so this is not a
+        # boundary crossing on its own.
+        outf.write("UMLS:C0717758\txref\tFOOBAR:2\n")
+        # Malformed line, must be skipped.
+        outf.write("CHEBI:4875\tonlytwo\n")
+
+    # --- GeneProtein conflation: P0DJD9 reaches a gene; Q9Y275 does not. -------------------------
+    geneprotein = str(tmp_path / "conflation" / "GeneProtein.txt")
+    _write_jsonl(geneprotein, [["NCBIGene:5222", "UniProtKB:P0DJD9"], ["UniProtKB:Q9Y275"]])
+
+    bridges = str(tmp_path / "out" / "bridges.tsv")
+    pairs = str(tmp_path / "out" / "pairs.tsv")
+    duplicates = str(tmp_path / "out" / "duplicates.tsv")
+    summary = str(tmp_path / "out" / "summary.tsv")
+
+    counts = generate_protein_chemical_overlap_report(
+        chemical_compendia=[chemical_compendium],
+        protein_compendia=[protein_compendium],
+        concord_files=[concord],
+        bridges_tsv=bridges,
+        candidate_pairs_tsv=pairs,
+        duplicate_curies_tsv=duplicates,
+        summary_tsv=summary,
+        geneprotein_conflation=geneprotein,
+    )
+
+    assert counts["bridge_edges"] == 2
+    assert counts["candidate_pairs"] == 2
+    assert counts["duplicate_curies"] == 1
+
+    # --- Bridges -----------------------------------------------------------------------------
+    bridge_rows = _read_tsv(bridges)
+    assert len(bridge_rows) == 2
+    by_chem = {row["chem_leader"]: row for row in bridge_rows}
+
+    # CHEBI:24536 crossing: chem has an InChIKey, protein reaches a gene.
+    assert by_chem["CHEBI:24536"]["chem_has_inchikey"] == "true"
+    assert by_chem["CHEBI:24536"]["prot_reaches_gene"] == "true"
+    assert by_chem["CHEBI:24536"]["prot_leader"] == "UniProtKB:P0DJD9"
+    assert by_chem["CHEBI:24536"]["source_concord"] == "chemicals/DrugCentral"
+
+    # CHEBI:4875 crossing (via its DrugBank member): no InChIKey, protein does not reach a gene.
+    assert by_chem["CHEBI:4875"]["chem_has_inchikey"] == "false"
+    assert by_chem["CHEBI:4875"]["prot_reaches_gene"] == "false"
+    assert by_chem["CHEBI:4875"]["chem_curie"] == "DRUGBANK:DB00005"
+    assert by_chem["CHEBI:4875"]["prot_leader"] == "UniProtKB:Q9Y275"
+
+    # --- Candidate pairs ---------------------------------------------------------------------
+    pair_rows = _read_tsv(pairs)
+    pair_keys = {(row["chem_leader"], row["prot_leader"]) for row in pair_rows}
+    assert pair_keys == {("CHEBI:24536", "UniProtKB:P0DJD9"), ("CHEBI:4875", "UniProtKB:Q9Y275")}
+
+    # --- Duplicate CURIEs (#276/#513) --------------------------------------------------------
+    dup_rows = _read_tsv(duplicates)
+    assert len(dup_rows) == 1
+    assert dup_rows[0]["curie"] == "UMLS:C0717758"
+    assert dup_rows[0]["chem_leader"] == "CHEBI:4875"
+    assert dup_rows[0]["prot_leader"] == "UniProtKB:P0DJD9"
+
+    # --- Summary -----------------------------------------------------------------------------
+    summary_rows = _read_tsv(summary)
+    by_source = {row["source_concord"]: row for row in summary_rows}
+    assert by_source["chemicals/DrugCentral"]["bridge_edges"] == "2"
+    assert by_source["chemicals/DrugCentral"]["edges_with_chem_inchikey"] == "1"
+    assert by_source["chemicals/DrugCentral"]["edges_without_chem_inchikey"] == "1"
+    assert by_source["TOTAL"]["distinct_candidate_pairs"] == "2"
+
+
+@pytest.mark.unit
+def test_report_without_geneprotein_conflation(tmp_path):
+    """prot_reaches_gene should simply be false everywhere when no conflation file is given."""
+    chemical_compendium = str(tmp_path / "compendia" / "ChemicalEntity.txt")
+    _write_jsonl(
+        chemical_compendium,
+        [_clique([("CHEBI:24536", "Pepsin")], "biolink:SmallMolecule", "Pepsin")],
+    )
+    protein_compendium = str(tmp_path / "compendia" / "Protein.txt")
+    _write_jsonl(
+        protein_compendium,
+        [_clique([("UniProtKB:P0DJD9", "Pepsin A-5")], "biolink:Protein", "Pepsin A-5")],
+    )
+    concord = str(tmp_path / "intermediate" / "protein" / "concords" / "UMLS")
+    os.makedirs(os.path.dirname(concord), exist_ok=True)
+    with open(concord, "w") as outf:
+        outf.write("CHEBI:24536\txref\tUniProtKB:P0DJD9\n")
+
+    bridges = str(tmp_path / "out" / "bridges.tsv")
+    counts = generate_protein_chemical_overlap_report(
+        chemical_compendia=[chemical_compendium],
+        protein_compendia=[protein_compendium],
+        concord_files=[concord],
+        bridges_tsv=bridges,
+        candidate_pairs_tsv=str(tmp_path / "out" / "pairs.tsv"),
+        duplicate_curies_tsv=str(tmp_path / "out" / "duplicates.tsv"),
+        summary_tsv=str(tmp_path / "out" / "summary.tsv"),
+        geneprotein_conflation=None,
+    )
+    assert counts["bridge_edges"] == 1
+    assert _read_tsv(bridges)[0]["prot_reaches_gene"] == "false"


### PR DESCRIPTION
Inventories the cross-references that bridge the chemical/protein boundary, so the Translator community can review which protein and chemical cliques a merge would combine. This is the empirical input to the "list of mappings that would be applied if we combined proteins and chemicals" called for in #706, and a generalization of the UMLS-only report proposed in #667.

## What it does

`generate_protein_chemical_overlap_report()` streams the chemical compendia, the protein compendium, and every concord file, and finds concord edges whose two endpoints landed in different cliques — one chemical, one protein. It writes four TSVs under `babel_outputs/reports/protein_chemical/`:

- **`candidate_pairs.tsv`** — deduplicated (chemical leader → protein leader) merge candidates with supporting sources/predicates aggregated and sorted by evidence. The SSSOM-able mapping list a DrugProtein conflation (#440) would apply.
- **`bridges.tsv`** — one row per boundary-crossing concord edge, source-attributed (raw evidence).
- **`duplicate_curies.tsv`** — CURIEs in both a chemical and a protein clique (#276/#513). Scoped to concord-referenced CURIEs to keep memory bounded; the exhaustive list is a one-query lookup against the DuckDB `Edge` table.
- **`summary.tsv`** — per-source counts with the discriminator splits and a `TOTAL` row.

Each candidate carries two triage discriminators:

- **`chem_has_inchikey`** — a structurally-defined chemical cross-referenced to a protein is usually a *bug* (e.g. CHEBI:24536 "Pepsin" actually being hexachlorocyclohexane); the genuine protein-as-chemical cases have no InChIKey.
- **`prot_reaches_gene`** — whether merging would make a chemical normalize all the way to a *gene* (the #662 concern), derived from the GeneProtein conflation.

Memory is bounded by concord size: only CURIEs referenced by a concord are indexed, so the large compendia are streamed rather than held in RAM.

## Changes

- `src/reports/protein_chemical_overlap.py` — core module.
- `tests/reports/test_protein_chemical_overlap.py` — unit tests on synthetic fixtures (InChIKey vs no-InChIKey crossings, duplicate CURIE, gene-reaching protein, no-conflation path).
- `src/snakefiles/reports.snakefile` — rule `generate_protein_chemical_overlap_report`, gated on `outputs_done` and registered under `all_reports`.
- `docs/reports/ProteinChemicalOverlap.md` (+ README index entry) — purpose, discriminators, outputs, how to run against a downloaded build, and a future-work section.

## Follow-up

The natural next step is a **conflation-chain impact simulator** that consumes `candidate_pairs.tsv` and shows before/after normalization for a probe set — tracked in #829.

## Status / notes

- `ruff check`, `ruff format --check`, `snakefmt --check`, `rumdl` all clean; unit tests pass.
- Not yet validated against a real build — the logic is exercised by unit fixtures only. Running it against a downloaded `babel_outputs/` (e.g. the stars.renci.org snapshot) and sanity-checking the top candidate pairs is a good pre-merge step. Draft until then.

Related: #706, #667, #662, #654, #513, #440, #276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)