### PR TITLE
Download and ingest all ComplexPortal species into the MacromolecularComplex compendium (#751)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,8 +200,10 @@ Deeper, source-specific notes live under `docs/sources/<PREFIX>/` (one directory
 named by its CURIE prefix); see `docs/sources/README.md` for the convention and an index. Check
 there first when working on a specific vocabulary, and add to it when you learn something
 non-obvious about how Babel ingests that source. Keep the detail in the source file — `CLAUDE.md`
-should point here, not duplicate it. Documented so far: MeSH
-(`docs/sources/MESH/Ingestion.md`) and UMLS (`docs/sources/UMLS/Leftover.md`).
+should point here, not duplicate it. Documented so far: ComplexPortal
+(`docs/sources/COMPLEXPORTAL/Ingestion.md`), MeSH (`docs/sources/MESH/Ingestion.md`), and UMLS
+(`docs/sources/UMLS/Leftover.md`). Cross-cutting download/discovery patterns (HTTP autoindex
+listing vs FTP `NLST`) live in `docs/sources/DownloadPatterns.md`.
 
 ### Per-compendium metadata YAMLs
 
@@ -268,9 +270,25 @@ option would be best.
   Explicit paths let unit tests pass `tmp_path`-based paths without patching the config, and
   let Snakemake rules declare inputs and outputs precisely.
 
+- **Pin external column layouts in source, assert headers in tests** — when a handler parses a
+  fixed-column TSV by index, define the column list as a module-level constant in the source
+  (e.g. `complexportal.COMPLEXTAB_COLUMNS`/`COMPLEXTAB_HEADER`), import it into the tests to build
+  fixture rows, and add a test that asserts the upstream header still has the expected column at
+  each index Babel reads. The constant is the canonical format documentation living next to the
+  code; the header assertion turns a silent upstream re-ordering into a loud test failure instead
+  of corrupted output. See `src/datahandlers/complexportal.py`.
+
+- **Manifest/sentinel as the Snakemake output of a multi-file download** — when a rule downloads
+  many files discovered at runtime, write a manifest listing them as the *last* action and declare
+  the manifest (not the individual files or a separate flag) as the rule's output. Its presence
+  then reliably signals that the whole download phase completed, and the extraction rule reads it
+  to know what to parse. See `complexportal.pull_complexportal()`.
+
 - **Test assertion helpers** — `tests/conftest.py` exports `assert_labels_file_valid`,
-  `assert_synonyms_file_valid`, `assert_ids_file_valid`, and `assert_concordance_file_valid`.
-  Use these instead of hand-rolling TSV checks in new tests.
+  `assert_synonyms_file_valid`, `assert_ids_file_valid`, `assert_concordance_file_valid`,
+  `assert_taxa_file_valid`, and `assert_descriptions_file_valid` (plus `read_tsv`). Use these
+  instead of hand-rolling TSV checks in new tests; when a handler adds a new output kind, add the
+  matching helper to the root conftest rather than a private one in the test file.
 
 ## Debugging
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,8 +86,13 @@ uv run rumdl fmt .                       # Markdown auto-fix
 
 Snakemake drives a two-phase pipeline:
 
-1. **Data Collection** — downloads from FTP/web sources, producing `labels` (CURIE→name) and
-   `synonyms` (CURIE→predicate→synonym) files in `babel_downloads/[PREFIX]/`.
+1. **Data Collection** — downloads from FTP/web sources, producing per-source attribute files in
+   `babel_downloads/[PREFIX]/` that the factories in `node.py` pick up by prefix. Each is an
+   independent, optional TSV: `labels` (CURIE→name, read by `NodeFactory`), `synonyms`
+   (CURIE→predicate→synonym, `SynonymFactory`), `taxa` (CURIE→`NCBITaxon:NNNN`, `TaxonFactory`),
+   and `descriptions` (CURIE→text, `DescriptionFactory`). A handler emits whichever of these its
+   source supports; supplying `taxa`/`descriptions` is how a source enriches its cliques with
+   taxon and description data (see ComplexPortal and NCBIGene for examples that emit all four).
 2. **Compendium Building** — extracts identifiers per semantic type into `ids/[TYPE]`, creates
    pairwise cross-reference mappings (concords), merges them into equivalence cliques via
    union-find, and outputs enriched JSONL compendia.
@@ -231,6 +236,10 @@ option would be best.
 
 ## Conventions
 
+When adding or enhancing a data source ingest, `docs/Development.md` ("Enhancing a data source
+ingest") collects the process-level lessons (which attribute files to emit, IDs-file typing,
+docstrings, and when to add a pipeline test) that the individual conventions below back up.
+
 - **Commits** — if you need to make a large change, break it into multiple commits so it's clearer
   what changes are related.
 
@@ -283,6 +292,18 @@ option would be best.
   the manifest (not the individual files or a separate flag) as the rule's output. Its presence
   then reliably signals that the whole download phase completed, and the extraction rule reads it
   to know what to parse. See `complexportal.pull_complexportal()`.
+
+- **Always write an explicit Biolink type in the IDs file** — the `ids/[TYPE]/[PREFIX]` file is
+  `CURIE\tbiolink:Type`. Even when every CURIE from a source has the same prefix and type (so the
+  type column looks redundant), write it explicitly: it is essential the moment a source spans
+  multiple types, and it documents intent. Prefer generating IDs directly from the source rows
+  (as each CURIE is first seen) rather than deriving the file from `labels` via `awk` — deriving
+  from labels silently drops any identifier whose label column is empty.
+
+- **Docstrings** — give modules, classes, and non-trivial functions a docstring saying what they
+  do and any non-obvious behavior (e.g. dedup keys, side effects, why a network call happens).
+  This is cheap, survives refactors, and is the first thing read when revisiting an ingest. Name
+  functions for what they do — e.g. `fetch_*` (not `get_*`) when the call hits the network.
 
 - **Test assertion helpers** — `tests/conftest.py` exports `assert_labels_file_valid`,
   `assert_synonyms_file_valid`, `assert_ids_file_valid`, `assert_concordance_file_valid`,

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -9,6 +9,75 @@ This document describes the current development workflow for Babel and ideas for
 If a needed constant is missing, add it to `src/categories.py` first. This keeps all Biolink class
 names in one place so a rename only requires a single-file update.
 
+## Enhancing a data source ingest
+
+When you add a new data source or extend an existing one (the
+[ComplexPortal PR #831](https://github.com/NCATSTranslator/Babel/pull/831) is a worked example of
+all of this), these lessons are worth applying. The Babel-specific conventions referenced here are
+spelled out in `CLAUDE.md`; this section is the human-readable overview.
+
+### Emit the attribute files your source supports
+
+The data-collection phase writes per-source attribute files into `babel_downloads/[PREFIX]/`, and
+the factories in `src/node.py` pick them up by prefix. There are four, each an independent,
+optional TSV:
+
+- `labels` — `CURIE → name` (read by `NodeFactory`).
+- `synonyms` — `CURIE → predicate → synonym` (`SynonymFactory`).
+- `taxa` — `CURIE → NCBITaxon:NNNN` (`TaxonFactory`).
+- `descriptions` — `CURIE → text` (`DescriptionFactory`).
+
+Emit whichever your source supports — providing `taxa` and `descriptions` is simply how a source
+enriches its cliques, and it costs little once you are already parsing the rows. Match each
+output's **deduplication key to its downstream consumer**: labels key on the identifier alone
+(first-seen wins), but taxa and descriptions keep every distinct `(identifier, value)` pair because
+their factories accumulate per identifier.
+
+### Write an explicit Biolink type in the IDs file
+
+The `ids/[TYPE]/[PREFIX]` file is `CURIE → biolink:Type`. Write the type explicitly even when every
+CURIE from the source has the same prefix and type: the column looks redundant in that case, but it
+is **essential** the moment a source spans multiple types, and it makes intent obvious. Generate
+the IDs from the source rows as each CURIE is first seen, rather than deriving the file from
+`labels` via `awk` — deriving from labels silently drops any identifier whose label is empty.
+
+### Document the code with docstrings
+
+Give modules, classes, and non-trivial functions a docstring covering what they do and any
+non-obvious behavior (dedup keys, side effects, why a network call happens). Name functions for
+what they do — `fetch_*` rather than `get_*` when the call hits the network. Docstrings are cheap,
+survive refactors, and are the first thing read when someone revisits the ingest.
+
+### Bite the bullet and add a pipeline test
+
+If the source has no pipeline test, consider writing one even though it is more work up front. It
+pays off three ways:
+
+- It forces you to write smaller, regularly-runnable **`network` tests** — that the upstream
+  listing still returns files, that the header columns you read by index are still where you expect
+  — which catch an upstream format change _before_ it silently corrupts output.
+- It validates the handler end-to-end against real data using the shared `assert_*_file_valid`
+  helpers in `tests/conftest.py`.
+- It becomes the natural home for later assertions about that source's compendium output.
+
+See [`tests/README.md`](../tests/README.md) and
+`tests/{datahandlers,pipeline}/test_complexportal.py`.
+
+### A few more habits that paid off
+
+- **Validate upstream format and fail loudly.** Pin the column layout as a constant in the source
+  module, import it into tests, and assert the live header still matches. Raise `ValueError` /
+  `RuntimeError` on anything unexpected (a missing column, a zero-length file listing, an
+  already-prefixed taxon) rather than producing wrong output quietly.
+- **Use a manifest as the download sentinel** for multi-file downloads: write the list of
+  downloaded files last and make _that_ the Snakemake output, so its presence proves the download
+  phase finished and the extraction rule knows what to parse.
+- **Accept explicit file-path arguments** (`infile`/`outfile`/…) instead of calling
+  `make_local_name` inside the handler, so unit tests can point at `tmp_path` without patching the
+  config and Snakemake can declare inputs/outputs precisely.
+- **Record provenance** with `write_metadata()` so the per-source `metadata.yaml` captures where
+  each output came from.
+
 ## Current Development Process
 
 Developing a change to Babel is significantly more complicated than developing most software,

--- a/docs/sources/COMPLEXPORTAL/Ingestion.md
+++ b/docs/sources/COMPLEXPORTAL/Ingestion.md
@@ -1,0 +1,78 @@
+# ComplexPortal ingestion
+
+[ComplexPortal](https://www.ebi.ac.uk/complexportal/) (EBI) is the only source for the
+`MacromolecularComplex` compendium. Each complex has a `ComplexPortal:CPX-NNNN` accession.
+The handler is `src/datahandlers/complexportal.py`; the compendium builder is
+`src/createcompendia/macromolecular_complex.py`.
+
+## What we ingest
+
+ComplexPortal publishes one ComplexTAB TSV file per species under
+`https://ftp.ebi.ac.uk/pub/databases/intact/complex/current/complextab/`. The original Babel
+ingest downloaded only a single hard-coded species file; we now download **all** of them and
+union the results into one compendium.
+
+The ComplexTAB format has 19 columns. The canonical column list lives in the source module as
+`COMPLEXTAB_COLUMNS` / `COMPLEXTAB_HEADER` (next to the code that reads it) rather than only in
+the docs. Babel currently reads four of them:
+
+- Column 0 — `#Complex ac` → the `ComplexPortal:` CURIE.
+- Column 1 — `Recommended name` → the label.
+- Column 2 — `Aliases for complex` → `|`-separated synonyms (`has_exact_synonym`), or `-`.
+- Column 3 — `Taxonomy identifier` → a bare NCBI taxon integer → `NCBITaxon:NNNN`, or `-`.
+- Column 9 — `Description` → free-text description.
+
+Columns flagged in `COMPLEXTAB_COLUMNS` as future candidates (participants, GO annotations,
+cross references to Reactome/wwPDB/PubMed, disease associations) are not ingested yet but are
+the obvious next sources of concords or enrichment if we want them.
+
+## File discovery and download
+
+File discovery scrapes the Apache autoindex HTML listing (`fetch_complexportal_tsv_filenames`)
+rather than using FTP `NLST`, and downloads each file over HTTPS with `pull_via_urllib`. The
+rationale and the FTP fallback plan are in the cross-cutting
+[DownloadPatterns.md](../DownloadPatterns.md). `fetch_complexportal_tsv_filenames` raises if the
+listing yields zero `.tsv` files, so a format change surfaces immediately instead of silently
+producing an empty compendium.
+
+## Manifest as the download sentinel
+
+`pull_complexportal()` downloads every TSV and then, **as its last action**, writes a manifest
+(`downloaded_tsv_files.txt`) listing the files it fetched. The Snakemake `get_complexportal` rule
+declares the manifest (not the individual TSVs or a separate `download_done` flag) as its output:
+because the manifest is written only after all downloads succeed, its presence is a reliable
+signal that the download phase completed. This cleanly separates the download phase from the
+extraction phase — `make_labels_synonyms_and_taxa` reads the manifest to know what to parse, and
+raises a clear `RuntimeError` (telling the user to delete the manifest and re-run
+`get_complexportal`) if a listed TSV is missing on disk.
+
+## Cross-file (cross-species) deduplication
+
+The same `CPX-NNNN` accession can appear in more than one species file (a complex conserved
+across species). Each output applies the dedup key that matches its downstream consumer:
+
+- **Labels** — keyed on the identifier alone, so the **first-seen label wins** and no duplicate
+  label row is written. (Keying on the `(identifier, label)` pair instead would let two species
+  files with different recommended names both emit a row, producing a malformed labels file.)
+- **IDs** — one row per identifier, written directly from the source rows as
+  `CURIE\tbiolink:MacromolecularComplex`. Deriving the IDs from the source rather than from the
+  labels file means an accession with an **empty recommended name** still gets an ID row. (This
+  replaced an `awk`-over-labels Snakemake rule.)
+- **Synonyms** — keyed on `(identifier, synonym)`, so the same alias seen in two files is written
+  once but distinct aliases all survive.
+- **Taxa** — keyed on `(identifier, taxon_id)`, so a complex conserved across N species records
+  **all N taxa**. The taxon column is a bare integer; the handler raises `ValueError` if it ever
+  arrives already `NCBITaxon:`-prefixed (guards against upstream drift producing
+  `NCBITaxon:NCBITaxon:9606`).
+- **Descriptions** — keyed on `(identifier, description)`. Identical text repeated across species
+  is written once, but distinct descriptions for the same complex are all kept, because
+  `DescriptionFactory` accumulates descriptions per identifier as a set.
+
+## Outputs
+
+`make_labels_synonyms_and_taxa` writes `labels`, `synonyms`, `taxa`, `descriptions`, a
+provenance `metadata.yaml`, and (when `idsfile` is given) the `ids/ComplexPortal` file consumed
+by the compendium builder. The taxa file feeds `TaxonFactory` and the descriptions file feeds
+`DescriptionFactory`; both are declared as explicit inputs to the
+`macromolecular_complex_compendia` rule so the Snakemake DAG reflects that they are read at
+compendium-build time.

--- a/docs/sources/DownloadPatterns.md
+++ b/docs/sources/DownloadPatterns.md
@@ -24,10 +24,10 @@ transfers.
 years and the parser is a handful of lines. `ftplib` adds a second protocol dependency and
 occasional auth/passive-mode headaches. The risk is that EBI (or another host) switches to a
 different listing format (e.g. Nginx JSON autoindex, a JavaScript SPA) and the parser silently
-returns an empty list. The existing `get_complexportal_tsv_filenames()` guard (`if not
+returns an empty list. The existing `fetch_complexportal_tsv_filenames()` guard (`if not
 tsv_filenames: raise RuntimeError(...)`) catches this immediately at runtime.
 
-**If the HTML listing breaks** — switch `get_complexportal_tsv_filenames()` (and equivalent
+**If the HTML listing breaks** — switch `fetch_complexportal_tsv_filenames()` (and equivalent
 functions in other handlers) to use `ftplib.FTP.nlst()` or `MLSD` for discovery while keeping
 `pull_via_urllib` for the actual download. That combination gives structured directory listings
 without sacrificing download reliability. The FTP URL for EBI is

--- a/docs/sources/DownloadPatterns.md
+++ b/docs/sources/DownloadPatterns.md
@@ -1,0 +1,37 @@
+# Source Download Patterns
+
+This file documents recurring patterns and trade-offs that appear across multiple data handlers in
+`src/datahandlers/`. Prefer adding source-specific notes to that source's own directory; put
+guidance here only when the same pattern applies to several sources.
+
+## HTTP directory listing vs FTP for file discovery
+
+Several upstream sources (EBI FTP, NCBI FTP, etc.) expose their file listings both as a native FTP
+service and as an HTTP mirror whose URLs look like
+`https://ftp.example.org/pub/databases/source/current/`.
+
+**Current approach in Babel** — when a handler only needs to discover which files exist in a
+directory and then download them, we parse the HTTP directory listing rather than connecting via
+FTP. `src/datahandlers/complexportal.py` is the canonical example: `_DirectoryListingParser`
+scrapes `<a href>` tags from the Apache autoindex page to enumerate TSV filenames, and then
+`pull_via_urllib` downloads each file over HTTPS.
+
+**Why HTTP over FTP for the actual download** — FTP connections can stall or time out on large
+files, especially through firewalls and NAT. HTTPS is more reliable for multi-hundred-megabyte
+transfers.
+
+**Why HTTP listing instead of FTP `NLST`/`MLSD`** — EBI's autoindex format has been stable for
+years and the parser is a handful of lines. `ftplib` adds a second protocol dependency and
+occasional auth/passive-mode headaches. The risk is that EBI (or another host) switches to a
+different listing format (e.g. Nginx JSON autoindex, a JavaScript SPA) and the parser silently
+returns an empty list. The existing `get_complexportal_tsv_filenames()` guard (`if not
+tsv_filenames: raise RuntimeError(...)`) catches this immediately at runtime.
+
+**If the HTML listing breaks** — switch `get_complexportal_tsv_filenames()` (and equivalent
+functions in other handlers) to use `ftplib.FTP.nlst()` or `MLSD` for discovery while keeping
+`pull_via_urllib` for the actual download. That combination gives structured directory listings
+without sacrificing download reliability. The FTP URL for EBI is
+`ftp.ebi.ac.uk/pub/databases/intact/complex/current/complextab/`.
+
+**When to prefer FTP listing from the start** — if the HTTP mirror does not serve an Apache-style
+autoindex (no `<a href>` links to files), use FTP `NLST`/`MLSD` for discovery instead.

--- a/docs/sources/README.md
+++ b/docs/sources/README.md
@@ -22,5 +22,10 @@ letting it accumulate in `CLAUDE.md` — `CLAUDE.md` should point here, not dupl
   unclaimed UMLS concepts are swept up and typed, the manual STY→Biolink override tables and the
   drift test that keeps them honest, and the coverage report under `reports/umls/`.
 
+## Cross-cutting patterns
+
+- **Download patterns** ([DownloadPatterns.md](./DownloadPatterns.md)) — HTTP directory listing
+  vs FTP for file discovery, and when to use each approach.
+
 See the data handlers in `src/datahandlers/` and the compendium builders in
 `src/createcompendia/` for the code behind each source.

--- a/docs/sources/README.md
+++ b/docs/sources/README.md
@@ -15,6 +15,10 @@ letting it accumulate in `CLAUDE.md` — `CLAUDE.md` should point here, not dupl
 
 ## Sources documented so far
 
+- **COMPLEXPORTAL** ([COMPLEXPORTAL/Ingestion.md](./COMPLEXPORTAL/Ingestion.md)) — the
+  `MacromolecularComplex` source: which ComplexTAB columns Babel reads, downloading all species
+  files, the manifest-as-download-sentinel pattern, and the per-output cross-species
+  deduplication rules (labels, IDs, synonyms, taxa, descriptions).
 - **MESH** ([MESH/Ingestion.md](./MESH/Ingestion.md)) — how MeSH is partitioned across compendia
   by tree letter, how Supplementary Concept Records (SCRs) are typed and routed, the
   chemical/protein D-tree split, and which MeSH branches/SCR classes we deliberately skip.

--- a/src/datahandlers/complexportal.py
+++ b/src/datahandlers/complexportal.py
@@ -75,20 +75,21 @@ def _read_manifest(manifest_file):
         return [line.strip() for line in manifest if line.strip()]
 
 
-def make_labels_and_synonyms(manifest_file, download_dir, labelfile, synfile, metadata_yaml):
+def make_labels_synonyms_and_taxa(manifest_file, download_dir, labelfile, synfile, taxafile, metadata_yaml):
     filenames = _read_manifest(manifest_file)
     used_labels = set()
     used_synonyms = set()
+    used_taxa = set()
 
-    with open(labelfile, "w") as outl, open(synfile, "w") as outsyn:
+    with open(labelfile, "w") as outl, open(synfile, "w") as outsyn, open(taxafile, "w") as outt:
         for filename in filenames:
             infile = os.path.join(download_dir, filename)
             with open(infile) as inf:
                 next(inf)  # skip header
                 for line in inf:
-                    sline = line.split("\t", 3)
-                    if len(sline) < 3:
-                        raise ValueError(f"Expected at least 3 columns in {infile}, found {len(sline)}")
+                    sline = line.split("\t", 4)
+                    if len(sline) < 4:
+                        raise ValueError(f"Expected at least 4 columns in {infile}, found {len(sline)}")
 
                     identifier = f"{COMPLEXPORTAL}:{sline[0]}"
                     label = sline[1]  # recommended name
@@ -96,13 +97,20 @@ def make_labels_and_synonyms(manifest_file, download_dir, labelfile, synfile, me
                         outl.write(f"{identifier}\t{label}\n")
                         used_labels.add(identifier)
 
-                    synonyms_str = sline[2]  # aliases
+                    synonyms_str = sline[2]  # aliases for complex
                     if synonyms_str != "-":
                         for syn in synonyms_str.split("|"):
                             synonym_row = (identifier, syn)
                             if synonym_row not in used_synonyms:
                                 outsyn.write(f"{identifier}\t{HAS_EXACT_SYNONYM}\t{syn}\n")
                                 used_synonyms.add(synonym_row)
+
+                    taxon_id = sline[3].strip()  # taxonomy identifier (NCBI taxon integer)
+                    if taxon_id and taxon_id != "-":
+                        taxa_row = (identifier, taxon_id)
+                        if taxa_row not in used_taxa:
+                            outt.write(f"{identifier}\tNCBITaxon:{taxon_id}\n")
+                            used_taxa.add(taxa_row)
 
     write_metadata(
         metadata_yaml,

--- a/src/datahandlers/complexportal.py
+++ b/src/datahandlers/complexportal.py
@@ -25,11 +25,14 @@ class _DirectoryListingParser(HTMLParser):
                 self.hrefs.append(value)
 
 
-def get_complexportal_tsv_filenames(url=COMPLEXPORTAL_COMPLEXTAB_URL):
-    # We parse the Apache autoindex HTML rather than using FTP NLST because HTTPS is more reliable
-    # for large downloads. If EBI changes their listing format (e.g. switches to Nginx or a JS SPA)
-    # and this starts returning an empty list, switch to ftplib.FTP.nlst() for discovery while
-    # keeping pull_via_urllib for the actual download. See docs/sources/DownloadPatterns.md.
+def fetch_complexportal_tsv_filenames(url=COMPLEXPORTAL_COMPLEXTAB_URL):
+    """Fetch the list of available ComplexPortal TSV filenames by parsing the remote HTTP directory listing.
+
+    Parses Apache autoindex HTML from `url` rather than using FTP NLST because HTTPS is more
+    reliable for large file downloads. If EBI changes their listing format (e.g. switches to Nginx
+    or a JS SPA) and this starts returning an empty list, switch to ftplib.FTP.nlst() for discovery
+    while keeping pull_via_urllib for the actual download. See docs/sources/DownloadPatterns.md.
+    """
     req = urllib.request.Request(url, headers={"User-Agent": get_user_agent()})
     with urllib.request.urlopen(req) as response:
         listing = response.read().decode("utf-8")
@@ -53,7 +56,7 @@ def pull_complexportal(manifest_file=None):
     if manifest_file is None:
         manifest_file = _default_manifest_file()
 
-    filenames = get_complexportal_tsv_filenames()
+    filenames = fetch_complexportal_tsv_filenames()
     for filename in filenames:
         pull_via_urllib(
             COMPLEXPORTAL_COMPLEXTAB_URL,

--- a/src/datahandlers/complexportal.py
+++ b/src/datahandlers/complexportal.py
@@ -75,21 +75,27 @@ def _read_manifest(manifest_file):
         return [line.strip() for line in manifest if line.strip()]
 
 
-def make_labels_synonyms_and_taxa(manifest_file, download_dir, labelfile, synfile, taxafile, metadata_yaml):
+def make_labels_synonyms_and_taxa(manifest_file, download_dir, labelfile, synfile, taxafile, descfile, metadata_yaml):
     filenames = _read_manifest(manifest_file)
     used_labels = set()
     used_synonyms = set()
     used_taxa = set()
+    used_descs = set()  # (identifier, description) pairs — same text from two files is written only once
 
-    with open(labelfile, "w") as outl, open(synfile, "w") as outsyn, open(taxafile, "w") as outt:
+    with (
+        open(labelfile, "w") as outl,
+        open(synfile, "w") as outsyn,
+        open(taxafile, "w") as outt,
+        open(descfile, "w") as outd,
+    ):
         for filename in filenames:
             infile = os.path.join(download_dir, filename)
             with open(infile) as inf:
                 next(inf)  # skip header
                 for line in inf:
-                    sline = line.split("\t", 4)
-                    if len(sline) < 4:
-                        raise ValueError(f"Expected at least 4 columns in {infile}, found {len(sline)}")
+                    sline = line.split("\t", 10)
+                    if len(sline) < 10:
+                        raise ValueError(f"Expected at least 10 columns in {infile}, found {len(sline)}")
 
                     identifier = f"{COMPLEXPORTAL}:{sline[0]}"
                     label = sline[1]  # recommended name
@@ -112,11 +118,18 @@ def make_labels_synonyms_and_taxa(manifest_file, download_dir, labelfile, synfil
                             outt.write(f"{identifier}\tNCBITaxon:{taxon_id}\n")
                             used_taxa.add(taxa_row)
 
+                    description = sline[9].strip()  # free-text description
+                    if description and description != "-":
+                        desc_row = (identifier, description)
+                        if desc_row not in used_descs:
+                            outd.write(f"{identifier}\t{description}\n")
+                            used_descs.add(desc_row)
+
     write_metadata(
         metadata_yaml,
         typ="transform",
         name="ComplexPortal",
-        description="Labels and synonyms extracted from ComplexPortal ComplexTAB downloads",
+        description="Labels, synonyms, taxa, and descriptions extracted from ComplexPortal ComplexTAB downloads",
         sources=[
             {
                 "type": "download",

--- a/src/datahandlers/complexportal.py
+++ b/src/datahandlers/complexportal.py
@@ -10,6 +10,7 @@ from src.prefixes import COMPLEXPORTAL
 
 COMPLEXPORTAL_COMPLEXTAB_URL = "https://ftp.ebi.ac.uk/pub/databases/intact/complex/current/complextab/"
 COMPLEXPORTAL_MANIFEST = "downloaded_tsv_files.txt"
+COMPLEXPORTAL_DOWNLOAD_DONE = "download_done"
 
 
 class _DirectoryListingParser(HTMLParser):
@@ -49,13 +50,16 @@ def fetch_complexportal_tsv_filenames(url=COMPLEXPORTAL_COMPLEXTAB_URL):
     return sorted(tsv_filenames)
 
 
-def _default_manifest_file():
-    return os.path.join(get_config()["download_directory"], COMPLEXPORTAL, COMPLEXPORTAL_MANIFEST)
+def _default_download_done_file():
+    return os.path.join(get_config()["download_directory"], COMPLEXPORTAL, COMPLEXPORTAL_DOWNLOAD_DONE)
 
 
-def pull_complexportal(manifest_file=None):
-    if manifest_file is None:
-        manifest_file = _default_manifest_file()
+def pull_complexportal(download_done_file=None):
+    if download_done_file is None:
+        download_done_file = _default_download_done_file()
+
+    download_dir = os.path.dirname(download_done_file)
+    os.makedirs(download_dir, exist_ok=True)
 
     filenames = fetch_complexportal_tsv_filenames()
     for filename in filenames:
@@ -66,9 +70,14 @@ def pull_complexportal(manifest_file=None):
             subpath=COMPLEXPORTAL,
         )
 
-    os.makedirs(os.path.dirname(manifest_file), exist_ok=True)
+    manifest_file = os.path.join(download_dir, COMPLEXPORTAL_MANIFEST)
     with open(manifest_file, "w") as manifest:
         manifest.writelines(f"{fn}\n" for fn in filenames)
+
+    # Written last so Snakemake only considers the download complete once both
+    # the manifest and all TSV files are in place.
+    with open(download_done_file, "w") as sentinel:
+        sentinel.write(f"Downloaded {len(filenames)} ComplexPortal TSV files.\n")
 
 
 def _read_manifest(manifest_file):
@@ -91,6 +100,12 @@ def make_labels_synonyms_and_taxa(manifest_file, download_dir, labelfile, synfil
     ):
         for filename in filenames:
             infile = os.path.join(download_dir, filename)
+            if not os.path.exists(infile):
+                raise RuntimeError(
+                    f"{infile} is listed in the manifest but does not exist. "
+                    f"Delete {os.path.join(download_dir, COMPLEXPORTAL_DOWNLOAD_DONE)} "
+                    "and re-run the get_complexportal Snakemake rule to re-download all files."
+                )
             with open(infile) as inf:
                 next(inf)  # skip header
                 for line in inf:

--- a/src/datahandlers/complexportal.py
+++ b/src/datahandlers/complexportal.py
@@ -5,6 +5,7 @@ from html.parser import HTMLParser
 
 from src.babel_utils import get_config, get_user_agent, pull_via_urllib
 from src.metadata.provenance import write_metadata
+from src.predicates import HAS_EXACT_SYNONYM
 from src.prefixes import COMPLEXPORTAL
 
 COMPLEXPORTAL_COMPLEXTAB_URL = "https://ftp.ebi.ac.uk/pub/databases/intact/complex/current/complextab/"
@@ -98,9 +99,9 @@ def make_labels_and_synonyms(manifest_file, labelfile, synfile, metadata_yaml):
                     synonyms_str = sline[2]  # aliases
                     if synonyms_str != "-":
                         for syn in synonyms_str.split("|"):
-                            synonym_row = (identifier, syn)
+                            synonym_row = (identifier, HAS_EXACT_SYNONYM, syn)
                             if synonym_row not in used_synonyms:
-                                outsyn.write(f"{identifier}\t{syn}\n")
+                                outsyn.write(f"{identifier}\t{HAS_EXACT_SYNONYM}\t{syn}\n")
                                 used_synonyms.add(synonym_row)
 
     write_metadata(

--- a/src/datahandlers/complexportal.py
+++ b/src/datahandlers/complexportal.py
@@ -26,6 +26,10 @@ class _DirectoryListingParser(HTMLParser):
 
 
 def get_complexportal_tsv_filenames(url=COMPLEXPORTAL_COMPLEXTAB_URL):
+    # We parse the Apache autoindex HTML rather than using FTP NLST because HTTPS is more reliable
+    # for large downloads. If EBI changes their listing format (e.g. switches to Nginx or a JS SPA)
+    # and this starts returning an empty list, switch to ftplib.FTP.nlst() for discovery while
+    # keeping pull_via_urllib for the actual download. See docs/sources/DownloadPatterns.md.
     req = urllib.request.Request(url, headers={"User-Agent": get_user_agent()})
     with urllib.request.urlopen(req) as response:
         listing = response.read().decode("utf-8")

--- a/src/datahandlers/complexportal.py
+++ b/src/datahandlers/complexportal.py
@@ -33,11 +33,7 @@ def get_complexportal_tsv_filenames(url=COMPLEXPORTAL_COMPLEXTAB_URL):
     parser = _DirectoryListingParser()
     parser.feed(listing)
 
-    tsv_filenames = set()
-    for href in parser.hrefs:
-        filename = posixpath.basename(href.rstrip("/"))
-        if filename.endswith(".tsv"):
-            tsv_filenames.add(filename)
+    tsv_filenames = {f for h in parser.hrefs if (f := posixpath.basename(h.rstrip("/"))).endswith(".tsv")}
 
     if not tsv_filenames:
         raise RuntimeError(f"No ComplexPortal TSV files found at {url}")
@@ -64,8 +60,7 @@ def pull_complexportal(manifest_file=None):
 
     os.makedirs(os.path.dirname(manifest_file), exist_ok=True)
     with open(manifest_file, "w") as manifest:
-        for filename in filenames:
-            manifest.write(f"{filename}\n")
+        manifest.writelines(f"{fn}\n" for fn in filenames)
 
 
 def _read_manifest(manifest_file):
@@ -73,9 +68,8 @@ def _read_manifest(manifest_file):
         return [line.strip() for line in manifest if line.strip()]
 
 
-def make_labels_and_synonyms(manifest_file, labelfile, synfile, metadata_yaml):
+def make_labels_and_synonyms(manifest_file, download_dir, labelfile, synfile, metadata_yaml):
     filenames = _read_manifest(manifest_file)
-    download_dir = os.path.dirname(manifest_file)
     used_labels = set()
     used_synonyms = set()
 
@@ -85,7 +79,7 @@ def make_labels_and_synonyms(manifest_file, labelfile, synfile, metadata_yaml):
             with open(infile) as inf:
                 next(inf)  # skip header
                 for line in inf:
-                    sline = line.split("\t")
+                    sline = line.split("\t", 3)
                     if len(sline) < 3:
                         raise ValueError(f"Expected at least 3 columns in {infile}, found {len(sline)}")
 
@@ -98,7 +92,7 @@ def make_labels_and_synonyms(manifest_file, labelfile, synfile, metadata_yaml):
                     synonyms_str = sline[2]  # aliases
                     if synonyms_str != "-":
                         for syn in synonyms_str.split("|"):
-                            synonym_row = (identifier, HAS_EXACT_SYNONYM, syn)
+                            synonym_row = (identifier, syn)
                             if synonym_row not in used_synonyms:
                                 outsyn.write(f"{identifier}\t{HAS_EXACT_SYNONYM}\t{syn}\n")
                                 used_synonyms.add(synonym_row)

--- a/src/datahandlers/complexportal.py
+++ b/src/datahandlers/complexportal.py
@@ -1,9 +1,11 @@
+import contextlib
 import os
 import posixpath
 import urllib.request
 from html.parser import HTMLParser
 
 from src.babel_utils import get_config, get_user_agent, pull_via_urllib
+from src.categories import MACROMOLECULAR_COMPLEX
 from src.metadata.provenance import write_metadata
 from src.predicates import HAS_EXACT_SYNONYM
 from src.prefixes import COMPLEXPORTAL
@@ -85,18 +87,22 @@ def _read_manifest(manifest_file):
         return [line.strip() for line in manifest if line.strip()]
 
 
-def make_labels_synonyms_and_taxa(manifest_file, download_dir, labelfile, synfile, taxafile, descfile, metadata_yaml):
+def make_labels_synonyms_and_taxa(
+    manifest_file, download_dir, labelfile, synfile, taxafile, descfile, metadata_yaml, idsfile=None
+):
     filenames = _read_manifest(manifest_file)
     used_identifiers = set()
     used_synonyms = set()
     used_taxa = set()
     used_descs = set()  # (identifier, description) pairs — same text from two files is written only once
 
+    ids_ctx = open(idsfile, "w") if idsfile else contextlib.nullcontext()
     with (
         open(labelfile, "w") as outl,
         open(synfile, "w") as outsyn,
         open(taxafile, "w") as outt,
         open(descfile, "w") as outd,
+        ids_ctx as outids,
     ):
         for filename in filenames:
             infile = os.path.join(download_dir, filename)
@@ -119,6 +125,8 @@ def make_labels_synonyms_and_taxa(manifest_file, download_dir, labelfile, synfil
                     label = sline[1]  # recommended name
                     if identifier not in used_identifiers:
                         outl.write(f"{identifier}\t{label}\n")
+                        if outids is not None:
+                            outids.write(f"{identifier}\t{MACROMOLECULAR_COMPLEX}\n")
                         used_identifiers.add(identifier)
 
                     synonyms_str = sline[2]  # aliases for complex

--- a/src/datahandlers/complexportal.py
+++ b/src/datahandlers/complexportal.py
@@ -91,10 +91,9 @@ def make_labels_and_synonyms(manifest_file, labelfile, synfile, metadata_yaml):
 
                     identifier = f"{COMPLEXPORTAL}:{sline[0]}"
                     label = sline[1]  # recommended name
-                    label_row = (identifier, label)
-                    if label_row not in used_labels:
+                    if identifier not in used_labels:
                         outl.write(f"{identifier}\t{label}\n")
-                        used_labels.add(label_row)
+                        used_labels.add(identifier)
 
                     synonyms_str = sline[2]  # aliases
                     if synonyms_str != "-":

--- a/src/datahandlers/complexportal.py
+++ b/src/datahandlers/complexportal.py
@@ -16,6 +16,8 @@ COMPLEXPORTAL_DOWNLOAD_DONE = "download_done"
 
 
 class _DirectoryListingParser(HTMLParser):
+    """Collect all href values from anchor tags in an HTML page."""
+
     def __init__(self):
         super().__init__()
         self.hrefs = []
@@ -57,6 +59,7 @@ def _default_download_done_file():
 
 
 def pull_complexportal(download_done_file=None):
+    """Download all ComplexPortal ComplexTAB TSV files and write a manifest listing them."""
     if download_done_file is None:
         download_done_file = _default_download_done_file()
 
@@ -90,6 +93,12 @@ def _read_manifest(manifest_file):
 def make_labels_synonyms_and_taxa(
     manifest_file, download_dir, labelfile, synfile, taxafile, descfile, metadata_yaml, idsfile=None
 ):
+    """Parse all TSV files listed in the manifest and write labels, synonyms, taxa, descriptions, and optionally IDs.
+
+    When `idsfile` is provided, every unique identifier is written there as
+    ``CURIE\\tbiolink:MacromolecularComplex``, derived directly from the source rows rather
+    than from the labels file, so IDs without a recommended name are still captured.
+    """
     filenames = _read_manifest(manifest_file)
     used_identifiers = set()
     used_synonyms = set()

--- a/src/datahandlers/complexportal.py
+++ b/src/datahandlers/complexportal.py
@@ -1,44 +1,119 @@
-from src.babel_utils import pull_via_urllib
+import os
+import posixpath
+import urllib.request
+from html.parser import HTMLParser
+
+from src.babel_utils import get_config, get_user_agent, pull_via_urllib
 from src.metadata.provenance import write_metadata
 from src.prefixes import COMPLEXPORTAL
 
-
-def pull_complexportal():
-    pull_via_urllib(
-        "http://ftp.ebi.ac.uk/pub/databases/intact/complex/current/complextab/",
-        "559292.tsv",
-        decompress=False,
-        subpath=COMPLEXPORTAL,
-    )
+COMPLEXPORTAL_COMPLEXTAB_URL = "https://ftp.ebi.ac.uk/pub/databases/intact/complex/current/complextab/"
+COMPLEXPORTAL_MANIFEST = "downloaded_tsv_files.txt"
 
 
-def make_labels_and_synonyms(infile, labelfile, synfile, metadata_yaml):
-    usedsyns = set()
-    with open(infile) as inf, open(labelfile, "w") as outl, open(synfile, "w") as outsyn:
-        next(inf)  # skip header
-        for line in inf:
-            sline = line.split("\t")
-            id = sline[0]
-            label = sline[1]  # recommended name
-            outl.write(f"{COMPLEXPORTAL}:{id}\t{label}\n")
-            synonyms_str = sline[2]  # aliases
-            if not synonyms_str == "-":
-                synonyms = synonyms_str.split("|")
-                for syn in synonyms:
-                    if syn not in usedsyns:
-                        outsyn.write(f"{COMPLEXPORTAL}:{id}\t{syn}\n")
-                        usedsyns.add(syn)
+class _DirectoryListingParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.hrefs = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag != "a":
+            return
+        for name, value in attrs:
+            if name == "href":
+                self.hrefs.append(value)
+
+
+def get_complexportal_tsv_filenames(url=COMPLEXPORTAL_COMPLEXTAB_URL):
+    req = urllib.request.Request(url, headers={"User-Agent": get_user_agent()})
+    with urllib.request.urlopen(req) as response:
+        listing = response.read().decode("utf-8")
+
+    parser = _DirectoryListingParser()
+    parser.feed(listing)
+
+    tsv_filenames = set()
+    for href in parser.hrefs:
+        filename = posixpath.basename(href.rstrip("/"))
+        if filename.endswith(".tsv"):
+            tsv_filenames.add(filename)
+
+    if not tsv_filenames:
+        raise RuntimeError(f"No ComplexPortal TSV files found at {url}")
+
+    return sorted(tsv_filenames)
+
+
+def _default_manifest_file():
+    return os.path.join(get_config()["download_directory"], COMPLEXPORTAL, COMPLEXPORTAL_MANIFEST)
+
+
+def pull_complexportal(manifest_file=None):
+    if manifest_file is None:
+        manifest_file = _default_manifest_file()
+
+    filenames = get_complexportal_tsv_filenames()
+    for filename in filenames:
+        pull_via_urllib(
+            COMPLEXPORTAL_COMPLEXTAB_URL,
+            filename,
+            decompress=False,
+            subpath=COMPLEXPORTAL,
+        )
+
+    os.makedirs(os.path.dirname(manifest_file), exist_ok=True)
+    with open(manifest_file, "w") as manifest:
+        for filename in filenames:
+            manifest.write(f"{filename}\n")
+
+
+def _read_manifest(manifest_file):
+    with open(manifest_file) as manifest:
+        return [line.strip() for line in manifest if line.strip()]
+
+
+def make_labels_and_synonyms(manifest_file, labelfile, synfile, metadata_yaml):
+    filenames = _read_manifest(manifest_file)
+    download_dir = os.path.dirname(manifest_file)
+    used_labels = set()
+    used_synonyms = set()
+
+    with open(labelfile, "w") as outl, open(synfile, "w") as outsyn:
+        for filename in filenames:
+            infile = os.path.join(download_dir, filename)
+            with open(infile) as inf:
+                next(inf)  # skip header
+                for line in inf:
+                    sline = line.split("\t")
+                    if len(sline) < 3:
+                        raise ValueError(f"Expected at least 3 columns in {infile}, found {len(sline)}")
+
+                    identifier = f"{COMPLEXPORTAL}:{sline[0]}"
+                    label = sline[1]  # recommended name
+                    label_row = (identifier, label)
+                    if label_row not in used_labels:
+                        outl.write(f"{identifier}\t{label}\n")
+                        used_labels.add(label_row)
+
+                    synonyms_str = sline[2]  # aliases
+                    if synonyms_str != "-":
+                        for syn in synonyms_str.split("|"):
+                            synonym_row = (identifier, syn)
+                            if synonym_row not in used_synonyms:
+                                outsyn.write(f"{identifier}\t{syn}\n")
+                                used_synonyms.add(synonym_row)
 
     write_metadata(
         metadata_yaml,
         typ="transform",
         name="ComplexPortal",
-        description="Labels and synonyms extracted from ComplexPortal download of 559292 (Saccharomyces cerevisiae)",
+        description="Labels and synonyms extracted from ComplexPortal ComplexTAB downloads",
         sources=[
             {
                 "type": "download",
-                "name": "ComplexPortal for organism 559292 (Saccharomyces cerevisiae)",
-                "url": "http://ftp.ebi.ac.uk/pub/databases/intact/complex/current/complextab/559292.tsv",
+                "name": f"ComplexPortal for organism {os.path.splitext(filename)[0]}",
+                "url": f"{COMPLEXPORTAL_COMPLEXTAB_URL}{filename}",
             }
+            for filename in filenames
         ],
     )

--- a/src/datahandlers/complexportal.py
+++ b/src/datahandlers/complexportal.py
@@ -12,7 +12,6 @@ from src.prefixes import COMPLEXPORTAL
 
 COMPLEXPORTAL_COMPLEXTAB_URL = "https://ftp.ebi.ac.uk/pub/databases/intact/complex/current/complextab/"
 COMPLEXPORTAL_MANIFEST = "downloaded_tsv_files.txt"
-COMPLEXPORTAL_DOWNLOAD_DONE = "download_done"
 
 # All 19 columns in the ComplexPortal ComplexTAB TSV format (as of 2026-06).
 # Columns read by Babel are marked with (*); the rest are set to "-" in most rows.
@@ -80,16 +79,20 @@ def fetch_complexportal_tsv_filenames(url=COMPLEXPORTAL_COMPLEXTAB_URL):
     return sorted(tsv_filenames)
 
 
-def _default_download_done_file():
-    return os.path.join(get_config()["download_directory"], COMPLEXPORTAL, COMPLEXPORTAL_DOWNLOAD_DONE)
+def _default_manifest_file():
+    return os.path.join(get_config()["download_directory"], COMPLEXPORTAL, COMPLEXPORTAL_MANIFEST)
 
 
-def pull_complexportal(download_done_file=None):
-    """Download all ComplexPortal ComplexTAB TSV files and write a manifest listing them."""
-    if download_done_file is None:
-        download_done_file = _default_download_done_file()
+def pull_complexportal(manifest_file=None):
+    """Download all ComplexPortal ComplexTAB TSV files and write a manifest listing them.
 
-    download_dir = os.path.dirname(download_done_file)
+    The manifest is written last, so its presence signals that all downloads completed
+    and Snakemake can treat it as the sentinel output for this rule.
+    """
+    if manifest_file is None:
+        manifest_file = _default_manifest_file()
+
+    download_dir = os.path.dirname(manifest_file)
     os.makedirs(download_dir, exist_ok=True)
 
     filenames = fetch_complexportal_tsv_filenames()
@@ -101,14 +104,8 @@ def pull_complexportal(download_done_file=None):
             subpath=COMPLEXPORTAL,
         )
 
-    manifest_file = os.path.join(download_dir, COMPLEXPORTAL_MANIFEST)
     with open(manifest_file, "w") as manifest:
         manifest.writelines(f"{fn}\n" for fn in filenames)
-
-    # Written last so Snakemake only considers the download complete once both
-    # the manifest and all TSV files are in place.
-    with open(download_done_file, "w") as sentinel:
-        sentinel.write(f"Downloaded {len(filenames)} ComplexPortal TSV files.\n")
 
 
 def _read_manifest(manifest_file):
@@ -144,7 +141,7 @@ def make_labels_synonyms_and_taxa(
             if not os.path.exists(infile):
                 raise RuntimeError(
                     f"{infile} is listed in the manifest but does not exist. "
-                    f"Delete {os.path.join(download_dir, COMPLEXPORTAL_DOWNLOAD_DONE)} "
+                    f"Delete {os.path.join(download_dir, COMPLEXPORTAL_MANIFEST)} "
                     "and re-run the get_complexportal Snakemake rule to re-download all files."
                 )
             with open(infile) as inf:

--- a/src/datahandlers/complexportal.py
+++ b/src/datahandlers/complexportal.py
@@ -40,7 +40,8 @@ def fetch_complexportal_tsv_filenames(url=COMPLEXPORTAL_COMPLEXTAB_URL):
     parser = _DirectoryListingParser()
     parser.feed(listing)
 
-    tsv_filenames = {f for h in parser.hrefs if (f := posixpath.basename(h.rstrip("/"))).endswith(".tsv")}
+    basenames = (posixpath.basename(h.rstrip("/")) for h in parser.hrefs)
+    tsv_filenames = {f for f in basenames if f.endswith(".tsv")}
 
     if not tsv_filenames:
         raise RuntimeError(f"No ComplexPortal TSV files found at {url}")
@@ -113,6 +114,11 @@ def make_labels_synonyms_and_taxa(manifest_file, download_dir, labelfile, synfil
 
                     taxon_id = sline[3].strip()  # taxonomy identifier (NCBI taxon integer)
                     if taxon_id and taxon_id != "-":
+                        if taxon_id.startswith("NCBITaxon:"):
+                            raise ValueError(
+                                f"Taxon ID {taxon_id!r} in {infile} is already prefixed; "
+                                "expected a bare integer (e.g. '9606')"
+                            )
                         taxa_row = (identifier, taxon_id)
                         if taxa_row not in used_taxa:
                             outt.write(f"{identifier}\tNCBITaxon:{taxon_id}\n")

--- a/src/datahandlers/complexportal.py
+++ b/src/datahandlers/complexportal.py
@@ -78,7 +78,7 @@ def _read_manifest(manifest_file):
 
 def make_labels_synonyms_and_taxa(manifest_file, download_dir, labelfile, synfile, taxafile, descfile, metadata_yaml):
     filenames = _read_manifest(manifest_file)
-    used_labels = set()
+    used_identifiers = set()
     used_synonyms = set()
     used_taxa = set()
     used_descs = set()  # (identifier, description) pairs — same text from two files is written only once
@@ -94,15 +94,17 @@ def make_labels_synonyms_and_taxa(manifest_file, download_dir, labelfile, synfil
             with open(infile) as inf:
                 next(inf)  # skip header
                 for line in inf:
+                    if not line.strip():
+                        continue
                     sline = line.split("\t", 10)
                     if len(sline) < 10:
                         raise ValueError(f"Expected at least 10 columns in {infile}, found {len(sline)}")
 
                     identifier = f"{COMPLEXPORTAL}:{sline[0]}"
                     label = sline[1]  # recommended name
-                    if identifier not in used_labels:
+                    if identifier not in used_identifiers:
                         outl.write(f"{identifier}\t{label}\n")
-                        used_labels.add(identifier)
+                        used_identifiers.add(identifier)
 
                     synonyms_str = sline[2]  # aliases for complex
                     if synonyms_str != "-":

--- a/src/datahandlers/complexportal.py
+++ b/src/datahandlers/complexportal.py
@@ -14,6 +14,32 @@ COMPLEXPORTAL_COMPLEXTAB_URL = "https://ftp.ebi.ac.uk/pub/databases/intact/compl
 COMPLEXPORTAL_MANIFEST = "downloaded_tsv_files.txt"
 COMPLEXPORTAL_DOWNLOAD_DONE = "download_done"
 
+# All 19 columns in the ComplexPortal ComplexTAB TSV format (as of 2026-06).
+# Columns read by Babel are marked with (*); the rest are set to "-" in most rows.
+# Columns noted as "could" are candidates for future ingestion.
+COMPLEXTAB_COLUMNS = [
+    "#Complex ac",  # 0  (*) complex accession → CURIE
+    "Recommended name",  # 1  (*) preferred label
+    "Aliases for complex",  # 2  (*) "|"-separated synonyms, or "-"
+    "Taxonomy identifier",  # 3  (*) NCBI taxon integer, or "-"
+    "Identifiers (and stoichiometry) of molecules in complex",  # 4  participants — could add to concords
+    "Evidence Code",  # 5
+    "Experimental evidence",  # 6
+    "Go Annotations",  # 7  GO terms — could enrich type/function info
+    "Cross references",  # 8  Reactome, PubMed, wwPDB, etc. — potential concord sources
+    "Description",  # 9  (*) free-text description
+    "Complex properties",  # 10
+    "Complex assembly",  # 11
+    "Ligand",  # 12
+    "Disease",  # 13 disease associations — potentially useful
+    "Agonist",  # 14
+    "Antagonist",  # 15
+    "Comment",  # 16
+    "Source",  # 17
+    "Expanded participant list",  # 18
+]
+COMPLEXTAB_HEADER = "\t".join(COMPLEXTAB_COLUMNS) + "\n"
+
 
 class _DirectoryListingParser(HTMLParser):
     """Collect all href values from anchor tags in an HTML page."""

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -79,19 +79,19 @@ rule get_EFO_labels:
 
 rule get_complexportal:
     output:
-        complexportal_tsv_list=config["download_directory"] + "/ComplexPortal/downloaded_tsv_files.txt",
+        download_done=config["download_directory"] + "/ComplexPortal/download_done",
     benchmark:
         config["output_directory"] + "/benchmarks/get_complexportal.tsv"
     resources:
         mem="8G",
         cpus_per_task=1,
     run:
-        complexportal.pull_complexportal(output.complexportal_tsv_list)
+        complexportal.pull_complexportal(output.download_done)
 
 
 rule get_complexportal_labels_and_synonyms:
     input:
-        manifest=config["download_directory"] + "/ComplexPortal/downloaded_tsv_files.txt",
+        download_done=config["download_directory"] + "/ComplexPortal/download_done",
     output:
         lfile=config["download_directory"] + "/ComplexPortal/labels",
         sfile=config["download_directory"] + "/ComplexPortal/synonyms",
@@ -101,9 +101,10 @@ rule get_complexportal_labels_and_synonyms:
     benchmark:
         config["output_directory"] + "/benchmarks/get_complexportal_labels_and_synonyms.tsv"
     run:
+        download_dir = os.path.dirname(input.download_done)
         complexportal.make_labels_synonyms_and_taxa(
-            input.manifest,
-            os.path.dirname(input.manifest),
+            os.path.join(download_dir, complexportal.COMPLEXPORTAL_MANIFEST),
+            download_dir,
             output.lfile,
             output.sfile,
             output.taxafile,

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -95,12 +95,13 @@ rule get_complexportal_labels_and_synonyms:
     output:
         lfile=config["download_directory"] + "/ComplexPortal/labels",
         sfile=config["download_directory"] + "/ComplexPortal/synonyms",
+        taxafile=config["download_directory"] + "/ComplexPortal/taxa",
         metadata_yaml=config["download_directory"] + "/ComplexPortal/metadata.yaml",
     benchmark:
         config["output_directory"] + "/benchmarks/get_complexportal_labels_and_synonyms.tsv"
     run:
-        complexportal.make_labels_and_synonyms(
-            input.manifest, os.path.dirname(input.manifest), output.lfile, output.sfile, output.metadata_yaml
+        complexportal.make_labels_synonyms_and_taxa(
+            input.manifest, os.path.dirname(input.manifest), output.lfile, output.sfile, output.taxafile, output.metadata_yaml
         )
 
 

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -79,7 +79,7 @@ rule get_EFO_labels:
 
 rule get_complexportal:
     output:
-        complexportal_tsv_list = config["download_directory"] + "/ComplexPortal/downloaded_tsv_files.txt",
+        complexportal_tsv_list=config["download_directory"] + "/ComplexPortal/downloaded_tsv_files.txt",
     benchmark:
         config["output_directory"] + "/benchmarks/get_complexportal.tsv"
     resources:
@@ -102,7 +102,13 @@ rule get_complexportal_labels_and_synonyms:
         config["output_directory"] + "/benchmarks/get_complexportal_labels_and_synonyms.tsv"
     run:
         complexportal.make_labels_synonyms_and_taxa(
-            input.manifest, os.path.dirname(input.manifest), output.lfile, output.sfile, output.taxafile, output.descfile, output.metadata_yaml
+            input.manifest,
+            os.path.dirname(input.manifest),
+            output.lfile,
+            output.sfile,
+            output.taxafile,
+            output.descfile,
+            output.metadata_yaml,
         )
 
 

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -79,14 +79,14 @@ rule get_EFO_labels:
 
 rule get_complexportal:
     output:
-        config["download_directory"] + "/ComplexPortal/downloaded_tsv_files.txt",
+        complexportal_tsv_list = config["download_directory"] + "/ComplexPortal/downloaded_tsv_files.txt",
     benchmark:
         config["output_directory"] + "/benchmarks/get_complexportal.tsv"
     resources:
         mem="8G",
         cpus_per_task=1,
     run:
-        complexportal.pull_complexportal(output[0])
+        complexportal.pull_complexportal(output.complexportal_tsv_list)
 
 
 rule get_complexportal_labels_and_synonyms:

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -79,19 +79,19 @@ rule get_EFO_labels:
 
 rule get_complexportal:
     output:
-        download_done=config["download_directory"] + "/ComplexPortal/download_done",
+        manifest=config["download_directory"] + "/ComplexPortal/" + complexportal.COMPLEXPORTAL_MANIFEST,
     benchmark:
         config["output_directory"] + "/benchmarks/get_complexportal.tsv"
     resources:
         mem="8G",
         cpus_per_task=1,
     run:
-        complexportal.pull_complexportal(output.download_done)
+        complexportal.pull_complexportal(output.manifest)
 
 
 rule get_complexportal_labels_and_synonyms:
     input:
-        download_done=config["download_directory"] + "/ComplexPortal/download_done",
+        manifest=config["download_directory"] + "/ComplexPortal/" + complexportal.COMPLEXPORTAL_MANIFEST,
     output:
         lfile=config["download_directory"] + "/ComplexPortal/labels",
         sfile=config["download_directory"] + "/ComplexPortal/synonyms",
@@ -102,10 +102,9 @@ rule get_complexportal_labels_and_synonyms:
     benchmark:
         config["output_directory"] + "/benchmarks/get_complexportal_labels_and_synonyms.tsv"
     run:
-        download_dir = os.path.dirname(input.download_done)
         complexportal.make_labels_synonyms_and_taxa(
-            os.path.join(download_dir, complexportal.COMPLEXPORTAL_MANIFEST),
-            download_dir,
+            input.manifest,
+            os.path.dirname(input.manifest),
             output.lfile,
             output.sfile,
             output.taxafile,

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -96,12 +96,13 @@ rule get_complexportal_labels_and_synonyms:
         lfile=config["download_directory"] + "/ComplexPortal/labels",
         sfile=config["download_directory"] + "/ComplexPortal/synonyms",
         taxafile=config["download_directory"] + "/ComplexPortal/taxa",
+        descfile=config["download_directory"] + "/ComplexPortal/descriptions",
         metadata_yaml=config["download_directory"] + "/ComplexPortal/metadata.yaml",
     benchmark:
         config["output_directory"] + "/benchmarks/get_complexportal_labels_and_synonyms.tsv"
     run:
         complexportal.make_labels_synonyms_and_taxa(
-            input.manifest, os.path.dirname(input.manifest), output.lfile, output.sfile, output.taxafile, output.metadata_yaml
+            input.manifest, os.path.dirname(input.manifest), output.lfile, output.sfile, output.taxafile, output.descfile, output.metadata_yaml
         )
 
 

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -98,6 +98,7 @@ rule get_complexportal_labels_and_synonyms:
         taxafile=config["download_directory"] + "/ComplexPortal/taxa",
         descfile=config["download_directory"] + "/ComplexPortal/descriptions",
         metadata_yaml=config["download_directory"] + "/ComplexPortal/metadata.yaml",
+        idsfile=config["intermediate_directory"] + "/macromolecular_complex/ids/ComplexPortal",
     benchmark:
         config["output_directory"] + "/benchmarks/get_complexportal_labels_and_synonyms.tsv"
     run:
@@ -110,6 +111,7 @@ rule get_complexportal_labels_and_synonyms:
             output.taxafile,
             output.descfile,
             output.metadata_yaml,
+            output.idsfile,
         )
 
 

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -99,7 +99,9 @@ rule get_complexportal_labels_and_synonyms:
     benchmark:
         config["output_directory"] + "/benchmarks/get_complexportal_labels_and_synonyms.tsv"
     run:
-        complexportal.make_labels_and_synonyms(input.manifest, output.lfile, output.sfile, output.metadata_yaml)
+        complexportal.make_labels_and_synonyms(
+            input.manifest, os.path.dirname(input.manifest), output.lfile, output.sfile, output.metadata_yaml
+        )
 
 
 ### MODS

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -79,27 +79,27 @@ rule get_EFO_labels:
 
 rule get_complexportal:
     output:
-        config["download_directory"] + "/ComplexPortal" + "/559292.tsv",
+        config["download_directory"] + "/ComplexPortal/downloaded_tsv_files.txt",
     benchmark:
         config["output_directory"] + "/benchmarks/get_complexportal.tsv"
     resources:
         mem="8G",
         cpus_per_task=1,
     run:
-        complexportal.pull_complexportal()
+        complexportal.pull_complexportal(output[0])
 
 
 rule get_complexportal_labels_and_synonyms:
     input:
-        infile=config["download_directory"] + "/ComplexPortal" + "/559292.tsv",
+        manifest=config["download_directory"] + "/ComplexPortal/downloaded_tsv_files.txt",
     output:
-        lfile=config["download_directory"] + "/ComplexPortal" + "/559292_labels.tsv",
-        sfile=config["download_directory"] + "/ComplexPortal" + "/559292_synonyms.tsv",
+        lfile=config["download_directory"] + "/ComplexPortal/labels",
+        sfile=config["download_directory"] + "/ComplexPortal/synonyms",
         metadata_yaml=config["download_directory"] + "/ComplexPortal/metadata.yaml",
     benchmark:
         config["output_directory"] + "/benchmarks/get_complexportal_labels_and_synonyms.tsv"
     run:
-        complexportal.make_labels_and_synonyms(input.infile, output.lfile, output.sfile, output.metadata_yaml)
+        complexportal.make_labels_and_synonyms(input.manifest, output.lfile, output.sfile, output.metadata_yaml)
 
 
 ### MODS

--- a/src/snakefiles/macromolecular_complex.snakefile
+++ b/src/snakefiles/macromolecular_complex.snakefile
@@ -18,6 +18,8 @@ rule macromolecular_complex_compendia:
     input:
         labels=config["download_directory"] + "/ComplexPortal/labels",
         synonyms=config["download_directory"] + "/ComplexPortal/synonyms",
+        taxafile=config["download_directory"] + "/ComplexPortal/taxa",
+        descfile=config["download_directory"] + "/ComplexPortal/descriptions",
         idlists=config["intermediate_directory"] + "/macromolecular_complex/ids/ComplexPortal",
         metadata_yaml=config["download_directory"] + "/ComplexPortal/metadata.yaml",
         icrdf_filename=config["download_directory"] + "/icRDF.tsv",

--- a/src/snakefiles/macromolecular_complex.snakefile
+++ b/src/snakefiles/macromolecular_complex.snakefile
@@ -3,17 +3,6 @@ import src.assess_compendia as assessments
 import src.snakefiles.util as util
 
 
-rule macromolecular_complex_ids:
-    input:
-        infile=config["download_directory"] + "/ComplexPortal/labels",
-    output:
-        outfile=config["intermediate_directory"] + "/macromolecular_complex/ids/ComplexPortal",
-    benchmark:
-        config["output_directory"] + "/benchmarks/macromolecular_complex_ids.tsv"
-    shell:
-        "awk '{{print $1\"\tbiolink:MacromolecularComplex\"}}' {input.infile} > {output.outfile}"
-
-
 rule macromolecular_complex_compendia:
     input:
         labels=config["download_directory"] + "/ComplexPortal/labels",

--- a/src/snakefiles/macromolecular_complex.snakefile
+++ b/src/snakefiles/macromolecular_complex.snakefile
@@ -5,7 +5,7 @@ import src.snakefiles.util as util
 
 rule macromolecular_complex_ids:
     input:
-        infile=config["download_directory"] + "/ComplexPortal/559292_labels.tsv",
+        infile=config["download_directory"] + "/ComplexPortal/labels",
     output:
         outfile=config["intermediate_directory"] + "/macromolecular_complex/ids/ComplexPortal",
     benchmark:
@@ -16,8 +16,8 @@ rule macromolecular_complex_ids:
 
 rule macromolecular_complex_compendia:
     input:
-        labels=config["download_directory"] + "/ComplexPortal/559292_labels.tsv",
-        synonyms=config["download_directory"] + "/ComplexPortal/559292_synonyms.tsv",
+        labels=config["download_directory"] + "/ComplexPortal/labels",
+        synonyms=config["download_directory"] + "/ComplexPortal/synonyms",
         idlists=config["intermediate_directory"] + "/macromolecular_complex/ids/ComplexPortal",
         metadata_yaml=config["download_directory"] + "/ComplexPortal/metadata.yaml",
         icrdf_filename=config["download_directory"] + "/icRDF.tsv",

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,6 +41,18 @@ considering), see [`docs/Testing.md`](../docs/Testing.md).
 - **Pipeline behavior specific to one vocabulary** → add `tests/pipeline/test_X_pipeline.py`
   marked `pipeline`.
 
+**Touching a data source that has no pipeline test? Consider writing one.** It is more work up
+front, but it pays off three ways and is worth biting the bullet for:
+
+- It forces you to write smaller **`network` tests** (e.g. that the upstream listing still returns
+  files, that the header columns Babel reads are still where it expects) that can run regularly and
+  catch an upstream format change *before* it silently corrupts output — see
+  `tests/pipeline/test_complexportal.py` (header-column assertion) and the `network` test in
+  `tests/datahandlers/test_complexportal.py`.
+- It validates the handler's outputs end-to-end against real data, using the shared
+  `assert_*_file_valid` helpers.
+- It becomes the place to hang later assertions about that source's compendium output.
+
 See [Future Plans](#future-plans) at the bottom of this file for a more detailed roadmap of
 planned test locations and conventions.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -150,9 +150,27 @@ For handlers that produce label/synonym files, add a module-scoped `*_output` fi
 `tmp_path_factory` that calls the extraction method once and stores the file contents as a dict.
 Individual tests then receive the pre-computed output rather than re-running the extraction.
 
+The **root** `tests/conftest.py` exports format-validation helpers shared by both datahandler and
+pipeline tests: `assert_labels_file_valid`, `assert_synonyms_file_valid`, `assert_ids_file_valid`,
+`assert_concordance_file_valid`, `assert_taxa_file_valid`, and `assert_descriptions_file_valid`.
+Each asserts the file is non-empty and column-shaped correctly and returns the parsed rows. Use
+these (and `read_tsv`) instead of hand-rolling TSV checks; when a handler grows a new output kind
+(as ComplexPortal did for taxa and descriptions), add the matching helper here rather than keeping
+a private one in the test file.
+
 - **`datahandlers/test_mesh.py`** (`unit`) — Unit tests for `src/datahandlers/mesh.py`.
   Covers `write_ids()` parameter validation, SCR filtering logic (mock-based), and
   `Mesh.get_scr_terms_mapped_to_trees()` using an inline pyoxigraph store.
+
+- **`datahandlers/test_complexportal.py`** (`unit`, one `network`) — Unit tests for
+  `src/datahandlers/complexportal.py`. Covers HTML directory-listing parsing (only `.tsv`
+  hrefs returned, sorted), download + manifest writing (mocked), and the cross-species
+  deduplication rules for every output (labels by identifier with first-seen winning, synonyms
+  and descriptions by pair, taxa keeping all `(id, taxon)` pairs, IDs including accessions with
+  an empty label). Test rows are built from the real 19-column header via `COMPLEXTAB_COLUMNS`/
+  `COMPLEXTAB_HEADER` imported from the source module, so a column-layout change in source is
+  reflected in the fixtures automatically. The single `network` test hits the live EBI listing
+  and asserts it returns at least one sorted `.tsv` file.
 
 - **`datahandlers/test_ensembl.py`** (`network`, `xfail`) — Integration test for the Ensembl
   BioMart data handler. Pulls real data from BioMart, verifies that batched downloads
@@ -186,6 +204,15 @@ and how to add new checks or vocabularies.
 - **`pipeline/test_ec.py`**, **`pipeline/test_rhea.py`**, **`pipeline/test_chembl.py`**,
   **`pipeline/test_clo.py`**, **`pipeline/test_efo.py`** (`pipeline`) — Output format and
   content checks for the EC, Rhea, ChEMBL, CLO, and EFO data handlers.
+
+- **`pipeline/test_complexportal.py`** (`pipeline`) — Downloads all ComplexPortal TSV files and
+  validates the `labels`, `synonyms`, `taxa`, and `descriptions` outputs with the shared
+  `assert_*_file_valid` helpers. Two guards worth copying for other sources: a **header-column
+  assertion** that pins the index of every column Babel reads, so an upstream format change is
+  caught here rather than silently corrupting the taxon/description extraction; and a
+  **cross-file consistency** test that re-reads every source TSV and confirms each `(CURIE,
+  taxon)` pair survives into the taxa output while labels and synonyms stay deduplicated (using
+  `collections.Counter`, not `O(n²)` `list.count()`).
 
 - **`pipeline/checks/`** (`pipeline`) — Per-compendium regression assertions tied to GitHub
   issues (ID-presence and direct cross-reference checks), designed for TDD. See

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,32 @@ def assert_concordance_file_valid(path: str) -> list[list[str]]:
     return rows
 
 
+def assert_taxa_file_valid(path: str) -> list[list[str]]:
+    """Assert the file is non-empty and every line is CURIE\\tNCBITaxon:ID; return the rows."""
+    rows = read_tsv(path)
+    assert rows, f"Taxa file is empty: {path}"
+    for cols in rows:
+        assert len(cols) == 2, f"Expected 2 columns, got {len(cols)}: {cols}"
+        assert ":" in cols[0], f"First column is not a CURIE: {cols[0]}"
+        assert cols[1].startswith("NCBITaxon:"), f"Second column is not an NCBITaxon CURIE: {cols[1]}"
+    return rows
+
+
+def assert_descriptions_file_valid(path: str) -> list[list[str]]:
+    """Assert the file is non-empty and every line is CURIE\\tdescription; return the rows."""
+    rows = []
+    with open(path) as f:
+        for line in f:
+            stripped = line.rstrip("\n")
+            if stripped:
+                cols = stripped.split("\t", 1)
+                assert len(cols) == 2, f"Expected 2 columns in descriptions file, got {len(cols)}: {cols}"
+                assert ":" in cols[0], f"First column is not a CURIE: {cols[0]}"
+                rows.append(cols)
+    assert rows, f"Descriptions file is empty: {path}"
+    return rows
+
+
 CONFLATION_FIXTURE_ROWS = [
     ["NCBIGENE:1", "UniProtKB:A0A000", "UniProtKB:B0B000"],
     ["NCBIGENE:2", "UniProtKB:C0C000"],

--- a/tests/datahandlers/test_complexportal.py
+++ b/tests/datahandlers/test_complexportal.py
@@ -25,31 +25,54 @@ class _FakeResponse:
 # Real ComplexPortal ComplexTAB header (all 19 columns as of 2026-06).
 # Columns currently used by Babel are marked with (*); the rest are set to "-" in test rows.
 # Columns worth considering for future use are noted inline.
-_HEADER = (
-    "#Complex ac\t"           # 0  (*) complex accession → CURIE
-    "Recommended name\t"      # 1  (*) preferred label
-    "Aliases for complex\t"   # 2  (*) "|"-separated synonyms, or "-"
-    "Taxonomy identifier\t"   # 3  (*) NCBI taxon integer, or "-"
-    "Identifiers (and stoichiometry) of molecules in complex\t"  # 4  participants — could add to concords
-    "Evidence Code\t"         # 5
-    "Experimental evidence\t" # 6
-    "Go Annotations\t"        # 7  GO terms — could enrich type/function info
-    "Cross references\t"      # 8  Reactome, PubMed, wwPDB, etc. — potential concord sources
-    "Description\t"           # 9  free-text description — could populate descriptions file
-    "Complex properties\t"    # 10
-    "Complex assembly\t"      # 11
-    "Ligand\t"                # 12
-    "Disease\t"               # 13 disease associations — potentially useful
-    "Agonist\t"               # 14
-    "Antagonist\t"            # 15
-    "Comment\t"               # 16
-    "Source\t"                # 17
-    "Expanded participant list\n"  # 18
-)
+_COLUMNS = [
+    "#Complex ac",                                           # 0  (*) complex accession → CURIE
+    "Recommended name",                                      # 1  (*) preferred label
+    "Aliases for complex",                                   # 2  (*) "|"-separated synonyms, or "-"
+    "Taxonomy identifier",                                   # 3  (*) NCBI taxon integer, or "-"
+    "Identifiers (and stoichiometry) of molecules in complex",  # 4  participants — could add to concords
+    "Evidence Code",                                         # 5
+    "Experimental evidence",                                 # 6
+    "Go Annotations",                                        # 7  GO terms — could enrich type/function info
+    "Cross references",                                      # 8  Reactome, PubMed, wwPDB, etc. — potential concord sources
+    "Description",                                           # 9  (*) free-text description
+    "Complex properties",                                    # 10
+    "Complex assembly",                                      # 11
+    "Ligand",                                                # 12
+    "Disease",                                               # 13 disease associations — potentially useful
+    "Agonist",                                               # 14
+    "Antagonist",                                            # 15
+    "Comment",                                               # 16
+    "Source",                                                # 17
+    "Expanded participant list",                             # 18
+]
+_HEADER = "\t".join(_COLUMNS) + "\n"
 
-# Shorthand for a row with all unused columns set to "-".
-def _row(ac, name, aliases, taxon):
-    return f"{ac}\t{name}\t{aliases}\t{taxon}\t" + "\t".join(["-"] * 15) + "\n"
+
+def _row(ac, name, aliases, taxon, description="-"):
+    """Build a test data row with only the columns Babel reads set to real values."""
+    values = ["-"] * len(_COLUMNS)
+    values[0] = ac
+    values[1] = name
+    values[2] = aliases
+    values[3] = taxon
+    values[9] = description
+    return "\t".join(values) + "\n"
+
+
+def _assert_descriptions_file_valid(path: str) -> list[list[str]]:
+    """Assert every line is CURIE\\tdescription; return the rows."""
+    rows = []
+    with open(path) as f:
+        for line in f:
+            stripped = line.rstrip("\n")
+            if stripped:
+                cols = stripped.split("\t", 1)
+                assert len(cols) == 2, f"Expected 2 columns in descriptions file, got {len(cols)}: {cols}"
+                assert cols[0].startswith(f"{COMPLEXPORTAL}:"), f"First column is not a ComplexPortal CURIE: {cols[0]}"
+                rows.append(cols)
+    assert rows, f"Descriptions file is empty: {path}"
+    return rows
 
 
 def _assert_taxa_file_valid(path: str) -> list[list[str]]:
@@ -125,27 +148,30 @@ def test_make_labels_synonyms_and_taxa_combines_manifest_files(tmp_path):
 
     (complexportal_dir / "10090.tsv").write_text(
         _HEADER
-        + _row("CPX-1", "Mediator complex", "Mediator|Mediator complex", "10090")
-        + _row("CPX-2", "Shared alias complex", "Mediator", "10090")
+        + _row("CPX-1", "Mediator complex", "Mediator|Mediator complex", "10090", "A conserved complex.")
+        + _row("CPX-2", "Shared alias complex", "Mediator", "10090", "Another complex.")
     )
     (complexportal_dir / "559292.tsv").write_text(
         _HEADER
-        + _row("CPX-1", "Mediator complex", "Mediator|Mediator complex", "559292")
+        # CPX-1 has the same description in both files — should appear only once.
+        + _row("CPX-1", "Mediator complex", "Mediator|Mediator complex", "559292", "A conserved complex.")
         + _row("CPX-3", "No alias complex", "-", "559292")
     )
 
     labels = complexportal_dir / "labels"
     synonyms = complexportal_dir / "synonyms"
     taxa = complexportal_dir / "taxa"
+    descriptions = complexportal_dir / "descriptions"
     metadata = complexportal_dir / "metadata.yaml"
 
     complexportal.make_labels_synonyms_and_taxa(
-        str(manifest), str(complexportal_dir), str(labels), str(synonyms), str(taxa), str(metadata)
+        str(manifest), str(complexportal_dir), str(labels), str(synonyms), str(taxa), str(descriptions), str(metadata)
     )
 
     label_rows = assert_labels_file_valid(str(labels))
     synonym_rows = assert_synonyms_file_valid(str(synonyms))
     taxa_rows = _assert_taxa_file_valid(str(taxa))
+    desc_rows = _assert_descriptions_file_valid(str(descriptions))
 
     assert label_rows == [
         [f"{COMPLEXPORTAL}:CPX-1", "Mediator complex"],
@@ -162,6 +188,12 @@ def test_make_labels_synonyms_and_taxa_combines_manifest_files(tmp_path):
     assert [f"{COMPLEXPORTAL}:CPX-1", "NCBITaxon:559292"] in taxa_rows
     assert [f"{COMPLEXPORTAL}:CPX-2", "NCBITaxon:10090"] in taxa_rows
     assert [f"{COMPLEXPORTAL}:CPX-3", "NCBITaxon:559292"] in taxa_rows
+    # CPX-1 appears in both files with the same description text — written only once.
+    cpx1_descs = [row[1] for row in desc_rows if row[0] == f"{COMPLEXPORTAL}:CPX-1"]
+    assert cpx1_descs == ["A conserved complex."]
+    assert [f"{COMPLEXPORTAL}:CPX-2", "Another complex."] in desc_rows
+    # CPX-3 has no description ("-"); it should not appear in the descriptions file.
+    assert not any(row[0] == f"{COMPLEXPORTAL}:CPX-3" for row in desc_rows)
     assert metadata.exists()
 
 
@@ -173,16 +205,21 @@ def test_make_labels_synonyms_and_taxa_deduplicates_labels_by_identifier(tmp_pat
     manifest = complexportal_dir / complexportal.COMPLEXPORTAL_MANIFEST
     manifest.write_text("9606.tsv\n10090.tsv\n")
 
-    (complexportal_dir / "9606.tsv").write_text(_HEADER + _row("CPX-1", "Human name", "-", "9606"))
-    (complexportal_dir / "10090.tsv").write_text(_HEADER + _row("CPX-1", "Mouse name", "-", "10090"))
+    (complexportal_dir / "9606.tsv").write_text(
+        _HEADER + _row("CPX-1", "Human name", "-", "9606", "Human-specific description.")
+    )
+    (complexportal_dir / "10090.tsv").write_text(
+        _HEADER + _row("CPX-1", "Mouse name", "-", "10090", "Mouse-specific description.")
+    )
 
     labels = complexportal_dir / "labels"
     synonyms = complexportal_dir / "synonyms"
     taxa = complexportal_dir / "taxa"
+    descriptions = complexportal_dir / "descriptions"
     metadata = complexportal_dir / "metadata.yaml"
 
     complexportal.make_labels_synonyms_and_taxa(
-        str(manifest), str(complexportal_dir), str(labels), str(synonyms), str(taxa), str(metadata)
+        str(manifest), str(complexportal_dir), str(labels), str(synonyms), str(taxa), str(descriptions), str(metadata)
     )
 
     label_rows = assert_labels_file_valid(str(labels))
@@ -192,6 +229,11 @@ def test_make_labels_synonyms_and_taxa_deduplicates_labels_by_identifier(tmp_pat
     taxa_rows = _assert_taxa_file_valid(str(taxa))
     assert [f"{COMPLEXPORTAL}:CPX-1", "NCBITaxon:9606"] in taxa_rows
     assert [f"{COMPLEXPORTAL}:CPX-1", "NCBITaxon:10090"] in taxa_rows
+
+    # Both descriptions are kept — DescriptionFactory accumulates all descriptions per identifier.
+    desc_rows = _assert_descriptions_file_valid(str(descriptions))
+    desc_texts = {row[1] for row in desc_rows if row[0] == f"{COMPLEXPORTAL}:CPX-1"}
+    assert desc_texts == {"Human-specific description.", "Mouse-specific description."}
 
 
 @pytest.mark.unit
@@ -211,15 +253,42 @@ def test_make_labels_synonyms_and_taxa_skips_missing_taxon(tmp_path):
     labels = complexportal_dir / "labels"
     synonyms = complexportal_dir / "synonyms"
     taxa = complexportal_dir / "taxa"
+    descriptions = complexportal_dir / "descriptions"
     metadata = complexportal_dir / "metadata.yaml"
 
     complexportal.make_labels_synonyms_and_taxa(
-        str(manifest), str(complexportal_dir), str(labels), str(synonyms), str(taxa), str(metadata)
+        str(manifest), str(complexportal_dir), str(labels), str(synonyms), str(taxa), str(descriptions), str(metadata)
     )
 
     taxa_rows = _assert_taxa_file_valid(str(taxa))
     assert len(taxa_rows) == 1
     assert taxa_rows[0] == [f"{COMPLEXPORTAL}:CPX-1", "NCBITaxon:9606"]
+
+
+@pytest.mark.unit
+def test_make_labels_synonyms_and_taxa_deduplicates_identical_descriptions(tmp_path):
+    """Same description text in two species files produces only one description row."""
+    complexportal_dir = tmp_path / "ComplexPortal"
+    complexportal_dir.mkdir()
+    manifest = complexportal_dir / complexportal.COMPLEXPORTAL_MANIFEST
+    manifest.write_text("9606.tsv\n10090.tsv\n")
+
+    shared_desc = "A description shared verbatim across species."
+    (complexportal_dir / "9606.tsv").write_text(_HEADER + _row("CPX-1", "Human name", "-", "9606", shared_desc))
+    (complexportal_dir / "10090.tsv").write_text(_HEADER + _row("CPX-1", "Mouse name", "-", "10090", shared_desc))
+
+    labels = complexportal_dir / "labels"
+    synonyms = complexportal_dir / "synonyms"
+    taxa = complexportal_dir / "taxa"
+    descriptions = complexportal_dir / "descriptions"
+    metadata = complexportal_dir / "metadata.yaml"
+
+    complexportal.make_labels_synonyms_and_taxa(
+        str(manifest), str(complexportal_dir), str(labels), str(synonyms), str(taxa), str(descriptions), str(metadata)
+    )
+
+    desc_rows = _assert_descriptions_file_valid(str(descriptions))
+    assert desc_rows == [[f"{COMPLEXPORTAL}:CPX-1", shared_desc]]
 
 
 @pytest.mark.network

--- a/tests/datahandlers/test_complexportal.py
+++ b/tests/datahandlers/test_complexportal.py
@@ -87,7 +87,9 @@ def test_fetch_complexportal_tsv_filenames_selects_tsv_links():
 
 @pytest.mark.unit
 def test_pull_complexportal_downloads_all_discovered_tsvs_and_writes_manifest(tmp_path):
-    manifest = tmp_path / "ComplexPortal" / complexportal.COMPLEXPORTAL_MANIFEST
+    complexportal_dir = tmp_path / "ComplexPortal"
+    download_done = complexportal_dir / complexportal.COMPLEXPORTAL_DOWNLOAD_DONE
+    manifest = complexportal_dir / complexportal.COMPLEXPORTAL_MANIFEST
 
     with (
         patch(
@@ -95,9 +97,10 @@ def test_pull_complexportal_downloads_all_discovered_tsvs_and_writes_manifest(tm
         ),
         patch("src.datahandlers.complexportal.pull_via_urllib") as mock_pull,
     ):
-        complexportal.pull_complexportal(str(manifest))
+        complexportal.pull_complexportal(str(download_done))
 
     assert manifest.read_text() == "10090.tsv\n559292.tsv\n"
+    assert download_done.exists(), "Sentinel file download_done should be written last"
     assert mock_pull.call_count == 2
     mock_pull.assert_any_call(
         complexportal.COMPLEXPORTAL_COMPLEXTAB_URL,

--- a/tests/datahandlers/test_complexportal.py
+++ b/tests/datahandlers/test_complexportal.py
@@ -5,7 +5,12 @@ import pytest
 from src.datahandlers import complexportal
 from src.predicates import HAS_EXACT_SYNONYM
 from src.prefixes import COMPLEXPORTAL
-from tests.conftest import assert_labels_file_valid, assert_synonyms_file_valid
+from tests.conftest import (
+    assert_descriptions_file_valid,
+    assert_labels_file_valid,
+    assert_synonyms_file_valid,
+    assert_taxa_file_valid,
+)
 
 
 class _FakeResponse:
@@ -58,37 +63,6 @@ def _row(ac, name, aliases, taxon, description="-"):
     values[3] = taxon
     values[9] = description
     return "\t".join(values) + "\n"
-
-
-def _assert_descriptions_file_valid(path: str) -> list[list[str]]:
-    """Assert every line is CURIE\\tdescription; return the rows."""
-    rows = []
-    with open(path) as f:
-        for line in f:
-            stripped = line.rstrip("\n")
-            if stripped:
-                cols = stripped.split("\t", 1)
-                assert len(cols) == 2, f"Expected 2 columns in descriptions file, got {len(cols)}: {cols}"
-                assert cols[0].startswith(f"{COMPLEXPORTAL}:"), f"First column is not a ComplexPortal CURIE: {cols[0]}"
-                rows.append(cols)
-    assert rows, f"Descriptions file is empty: {path}"
-    return rows
-
-
-def _assert_taxa_file_valid(path: str) -> list[list[str]]:
-    """Assert every line is CURIE\\tNCBITaxon:NNNN; return the rows."""
-    rows = []
-    with open(path) as f:
-        for line in f:
-            stripped = line.rstrip("\n")
-            if stripped:
-                cols = stripped.split("\t")
-                assert len(cols) == 2, f"Expected 2 columns in taxa file, got {len(cols)}: {cols}"
-                assert cols[0].startswith(f"{COMPLEXPORTAL}:"), f"First column is not a ComplexPortal CURIE: {cols[0]}"
-                assert cols[1].startswith("NCBITaxon:"), f"Second column is not an NCBITaxon CURIE: {cols[1]}"
-                rows.append(cols)
-    assert rows, f"Taxa file is empty: {path}"
-    return rows
 
 
 @pytest.mark.unit
@@ -170,8 +144,8 @@ def test_make_labels_synonyms_and_taxa_combines_manifest_files(tmp_path):
 
     label_rows = assert_labels_file_valid(str(labels))
     synonym_rows = assert_synonyms_file_valid(str(synonyms))
-    taxa_rows = _assert_taxa_file_valid(str(taxa))
-    desc_rows = _assert_descriptions_file_valid(str(descriptions))
+    taxa_rows = assert_taxa_file_valid(str(taxa))
+    desc_rows = assert_descriptions_file_valid(str(descriptions))
 
     assert label_rows == [
         [f"{COMPLEXPORTAL}:CPX-1", "Mediator complex"],
@@ -226,12 +200,12 @@ def test_make_labels_synonyms_and_taxa_deduplicates_labels_by_identifier(tmp_pat
     assert label_rows == [[f"{COMPLEXPORTAL}:CPX-1", "Human name"]]
 
     # Both taxa are recorded even though the label was deduplicated.
-    taxa_rows = _assert_taxa_file_valid(str(taxa))
+    taxa_rows = assert_taxa_file_valid(str(taxa))
     assert [f"{COMPLEXPORTAL}:CPX-1", "NCBITaxon:9606"] in taxa_rows
     assert [f"{COMPLEXPORTAL}:CPX-1", "NCBITaxon:10090"] in taxa_rows
 
     # Both descriptions are kept — DescriptionFactory accumulates all descriptions per identifier.
-    desc_rows = _assert_descriptions_file_valid(str(descriptions))
+    desc_rows = assert_descriptions_file_valid(str(descriptions))
     desc_texts = {row[1] for row in desc_rows if row[0] == f"{COMPLEXPORTAL}:CPX-1"}
     assert desc_texts == {"Human-specific description.", "Mouse-specific description."}
 
@@ -260,7 +234,7 @@ def test_make_labels_synonyms_and_taxa_skips_missing_taxon(tmp_path):
         str(manifest), str(complexportal_dir), str(labels), str(synonyms), str(taxa), str(descriptions), str(metadata)
     )
 
-    taxa_rows = _assert_taxa_file_valid(str(taxa))
+    taxa_rows = assert_taxa_file_valid(str(taxa))
     assert len(taxa_rows) == 1
     assert taxa_rows[0] == [f"{COMPLEXPORTAL}:CPX-1", "NCBITaxon:9606"]
 
@@ -287,7 +261,7 @@ def test_make_labels_synonyms_and_taxa_deduplicates_identical_descriptions(tmp_p
         str(manifest), str(complexportal_dir), str(labels), str(synonyms), str(taxa), str(descriptions), str(metadata)
     )
 
-    desc_rows = _assert_descriptions_file_valid(str(descriptions))
+    desc_rows = assert_descriptions_file_valid(str(descriptions))
     assert desc_rows == [[f"{COMPLEXPORTAL}:CPX-1", shared_desc]]
 
 

--- a/tests/datahandlers/test_complexportal.py
+++ b/tests/datahandlers/test_complexportal.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import pytest
 
 from src.datahandlers import complexportal
+from src.datahandlers.complexportal import COMPLEXTAB_COLUMNS, COMPLEXTAB_HEADER
 from src.predicates import HAS_EXACT_SYNONYM
 from src.prefixes import COMPLEXPORTAL
 from tests.conftest import (
@@ -28,36 +29,9 @@ class _FakeResponse:
         return self.content
 
 
-# Real ComplexPortal ComplexTAB header (all 19 columns as of 2026-06).
-# Columns currently used by Babel are marked with (*); the rest are set to "-" in test rows.
-# Columns worth considering for future use are noted inline.
-_COLUMNS = [
-    "#Complex ac",  # 0  (*) complex accession → CURIE
-    "Recommended name",  # 1  (*) preferred label
-    "Aliases for complex",  # 2  (*) "|"-separated synonyms, or "-"
-    "Taxonomy identifier",  # 3  (*) NCBI taxon integer, or "-"
-    "Identifiers (and stoichiometry) of molecules in complex",  # 4  participants — could add to concords
-    "Evidence Code",  # 5
-    "Experimental evidence",  # 6
-    "Go Annotations",  # 7  GO terms — could enrich type/function info
-    "Cross references",  # 8  Reactome, PubMed, wwPDB, etc. — potential concord sources
-    "Description",  # 9  (*) free-text description
-    "Complex properties",  # 10
-    "Complex assembly",  # 11
-    "Ligand",  # 12
-    "Disease",  # 13 disease associations — potentially useful
-    "Agonist",  # 14
-    "Antagonist",  # 15
-    "Comment",  # 16
-    "Source",  # 17
-    "Expanded participant list",  # 18
-]
-_HEADER = "\t".join(_COLUMNS) + "\n"
-
-
 def _row(ac, name, aliases, taxon, description="-"):
-    """Build a test data row with only the columns Babel reads set to real values."""
-    values = ["-"] * len(_COLUMNS)
+    """Build a ComplexTAB test row with only the Babel-read columns set; all others are '-'."""
+    values = ["-"] * len(COMPLEXTAB_COLUMNS)
     values[0] = ac
     values[1] = name
     values[2] = aliases
@@ -68,6 +42,7 @@ def _row(ac, name, aliases, taxon, description="-"):
 
 @pytest.mark.unit
 def test_fetch_complexportal_tsv_filenames_selects_tsv_links():
+    """Only .tsv hrefs are returned; parent-directory and non-tsv links are ignored."""
     listing = b"""
     <html>
       <body>
@@ -88,6 +63,7 @@ def test_fetch_complexportal_tsv_filenames_selects_tsv_links():
 
 @pytest.mark.unit
 def test_pull_complexportal_downloads_all_discovered_tsvs_and_writes_manifest(tmp_path):
+    """Every discovered TSV is fetched, the manifest lists them, and download_done is written last."""
     complexportal_dir = tmp_path / "ComplexPortal"
     download_done = complexportal_dir / complexportal.COMPLEXPORTAL_DOWNLOAD_DONE
     manifest = complexportal_dir / complexportal.COMPLEXPORTAL_MANIFEST
@@ -119,18 +95,19 @@ def test_pull_complexportal_downloads_all_discovered_tsvs_and_writes_manifest(tm
 
 @pytest.mark.unit
 def test_make_labels_synonyms_and_taxa_combines_manifest_files(tmp_path):
+    """Labels, synonyms, taxa, descriptions, and IDs are correctly extracted across multiple species files."""
     complexportal_dir = tmp_path / "ComplexPortal"
     complexportal_dir.mkdir()
     manifest = complexportal_dir / complexportal.COMPLEXPORTAL_MANIFEST
     manifest.write_text("10090.tsv\n559292.tsv\n")
 
     (complexportal_dir / "10090.tsv").write_text(
-        _HEADER
+        COMPLEXTAB_HEADER
         + _row("CPX-1", "Mediator complex", "Mediator|Mediator complex", "10090", "A conserved complex.")
         + _row("CPX-2", "Shared alias complex", "Mediator", "10090", "Another complex.")
     )
     (complexportal_dir / "559292.tsv").write_text(
-        _HEADER
+        COMPLEXTAB_HEADER
         # CPX-1 has the same description in both files — should appear only once.
         + _row("CPX-1", "Mediator complex", "Mediator|Mediator complex", "559292", "A conserved complex.")
         + _row("CPX-3", "No alias complex", "-", "559292")
@@ -197,10 +174,10 @@ def test_make_labels_synonyms_and_taxa_deduplicates_labels_by_identifier(tmp_pat
     manifest.write_text("9606.tsv\n10090.tsv\n")
 
     (complexportal_dir / "9606.tsv").write_text(
-        _HEADER + _row("CPX-1", "Human name", "-", "9606", "Human-specific description.")
+        COMPLEXTAB_HEADER + _row("CPX-1", "Human name", "-", "9606", "Human-specific description.")
     )
     (complexportal_dir / "10090.tsv").write_text(
-        _HEADER + _row("CPX-1", "Mouse name", "-", "10090", "Mouse-specific description.")
+        COMPLEXTAB_HEADER + _row("CPX-1", "Mouse name", "-", "10090", "Mouse-specific description.")
     )
 
     labels = complexportal_dir / "labels"
@@ -244,7 +221,9 @@ def test_make_labels_synonyms_and_taxa_skips_missing_taxon(tmp_path):
     manifest.write_text("9606.tsv\n")
 
     (complexportal_dir / "9606.tsv").write_text(
-        _HEADER + _row("CPX-1", "Complex with taxon", "-", "9606") + _row("CPX-2", "Complex without taxon", "-", "-")
+        COMPLEXTAB_HEADER
+        + _row("CPX-1", "Complex with taxon", "-", "9606")
+        + _row("CPX-2", "Complex without taxon", "-", "-")
     )
 
     labels = complexportal_dir / "labels"
@@ -279,8 +258,12 @@ def test_make_labels_synonyms_and_taxa_deduplicates_identical_descriptions(tmp_p
     manifest.write_text("9606.tsv\n10090.tsv\n")
 
     shared_desc = "A description shared verbatim across species."
-    (complexportal_dir / "9606.tsv").write_text(_HEADER + _row("CPX-1", "Human name", "-", "9606", shared_desc))
-    (complexportal_dir / "10090.tsv").write_text(_HEADER + _row("CPX-1", "Mouse name", "-", "10090", shared_desc))
+    (complexportal_dir / "9606.tsv").write_text(
+        COMPLEXTAB_HEADER + _row("CPX-1", "Human name", "-", "9606", shared_desc)
+    )
+    (complexportal_dir / "10090.tsv").write_text(
+        COMPLEXTAB_HEADER + _row("CPX-1", "Mouse name", "-", "10090", shared_desc)
+    )
 
     labels = complexportal_dir / "labels"
     synonyms = complexportal_dir / "synonyms"
@@ -313,7 +296,7 @@ def test_make_labels_synonyms_and_taxa_ids_file_includes_entries_with_empty_labe
     manifest.write_text("9606.tsv\n")
 
     (complexportal_dir / "9606.tsv").write_text(
-        _HEADER
+        COMPLEXTAB_HEADER
         + _row("CPX-1", "Normal complex", "-", "9606")
         + _row("CPX-2", "", "-", "9606")  # empty recommended name
     )
@@ -345,6 +328,7 @@ def test_make_labels_synonyms_and_taxa_ids_file_includes_entries_with_empty_labe
 
 @pytest.mark.network
 def test_fetch_complexportal_tsv_filenames_returns_real_files():
+    """Live EBI endpoint returns at least one .tsv file and the list is sorted."""
     filenames = complexportal.fetch_complexportal_tsv_filenames()
     assert len(filenames) > 0
     assert all(f.endswith(".tsv") for f in filenames)

--- a/tests/datahandlers/test_complexportal.py
+++ b/tests/datahandlers/test_complexportal.py
@@ -1,0 +1,110 @@
+from unittest.mock import patch
+
+import pytest
+
+from src.datahandlers import complexportal
+from src.prefixes import COMPLEXPORTAL
+from tests.conftest import assert_labels_file_valid, read_tsv
+
+
+class _FakeResponse:
+    def __init__(self, content):
+        self.content = content
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+    def read(self):
+        return self.content
+
+
+@pytest.mark.unit
+def test_get_complexportal_tsv_filenames_selects_tsv_links():
+    listing = b"""
+    <html>
+      <body>
+        <a href="../">Parent Directory</a>
+        <a href="README.htm">README.htm</a>
+        <a href="559292.tsv">559292.tsv</a>
+        <a href="9606.tsv">9606.tsv</a>
+        <a href="/pub/databases/intact/complex/current/complextab/10090.tsv">10090.tsv</a>
+      </body>
+    </html>
+    """
+
+    with patch("urllib.request.urlopen", return_value=_FakeResponse(listing)):
+        filenames = complexportal.get_complexportal_tsv_filenames("https://example.org/complextab/")
+
+    assert filenames == ["10090.tsv", "559292.tsv", "9606.tsv"]
+
+
+@pytest.mark.unit
+def test_pull_complexportal_downloads_all_discovered_tsvs_and_writes_manifest(tmp_path):
+    manifest = tmp_path / "ComplexPortal" / complexportal.COMPLEXPORTAL_MANIFEST
+
+    with (
+        patch(
+            "src.datahandlers.complexportal.get_complexportal_tsv_filenames", return_value=["10090.tsv", "559292.tsv"]
+        ),
+        patch("src.datahandlers.complexportal.pull_via_urllib") as mock_pull,
+    ):
+        complexportal.pull_complexportal(str(manifest))
+
+    assert manifest.read_text() == "10090.tsv\n559292.tsv\n"
+    assert mock_pull.call_count == 2
+    mock_pull.assert_any_call(
+        complexportal.COMPLEXPORTAL_COMPLEXTAB_URL,
+        "10090.tsv",
+        decompress=False,
+        subpath=COMPLEXPORTAL,
+    )
+    mock_pull.assert_any_call(
+        complexportal.COMPLEXPORTAL_COMPLEXTAB_URL,
+        "559292.tsv",
+        decompress=False,
+        subpath=COMPLEXPORTAL,
+    )
+
+
+@pytest.mark.unit
+def test_make_labels_and_synonyms_combines_manifest_files(tmp_path):
+    complexportal_dir = tmp_path / "ComplexPortal"
+    complexportal_dir.mkdir()
+    manifest = complexportal_dir / complexportal.COMPLEXPORTAL_MANIFEST
+    manifest.write_text("10090.tsv\n559292.tsv\n")
+
+    header = "Complex ac\tRecommended name\tAliases\tDescription\n"
+    (complexportal_dir / "10090.tsv").write_text(
+        header
+        + "CPX-1\tMediator complex\tMediator|Mediator complex\tA complex\n"
+        + "CPX-2\tShared alias complex\tMediator\tAnother complex\n"
+    )
+    (complexportal_dir / "559292.tsv").write_text(
+        header
+        + "CPX-1\tMediator complex\tMediator|Mediator complex\tA complex\n"
+        + "CPX-3\tNo alias complex\t-\tNo aliases\n"
+    )
+
+    labels = complexportal_dir / "labels"
+    synonyms = complexportal_dir / "synonyms"
+    metadata = complexportal_dir / "metadata.yaml"
+
+    complexportal.make_labels_and_synonyms(str(manifest), str(labels), str(synonyms), str(metadata))
+
+    label_rows = assert_labels_file_valid(str(labels))
+    synonym_rows = read_tsv(str(synonyms))
+
+    assert label_rows == [
+        [f"{COMPLEXPORTAL}:CPX-1", "Mediator complex"],
+        [f"{COMPLEXPORTAL}:CPX-2", "Shared alias complex"],
+        [f"{COMPLEXPORTAL}:CPX-3", "No alias complex"],
+    ]
+    assert synonym_rows == [
+        [f"{COMPLEXPORTAL}:CPX-1", "Mediator"],
+        [f"{COMPLEXPORTAL}:CPX-1", "Mediator complex"],
+        [f"{COMPLEXPORTAL}:CPX-2", "Mediator"],
+    ]
+    assert metadata.exists()

--- a/tests/datahandlers/test_complexportal.py
+++ b/tests/datahandlers/test_complexportal.py
@@ -63,9 +63,8 @@ def test_fetch_complexportal_tsv_filenames_selects_tsv_links():
 
 @pytest.mark.unit
 def test_pull_complexportal_downloads_all_discovered_tsvs_and_writes_manifest(tmp_path):
-    """Every discovered TSV is fetched, the manifest lists them, and download_done is written last."""
+    """Every discovered TSV is fetched and the manifest is written listing them all."""
     complexportal_dir = tmp_path / "ComplexPortal"
-    download_done = complexportal_dir / complexportal.COMPLEXPORTAL_DOWNLOAD_DONE
     manifest = complexportal_dir / complexportal.COMPLEXPORTAL_MANIFEST
 
     with (
@@ -74,10 +73,9 @@ def test_pull_complexportal_downloads_all_discovered_tsvs_and_writes_manifest(tm
         ),
         patch("src.datahandlers.complexportal.pull_via_urllib") as mock_pull,
     ):
-        complexportal.pull_complexportal(str(download_done))
+        complexportal.pull_complexportal(str(manifest))
 
     assert manifest.read_text() == "10090.tsv\n559292.tsv\n"
-    assert download_done.exists(), "Sentinel file download_done should be written last"
     assert mock_pull.call_count == 2
     mock_pull.assert_any_call(
         complexportal.COMPLEXPORTAL_COMPLEXTAB_URL,

--- a/tests/datahandlers/test_complexportal.py
+++ b/tests/datahandlers/test_complexportal.py
@@ -109,3 +109,33 @@ def test_make_labels_and_synonyms_combines_manifest_files(tmp_path):
         [f"{COMPLEXPORTAL}:CPX-2", HAS_EXACT_SYNONYM, "Mediator"],
     ]
     assert metadata.exists()
+
+
+@pytest.mark.unit
+def test_make_labels_and_synonyms_deduplicates_by_identifier(tmp_path):
+    """Same complex ID in two species files with different labels: first label wins, no duplicate row."""
+    complexportal_dir = tmp_path / "ComplexPortal"
+    complexportal_dir.mkdir()
+    manifest = complexportal_dir / complexportal.COMPLEXPORTAL_MANIFEST
+    manifest.write_text("9606.tsv\n10090.tsv\n")
+
+    header = "Complex ac\tRecommended name\tAliases\tDescription\n"
+    (complexportal_dir / "9606.tsv").write_text(header + "CPX-1\tHuman name\t-\tHuman complex\n")
+    (complexportal_dir / "10090.tsv").write_text(header + "CPX-1\tMouse name\t-\tMouse complex\n")
+
+    labels = complexportal_dir / "labels"
+    synonyms = complexportal_dir / "synonyms"
+    metadata = complexportal_dir / "metadata.yaml"
+
+    complexportal.make_labels_and_synonyms(str(manifest), str(labels), str(synonyms), str(metadata))
+
+    label_rows = assert_labels_file_valid(str(labels))
+    assert label_rows == [[f"{COMPLEXPORTAL}:CPX-1", "Human name"]]
+
+
+@pytest.mark.network
+def test_get_complexportal_tsv_filenames_returns_real_files():
+    filenames = complexportal.get_complexportal_tsv_filenames()
+    assert len(filenames) > 0
+    assert all(f.endswith(".tsv") for f in filenames)
+    assert filenames == sorted(filenames)

--- a/tests/datahandlers/test_complexportal.py
+++ b/tests/datahandlers/test_complexportal.py
@@ -3,8 +3,9 @@ from unittest.mock import patch
 import pytest
 
 from src.datahandlers import complexportal
+from src.predicates import HAS_EXACT_SYNONYM
 from src.prefixes import COMPLEXPORTAL
-from tests.conftest import assert_labels_file_valid, read_tsv
+from tests.conftest import assert_labels_file_valid, assert_synonyms_file_valid
 
 
 class _FakeResponse:
@@ -95,7 +96,7 @@ def test_make_labels_and_synonyms_combines_manifest_files(tmp_path):
     complexportal.make_labels_and_synonyms(str(manifest), str(labels), str(synonyms), str(metadata))
 
     label_rows = assert_labels_file_valid(str(labels))
-    synonym_rows = read_tsv(str(synonyms))
+    synonym_rows = assert_synonyms_file_valid(str(synonyms))
 
     assert label_rows == [
         [f"{COMPLEXPORTAL}:CPX-1", "Mediator complex"],
@@ -103,8 +104,8 @@ def test_make_labels_and_synonyms_combines_manifest_files(tmp_path):
         [f"{COMPLEXPORTAL}:CPX-3", "No alias complex"],
     ]
     assert synonym_rows == [
-        [f"{COMPLEXPORTAL}:CPX-1", "Mediator"],
-        [f"{COMPLEXPORTAL}:CPX-1", "Mediator complex"],
-        [f"{COMPLEXPORTAL}:CPX-2", "Mediator"],
+        [f"{COMPLEXPORTAL}:CPX-1", HAS_EXACT_SYNONYM, "Mediator"],
+        [f"{COMPLEXPORTAL}:CPX-1", HAS_EXACT_SYNONYM, "Mediator complex"],
+        [f"{COMPLEXPORTAL}:CPX-2", HAS_EXACT_SYNONYM, "Mediator"],
     ]
     assert metadata.exists()

--- a/tests/datahandlers/test_complexportal.py
+++ b/tests/datahandlers/test_complexportal.py
@@ -22,6 +22,26 @@ class _FakeResponse:
         return self.content
 
 
+# Real ComplexPortal TSV header (4 columns we use + a trailing column to test the split limit).
+_HEADER = "#Complex ac\tRecommended name\tAliases for complex\tTaxonomy identifier\tIdentifiers\n"
+
+
+def _assert_taxa_file_valid(path: str) -> list[list[str]]:
+    """Assert every line is CURIE\\tNCBITaxon:NNNN; return the rows."""
+    rows = []
+    with open(path) as f:
+        for line in f:
+            stripped = line.rstrip("\n")
+            if stripped:
+                cols = stripped.split("\t")
+                assert len(cols) == 2, f"Expected 2 columns in taxa file, got {len(cols)}: {cols}"
+                assert cols[0].startswith(f"{COMPLEXPORTAL}:"), f"First column is not a ComplexPortal CURIE: {cols[0]}"
+                assert cols[1].startswith("NCBITaxon:"), f"Second column is not an NCBITaxon CURIE: {cols[1]}"
+                rows.append(cols)
+    assert rows, f"Taxa file is empty: {path}"
+    return rows
+
+
 @pytest.mark.unit
 def test_fetch_complexportal_tsv_filenames_selects_tsv_links():
     listing = b"""
@@ -71,32 +91,35 @@ def test_pull_complexportal_downloads_all_discovered_tsvs_and_writes_manifest(tm
 
 
 @pytest.mark.unit
-def test_make_labels_and_synonyms_combines_manifest_files(tmp_path):
+def test_make_labels_synonyms_and_taxa_combines_manifest_files(tmp_path):
     complexportal_dir = tmp_path / "ComplexPortal"
     complexportal_dir.mkdir()
     manifest = complexportal_dir / complexportal.COMPLEXPORTAL_MANIFEST
     manifest.write_text("10090.tsv\n559292.tsv\n")
 
-    header = "Complex ac\tRecommended name\tAliases\tDescription\n"
     (complexportal_dir / "10090.tsv").write_text(
-        header
-        + "CPX-1\tMediator complex\tMediator|Mediator complex\tA complex\n"
-        + "CPX-2\tShared alias complex\tMediator\tAnother complex\n"
+        _HEADER
+        + "CPX-1\tMediator complex\tMediator|Mediator complex\t10090\tpart1\n"
+        + "CPX-2\tShared alias complex\tMediator\t10090\tpart2\n"
     )
     (complexportal_dir / "559292.tsv").write_text(
-        header
-        + "CPX-1\tMediator complex\tMediator|Mediator complex\tA complex\n"
-        + "CPX-3\tNo alias complex\t-\tNo aliases\n"
+        _HEADER
+        + "CPX-1\tMediator complex\tMediator|Mediator complex\t559292\tpart1\n"
+        + "CPX-3\tNo alias complex\t-\t559292\tpart3\n"
     )
 
     labels = complexportal_dir / "labels"
     synonyms = complexportal_dir / "synonyms"
+    taxa = complexportal_dir / "taxa"
     metadata = complexportal_dir / "metadata.yaml"
 
-    complexportal.make_labels_and_synonyms(str(manifest), str(complexportal_dir), str(labels), str(synonyms), str(metadata))
+    complexportal.make_labels_synonyms_and_taxa(
+        str(manifest), str(complexportal_dir), str(labels), str(synonyms), str(taxa), str(metadata)
+    )
 
     label_rows = assert_labels_file_valid(str(labels))
     synonym_rows = assert_synonyms_file_valid(str(synonyms))
+    taxa_rows = _assert_taxa_file_valid(str(taxa))
 
     assert label_rows == [
         [f"{COMPLEXPORTAL}:CPX-1", "Mediator complex"],
@@ -108,29 +131,69 @@ def test_make_labels_and_synonyms_combines_manifest_files(tmp_path):
         [f"{COMPLEXPORTAL}:CPX-1", HAS_EXACT_SYNONYM, "Mediator complex"],
         [f"{COMPLEXPORTAL}:CPX-2", HAS_EXACT_SYNONYM, "Mediator"],
     ]
+    # CPX-1 appears in both files with different taxa; both taxa should be recorded.
+    assert [f"{COMPLEXPORTAL}:CPX-1", "NCBITaxon:10090"] in taxa_rows
+    assert [f"{COMPLEXPORTAL}:CPX-1", "NCBITaxon:559292"] in taxa_rows
+    assert [f"{COMPLEXPORTAL}:CPX-2", "NCBITaxon:10090"] in taxa_rows
+    assert [f"{COMPLEXPORTAL}:CPX-3", "NCBITaxon:559292"] in taxa_rows
     assert metadata.exists()
 
 
 @pytest.mark.unit
-def test_make_labels_and_synonyms_deduplicates_by_identifier(tmp_path):
-    """Same complex ID in two species files with different labels: first label wins, no duplicate row."""
+def test_make_labels_synonyms_and_taxa_deduplicates_labels_by_identifier(tmp_path):
+    """Same complex ID in two species files with different labels: first label wins, no duplicate label row."""
     complexportal_dir = tmp_path / "ComplexPortal"
     complexportal_dir.mkdir()
     manifest = complexportal_dir / complexportal.COMPLEXPORTAL_MANIFEST
     manifest.write_text("9606.tsv\n10090.tsv\n")
 
-    header = "Complex ac\tRecommended name\tAliases\tDescription\n"
-    (complexportal_dir / "9606.tsv").write_text(header + "CPX-1\tHuman name\t-\tHuman complex\n")
-    (complexportal_dir / "10090.tsv").write_text(header + "CPX-1\tMouse name\t-\tMouse complex\n")
+    (complexportal_dir / "9606.tsv").write_text(_HEADER + "CPX-1\tHuman name\t-\t9606\tpart1\n")
+    (complexportal_dir / "10090.tsv").write_text(_HEADER + "CPX-1\tMouse name\t-\t10090\tpart1\n")
 
     labels = complexportal_dir / "labels"
     synonyms = complexportal_dir / "synonyms"
+    taxa = complexportal_dir / "taxa"
     metadata = complexportal_dir / "metadata.yaml"
 
-    complexportal.make_labels_and_synonyms(str(manifest), str(complexportal_dir), str(labels), str(synonyms), str(metadata))
+    complexportal.make_labels_synonyms_and_taxa(
+        str(manifest), str(complexportal_dir), str(labels), str(synonyms), str(taxa), str(metadata)
+    )
 
     label_rows = assert_labels_file_valid(str(labels))
     assert label_rows == [[f"{COMPLEXPORTAL}:CPX-1", "Human name"]]
+
+    # Both taxa are recorded even though the label was deduplicated.
+    taxa_rows = _assert_taxa_file_valid(str(taxa))
+    assert [f"{COMPLEXPORTAL}:CPX-1", "NCBITaxon:9606"] in taxa_rows
+    assert [f"{COMPLEXPORTAL}:CPX-1", "NCBITaxon:10090"] in taxa_rows
+
+
+@pytest.mark.unit
+def test_make_labels_synonyms_and_taxa_skips_missing_taxon(tmp_path):
+    """Rows with '-' taxonomy identifier produce no taxa entry."""
+    complexportal_dir = tmp_path / "ComplexPortal"
+    complexportal_dir.mkdir()
+    manifest = complexportal_dir / complexportal.COMPLEXPORTAL_MANIFEST
+    manifest.write_text("9606.tsv\n")
+
+    (complexportal_dir / "9606.tsv").write_text(
+        _HEADER
+        + "CPX-1\tComplex with taxon\t-\t9606\tpart1\n"
+        + "CPX-2\tComplex without taxon\t-\t-\tpart2\n"
+    )
+
+    labels = complexportal_dir / "labels"
+    synonyms = complexportal_dir / "synonyms"
+    taxa = complexportal_dir / "taxa"
+    metadata = complexportal_dir / "metadata.yaml"
+
+    complexportal.make_labels_synonyms_and_taxa(
+        str(manifest), str(complexportal_dir), str(labels), str(synonyms), str(taxa), str(metadata)
+    )
+
+    taxa_rows = _assert_taxa_file_valid(str(taxa))
+    assert len(taxa_rows) == 1
+    assert taxa_rows[0] == [f"{COMPLEXPORTAL}:CPX-1", "NCBITaxon:9606"]
 
 
 @pytest.mark.network

--- a/tests/datahandlers/test_complexportal.py
+++ b/tests/datahandlers/test_complexportal.py
@@ -93,7 +93,7 @@ def test_make_labels_and_synonyms_combines_manifest_files(tmp_path):
     synonyms = complexportal_dir / "synonyms"
     metadata = complexportal_dir / "metadata.yaml"
 
-    complexportal.make_labels_and_synonyms(str(manifest), str(labels), str(synonyms), str(metadata))
+    complexportal.make_labels_and_synonyms(str(manifest), str(complexportal_dir), str(labels), str(synonyms), str(metadata))
 
     label_rows = assert_labels_file_valid(str(labels))
     synonym_rows = assert_synonyms_file_valid(str(synonyms))
@@ -127,7 +127,7 @@ def test_make_labels_and_synonyms_deduplicates_by_identifier(tmp_path):
     synonyms = complexportal_dir / "synonyms"
     metadata = complexportal_dir / "metadata.yaml"
 
-    complexportal.make_labels_and_synonyms(str(manifest), str(labels), str(synonyms), str(metadata))
+    complexportal.make_labels_and_synonyms(str(manifest), str(complexportal_dir), str(labels), str(synonyms), str(metadata))
 
     label_rows = assert_labels_file_valid(str(labels))
     assert label_rows == [[f"{COMPLEXPORTAL}:CPX-1", "Human name"]]

--- a/tests/datahandlers/test_complexportal.py
+++ b/tests/datahandlers/test_complexportal.py
@@ -22,8 +22,34 @@ class _FakeResponse:
         return self.content
 
 
-# Real ComplexPortal TSV header (4 columns we use + a trailing column to test the split limit).
-_HEADER = "#Complex ac\tRecommended name\tAliases for complex\tTaxonomy identifier\tIdentifiers\n"
+# Real ComplexPortal ComplexTAB header (all 19 columns as of 2026-06).
+# Columns currently used by Babel are marked with (*); the rest are set to "-" in test rows.
+# Columns worth considering for future use are noted inline.
+_HEADER = (
+    "#Complex ac\t"           # 0  (*) complex accession → CURIE
+    "Recommended name\t"      # 1  (*) preferred label
+    "Aliases for complex\t"   # 2  (*) "|"-separated synonyms, or "-"
+    "Taxonomy identifier\t"   # 3  (*) NCBI taxon integer, or "-"
+    "Identifiers (and stoichiometry) of molecules in complex\t"  # 4  participants — could add to concords
+    "Evidence Code\t"         # 5
+    "Experimental evidence\t" # 6
+    "Go Annotations\t"        # 7  GO terms — could enrich type/function info
+    "Cross references\t"      # 8  Reactome, PubMed, wwPDB, etc. — potential concord sources
+    "Description\t"           # 9  free-text description — could populate descriptions file
+    "Complex properties\t"    # 10
+    "Complex assembly\t"      # 11
+    "Ligand\t"                # 12
+    "Disease\t"               # 13 disease associations — potentially useful
+    "Agonist\t"               # 14
+    "Antagonist\t"            # 15
+    "Comment\t"               # 16
+    "Source\t"                # 17
+    "Expanded participant list\n"  # 18
+)
+
+# Shorthand for a row with all unused columns set to "-".
+def _row(ac, name, aliases, taxon):
+    return f"{ac}\t{name}\t{aliases}\t{taxon}\t" + "\t".join(["-"] * 15) + "\n"
 
 
 def _assert_taxa_file_valid(path: str) -> list[list[str]]:
@@ -99,13 +125,13 @@ def test_make_labels_synonyms_and_taxa_combines_manifest_files(tmp_path):
 
     (complexportal_dir / "10090.tsv").write_text(
         _HEADER
-        + "CPX-1\tMediator complex\tMediator|Mediator complex\t10090\tpart1\n"
-        + "CPX-2\tShared alias complex\tMediator\t10090\tpart2\n"
+        + _row("CPX-1", "Mediator complex", "Mediator|Mediator complex", "10090")
+        + _row("CPX-2", "Shared alias complex", "Mediator", "10090")
     )
     (complexportal_dir / "559292.tsv").write_text(
         _HEADER
-        + "CPX-1\tMediator complex\tMediator|Mediator complex\t559292\tpart1\n"
-        + "CPX-3\tNo alias complex\t-\t559292\tpart3\n"
+        + _row("CPX-1", "Mediator complex", "Mediator|Mediator complex", "559292")
+        + _row("CPX-3", "No alias complex", "-", "559292")
     )
 
     labels = complexportal_dir / "labels"
@@ -147,8 +173,8 @@ def test_make_labels_synonyms_and_taxa_deduplicates_labels_by_identifier(tmp_pat
     manifest = complexportal_dir / complexportal.COMPLEXPORTAL_MANIFEST
     manifest.write_text("9606.tsv\n10090.tsv\n")
 
-    (complexportal_dir / "9606.tsv").write_text(_HEADER + "CPX-1\tHuman name\t-\t9606\tpart1\n")
-    (complexportal_dir / "10090.tsv").write_text(_HEADER + "CPX-1\tMouse name\t-\t10090\tpart1\n")
+    (complexportal_dir / "9606.tsv").write_text(_HEADER + _row("CPX-1", "Human name", "-", "9606"))
+    (complexportal_dir / "10090.tsv").write_text(_HEADER + _row("CPX-1", "Mouse name", "-", "10090"))
 
     labels = complexportal_dir / "labels"
     synonyms = complexportal_dir / "synonyms"
@@ -178,8 +204,8 @@ def test_make_labels_synonyms_and_taxa_skips_missing_taxon(tmp_path):
 
     (complexportal_dir / "9606.tsv").write_text(
         _HEADER
-        + "CPX-1\tComplex with taxon\t-\t9606\tpart1\n"
-        + "CPX-2\tComplex without taxon\t-\t-\tpart2\n"
+        + _row("CPX-1", "Complex with taxon", "-", "9606")
+        + _row("CPX-2", "Complex without taxon", "-", "-")
     )
 
     labels = complexportal_dir / "labels"

--- a/tests/datahandlers/test_complexportal.py
+++ b/tests/datahandlers/test_complexportal.py
@@ -7,6 +7,7 @@ from src.predicates import HAS_EXACT_SYNONYM
 from src.prefixes import COMPLEXPORTAL
 from tests.conftest import (
     assert_descriptions_file_valid,
+    assert_ids_file_valid,
     assert_labels_file_valid,
     assert_synonyms_file_valid,
     assert_taxa_file_valid,
@@ -31,25 +32,25 @@ class _FakeResponse:
 # Columns currently used by Babel are marked with (*); the rest are set to "-" in test rows.
 # Columns worth considering for future use are noted inline.
 _COLUMNS = [
-    "#Complex ac",                                           # 0  (*) complex accession → CURIE
-    "Recommended name",                                      # 1  (*) preferred label
-    "Aliases for complex",                                   # 2  (*) "|"-separated synonyms, or "-"
-    "Taxonomy identifier",                                   # 3  (*) NCBI taxon integer, or "-"
+    "#Complex ac",  # 0  (*) complex accession → CURIE
+    "Recommended name",  # 1  (*) preferred label
+    "Aliases for complex",  # 2  (*) "|"-separated synonyms, or "-"
+    "Taxonomy identifier",  # 3  (*) NCBI taxon integer, or "-"
     "Identifiers (and stoichiometry) of molecules in complex",  # 4  participants — could add to concords
-    "Evidence Code",                                         # 5
-    "Experimental evidence",                                 # 6
-    "Go Annotations",                                        # 7  GO terms — could enrich type/function info
-    "Cross references",                                      # 8  Reactome, PubMed, wwPDB, etc. — potential concord sources
-    "Description",                                           # 9  (*) free-text description
-    "Complex properties",                                    # 10
-    "Complex assembly",                                      # 11
-    "Ligand",                                                # 12
-    "Disease",                                               # 13 disease associations — potentially useful
-    "Agonist",                                               # 14
-    "Antagonist",                                            # 15
-    "Comment",                                               # 16
-    "Source",                                                # 17
-    "Expanded participant list",                             # 18
+    "Evidence Code",  # 5
+    "Experimental evidence",  # 6
+    "Go Annotations",  # 7  GO terms — could enrich type/function info
+    "Cross references",  # 8  Reactome, PubMed, wwPDB, etc. — potential concord sources
+    "Description",  # 9  (*) free-text description
+    "Complex properties",  # 10
+    "Complex assembly",  # 11
+    "Ligand",  # 12
+    "Disease",  # 13 disease associations — potentially useful
+    "Agonist",  # 14
+    "Antagonist",  # 15
+    "Comment",  # 16
+    "Source",  # 17
+    "Expanded participant list",  # 18
 ]
 _HEADER = "\t".join(_COLUMNS) + "\n"
 
@@ -139,16 +140,25 @@ def test_make_labels_synonyms_and_taxa_combines_manifest_files(tmp_path):
     synonyms = complexportal_dir / "synonyms"
     taxa = complexportal_dir / "taxa"
     descriptions = complexportal_dir / "descriptions"
+    ids = complexportal_dir / "ids"
     metadata = complexportal_dir / "metadata.yaml"
 
     complexportal.make_labels_synonyms_and_taxa(
-        str(manifest), str(complexportal_dir), str(labels), str(synonyms), str(taxa), str(descriptions), str(metadata)
+        str(manifest),
+        str(complexportal_dir),
+        str(labels),
+        str(synonyms),
+        str(taxa),
+        str(descriptions),
+        str(metadata),
+        str(ids),
     )
 
     label_rows = assert_labels_file_valid(str(labels))
     synonym_rows = assert_synonyms_file_valid(str(synonyms))
     taxa_rows = assert_taxa_file_valid(str(taxa))
     desc_rows = assert_descriptions_file_valid(str(descriptions))
+    ids_rows = assert_ids_file_valid(str(ids))
 
     assert label_rows == [
         [f"{COMPLEXPORTAL}:CPX-1", "Mediator complex"],
@@ -171,6 +181,10 @@ def test_make_labels_synonyms_and_taxa_combines_manifest_files(tmp_path):
     assert [f"{COMPLEXPORTAL}:CPX-2", "Another complex."] in desc_rows
     # CPX-3 has no description ("-"); it should not appear in the descriptions file.
     assert not any(row[0] == f"{COMPLEXPORTAL}:CPX-3" for row in desc_rows)
+    # All three distinct IDs must appear in the IDs file exactly once.
+    ids_curies = [row[0] for row in ids_rows]
+    assert ids_curies == [f"{COMPLEXPORTAL}:CPX-1", f"{COMPLEXPORTAL}:CPX-2", f"{COMPLEXPORTAL}:CPX-3"]
+    assert all(row[1] == "biolink:MacromolecularComplex" for row in ids_rows)
     assert metadata.exists()
 
 
@@ -193,10 +207,18 @@ def test_make_labels_synonyms_and_taxa_deduplicates_labels_by_identifier(tmp_pat
     synonyms = complexportal_dir / "synonyms"
     taxa = complexportal_dir / "taxa"
     descriptions = complexportal_dir / "descriptions"
+    ids = complexportal_dir / "ids"
     metadata = complexportal_dir / "metadata.yaml"
 
     complexportal.make_labels_synonyms_and_taxa(
-        str(manifest), str(complexportal_dir), str(labels), str(synonyms), str(taxa), str(descriptions), str(metadata)
+        str(manifest),
+        str(complexportal_dir),
+        str(labels),
+        str(synonyms),
+        str(taxa),
+        str(descriptions),
+        str(metadata),
+        str(ids),
     )
 
     label_rows = assert_labels_file_valid(str(labels))
@@ -222,19 +244,25 @@ def test_make_labels_synonyms_and_taxa_skips_missing_taxon(tmp_path):
     manifest.write_text("9606.tsv\n")
 
     (complexportal_dir / "9606.tsv").write_text(
-        _HEADER
-        + _row("CPX-1", "Complex with taxon", "-", "9606")
-        + _row("CPX-2", "Complex without taxon", "-", "-")
+        _HEADER + _row("CPX-1", "Complex with taxon", "-", "9606") + _row("CPX-2", "Complex without taxon", "-", "-")
     )
 
     labels = complexportal_dir / "labels"
     synonyms = complexportal_dir / "synonyms"
     taxa = complexportal_dir / "taxa"
     descriptions = complexportal_dir / "descriptions"
+    ids = complexportal_dir / "ids"
     metadata = complexportal_dir / "metadata.yaml"
 
     complexportal.make_labels_synonyms_and_taxa(
-        str(manifest), str(complexportal_dir), str(labels), str(synonyms), str(taxa), str(descriptions), str(metadata)
+        str(manifest),
+        str(complexportal_dir),
+        str(labels),
+        str(synonyms),
+        str(taxa),
+        str(descriptions),
+        str(metadata),
+        str(ids),
     )
 
     taxa_rows = assert_taxa_file_valid(str(taxa))
@@ -258,14 +286,61 @@ def test_make_labels_synonyms_and_taxa_deduplicates_identical_descriptions(tmp_p
     synonyms = complexportal_dir / "synonyms"
     taxa = complexportal_dir / "taxa"
     descriptions = complexportal_dir / "descriptions"
+    ids = complexportal_dir / "ids"
     metadata = complexportal_dir / "metadata.yaml"
 
     complexportal.make_labels_synonyms_and_taxa(
-        str(manifest), str(complexportal_dir), str(labels), str(synonyms), str(taxa), str(descriptions), str(metadata)
+        str(manifest),
+        str(complexportal_dir),
+        str(labels),
+        str(synonyms),
+        str(taxa),
+        str(descriptions),
+        str(metadata),
+        str(ids),
     )
 
     desc_rows = assert_descriptions_file_valid(str(descriptions))
     assert desc_rows == [[f"{COMPLEXPORTAL}:CPX-1", shared_desc]]
+
+
+@pytest.mark.unit
+def test_make_labels_synonyms_and_taxa_ids_file_includes_entries_with_empty_label(tmp_path):
+    """IDs file must include every identifier even when the recommended name column is empty."""
+    complexportal_dir = tmp_path / "ComplexPortal"
+    complexportal_dir.mkdir()
+    manifest = complexportal_dir / complexportal.COMPLEXPORTAL_MANIFEST
+    manifest.write_text("9606.tsv\n")
+
+    (complexportal_dir / "9606.tsv").write_text(
+        _HEADER
+        + _row("CPX-1", "Normal complex", "-", "9606")
+        + _row("CPX-2", "", "-", "9606")  # empty recommended name
+    )
+
+    labels = complexportal_dir / "labels"
+    synonyms = complexportal_dir / "synonyms"
+    taxa = complexportal_dir / "taxa"
+    descriptions = complexportal_dir / "descriptions"
+    ids = complexportal_dir / "ids"
+    metadata = complexportal_dir / "metadata.yaml"
+
+    complexportal.make_labels_synonyms_and_taxa(
+        str(manifest),
+        str(complexportal_dir),
+        str(labels),
+        str(synonyms),
+        str(taxa),
+        str(descriptions),
+        str(metadata),
+        str(ids),
+    )
+
+    ids_rows = assert_ids_file_valid(str(ids))
+    ids_curies = [row[0] for row in ids_rows]
+    assert f"{COMPLEXPORTAL}:CPX-1" in ids_curies
+    assert f"{COMPLEXPORTAL}:CPX-2" in ids_curies, "ID with empty label must still appear in IDs file"
+    assert all(row[1] == "biolink:MacromolecularComplex" for row in ids_rows)
 
 
 @pytest.mark.network

--- a/tests/datahandlers/test_complexportal.py
+++ b/tests/datahandlers/test_complexportal.py
@@ -23,7 +23,7 @@ class _FakeResponse:
 
 
 @pytest.mark.unit
-def test_get_complexportal_tsv_filenames_selects_tsv_links():
+def test_fetch_complexportal_tsv_filenames_selects_tsv_links():
     listing = b"""
     <html>
       <body>
@@ -37,7 +37,7 @@ def test_get_complexportal_tsv_filenames_selects_tsv_links():
     """
 
     with patch("urllib.request.urlopen", return_value=_FakeResponse(listing)):
-        filenames = complexportal.get_complexportal_tsv_filenames("https://example.org/complextab/")
+        filenames = complexportal.fetch_complexportal_tsv_filenames("https://example.org/complextab/")
 
     assert filenames == ["10090.tsv", "559292.tsv", "9606.tsv"]
 
@@ -48,7 +48,7 @@ def test_pull_complexportal_downloads_all_discovered_tsvs_and_writes_manifest(tm
 
     with (
         patch(
-            "src.datahandlers.complexportal.get_complexportal_tsv_filenames", return_value=["10090.tsv", "559292.tsv"]
+            "src.datahandlers.complexportal.fetch_complexportal_tsv_filenames", return_value=["10090.tsv", "559292.tsv"]
         ),
         patch("src.datahandlers.complexportal.pull_via_urllib") as mock_pull,
     ):
@@ -134,8 +134,8 @@ def test_make_labels_and_synonyms_deduplicates_by_identifier(tmp_path):
 
 
 @pytest.mark.network
-def test_get_complexportal_tsv_filenames_returns_real_files():
-    filenames = complexportal.get_complexportal_tsv_filenames()
+def test_fetch_complexportal_tsv_filenames_returns_real_files():
+    filenames = complexportal.fetch_complexportal_tsv_filenames()
     assert len(filenames) > 0
     assert all(f.endswith(".tsv") for f in filenames)
     assert filenames == sorted(filenames)

--- a/tests/pipeline/test_complexportal.py
+++ b/tests/pipeline/test_complexportal.py
@@ -14,8 +14,12 @@ import pytest
 from src.babel_utils import make_local_name
 from src.datahandlers import complexportal
 from src.prefixes import COMPLEXPORTAL
-from tests.conftest import assert_labels_file_valid, assert_synonyms_file_valid
-from tests.datahandlers.test_complexportal import _assert_descriptions_file_valid, _assert_taxa_file_valid
+from tests.conftest import (
+    assert_descriptions_file_valid,
+    assert_labels_file_valid,
+    assert_synonyms_file_valid,
+    assert_taxa_file_valid,
+)
 from tests.pipeline.conftest import _download_or_fail
 
 # ---------------------------------------------------------------------------
@@ -124,7 +128,7 @@ def test_complexportal_synonyms_valid(complexportal_pipeline_outputs):
 @pytest.mark.pipeline
 def test_complexportal_taxa_valid(complexportal_pipeline_outputs):
     """Taxa file is non-empty and every row is a valid CURIE→NCBITaxon:NNNN pair."""
-    rows = _assert_taxa_file_valid(complexportal_pipeline_outputs["taxa"])
+    rows = assert_taxa_file_valid(complexportal_pipeline_outputs["taxa"])
     # Every label in the labels file should have at least one taxon entry.
     from tests.conftest import read_tsv
 
@@ -137,7 +141,7 @@ def test_complexportal_taxa_valid(complexportal_pipeline_outputs):
 @pytest.mark.pipeline
 def test_complexportal_descriptions_valid(complexportal_pipeline_outputs):
     """Descriptions file is non-empty and every row is a valid CURIE→description pair."""
-    _assert_descriptions_file_valid(complexportal_pipeline_outputs["descriptions"])
+    assert_descriptions_file_valid(complexportal_pipeline_outputs["descriptions"])
 
 
 @pytest.mark.pipeline

--- a/tests/pipeline/test_complexportal.py
+++ b/tests/pipeline/test_complexportal.py
@@ -125,3 +125,68 @@ def test_complexportal_taxa_valid(complexportal_pipeline_outputs):
     taxa_curies = {row[0] for row in rows}
     missing = label_curies - taxa_curies
     assert not missing, f"{len(missing)} ComplexPortal identifiers have no taxon entry: {sorted(missing)[:10]}"
+
+
+@pytest.mark.pipeline
+def test_complexportal_cross_file_duplicates_handled_correctly(complexportal_tsv_files, complexportal_pipeline_outputs):
+    """Verify correct handling when the same CPX accession appears in multiple species TSV files.
+
+    Labels: each CURIE appears exactly once (first-file wins).
+    Synonyms: deduplicated by (CURIE, synonym) pair — no duplicate rows.
+    Taxa: every (CURIE, taxon) pair from every file is preserved — a complex
+          conserved across species should have one taxon entry per species.
+    """
+    from src.util import get_config  # deferred
+    from tests.conftest import read_tsv
+
+    cfg = get_config()
+    download_dir = os.path.join(cfg["download_directory"], COMPLEXPORTAL)
+
+    with open(complexportal_tsv_files) as mf:
+        filenames = [line.strip() for line in mf if line.strip()]
+
+    # Collect every (curie, taxon_id) pair seen across all source files.
+    curie_to_files: dict[str, list[str]] = {}
+    curie_taxon_pairs: set[tuple[str, str]] = set()
+    for filename in filenames:
+        tsv_path = os.path.join(download_dir, filename)
+        with open(tsv_path) as f:
+            next(f)  # skip header
+            for line in f:
+                cols = line.split("\t", 4)
+                if len(cols) < 4:
+                    continue
+                curie = f"{COMPLEXPORTAL}:{cols[0]}"
+                taxon_id = cols[3].strip()
+                curie_to_files.setdefault(curie, []).append(filename)
+                if taxon_id and taxon_id != "-":
+                    curie_taxon_pairs.add((curie, taxon_id))
+
+    cross_file_curies = {c for c, files in curie_to_files.items() if len(files) > 1}
+
+    # Labels: every CURIE appears exactly once.
+    label_rows = read_tsv(complexportal_pipeline_outputs["labels"])
+    label_curies = [row[0] for row in label_rows]
+    duplicate_labels = {c for c in label_curies if label_curies.count(c) > 1}
+    assert not duplicate_labels, f"Duplicate label rows for: {sorted(duplicate_labels)[:10]}"
+
+    # Synonyms: no duplicate (CURIE, synonym) rows.
+    syn_rows = read_tsv(complexportal_pipeline_outputs["synonyms"])
+    syn_pairs = [(row[0], row[2]) for row in syn_rows]
+    duplicate_syns = {pair for pair in syn_pairs if syn_pairs.count(pair) > 1}
+    assert not duplicate_syns, f"Duplicate synonym rows for: {sorted(duplicate_syns)[:5]}"
+
+    # Taxa: every (CURIE, taxon) pair from the source files is present in the output.
+    taxa_rows = read_tsv(complexportal_pipeline_outputs["taxa"])
+    output_taxon_pairs = {(row[0], row[1].removeprefix("NCBITaxon:")) for row in taxa_rows}
+    missing_pairs = curie_taxon_pairs - output_taxon_pairs
+    assert not missing_pairs, (
+        f"{len(missing_pairs)} (CURIE, taxon) pairs from source files are absent from taxa output: "
+        f"{sorted(missing_pairs)[:5]}"
+    )
+
+    # Report how many cross-file CURIEs were found (informational, not a failure).
+    if cross_file_curies:
+        print(f"\n[info] {len(cross_file_curies)} CURIEs appear in multiple species files — all handled correctly.")  # noqa: T201
+    else:
+        print("\n[info] No CURIEs found in multiple species files in this ComplexPortal release.")  # noqa: T201

--- a/tests/pipeline/test_complexportal.py
+++ b/tests/pipeline/test_complexportal.py
@@ -8,6 +8,7 @@ Run with:
 """
 
 import os
+from collections import Counter
 
 import pytest
 
@@ -183,14 +184,14 @@ def test_complexportal_cross_file_duplicates_handled_correctly(complexportal_tsv
 
     # Labels: every CURIE appears exactly once.
     label_rows = read_tsv(complexportal_pipeline_outputs["labels"])
-    label_curies = [row[0] for row in label_rows]
-    duplicate_labels = {c for c in label_curies if label_curies.count(c) > 1}
+    label_counts = Counter(row[0] for row in label_rows)
+    duplicate_labels = {c for c, n in label_counts.items() if n > 1}
     assert not duplicate_labels, f"Duplicate label rows for: {sorted(duplicate_labels)[:10]}"
 
     # Synonyms: no duplicate (CURIE, synonym) rows.
     syn_rows = read_tsv(complexportal_pipeline_outputs["synonyms"])
-    syn_pairs = [(row[0], row[2]) for row in syn_rows]
-    duplicate_syns = {pair for pair in syn_pairs if syn_pairs.count(pair) > 1}
+    syn_pair_counts = Counter((row[0], row[2]) for row in syn_rows)
+    duplicate_syns = {pair for pair, n in syn_pair_counts.items() if n > 1}
     assert not duplicate_syns, f"Duplicate synonym rows for: {sorted(duplicate_syns)[:5]}"
 
     # Taxa: every (CURIE, taxon) pair from the source files is present in the output.

--- a/tests/pipeline/test_complexportal.py
+++ b/tests/pipeline/test_complexportal.py
@@ -30,12 +30,12 @@ from tests.pipeline.conftest import _download_or_fail
 
 @pytest.fixture(scope="session")
 def complexportal_tsv_files():
-    """Download all ComplexPortal TSV files; fail if unavailable."""
-    download_done = make_local_name(complexportal.COMPLEXPORTAL_DOWNLOAD_DONE, subpath=COMPLEXPORTAL)
+    """Download all ComplexPortal TSV files; fail if unavailable. Returns the manifest path."""
+    manifest = make_local_name(complexportal.COMPLEXPORTAL_MANIFEST, subpath=COMPLEXPORTAL)
     return _download_or_fail(
         "ComplexPortal TSV files",
         complexportal.pull_complexportal,
-        download_done,
+        manifest,
     )
 
 
@@ -65,7 +65,9 @@ def complexportal_pipeline_outputs(complexportal_tsv_files, regenerate):
         or not os.path.exists(descriptions)
     ):
         os.makedirs(download_dir, exist_ok=True)
-        complexportal.make_labels_synonyms_and_taxa(manifest, download_dir, labels, synonyms, taxa, descriptions, metadata)
+        complexportal.make_labels_synonyms_and_taxa(
+            manifest, download_dir, labels, synonyms, taxa, descriptions, metadata
+        )
 
     return {"manifest": manifest, "labels": labels, "synonyms": synonyms, "taxa": taxa, "descriptions": descriptions}
 
@@ -77,11 +79,8 @@ def complexportal_pipeline_outputs(complexportal_tsv_files, regenerate):
 
 @pytest.mark.pipeline
 def test_complexportal_tsv_files_downloaded(complexportal_tsv_files):
-    """Sentinel and manifest files exist and the manifest lists at least one TSV."""
-    assert os.path.exists(complexportal_tsv_files), "download_done sentinel is missing"
-    download_dir = os.path.dirname(complexportal_tsv_files)
-    manifest = os.path.join(download_dir, complexportal.COMPLEXPORTAL_MANIFEST)
-    with open(manifest) as f:
+    """Manifest exists and lists at least one TSV file."""
+    with open(complexportal_tsv_files) as f:
         lines = [line.strip() for line in f if line.strip()]
     assert len(lines) > 0, "Manifest is empty — no TSV files were downloaded"
     assert all(fn.endswith(".tsv") for fn in lines), f"Non-TSV entry in manifest: {lines}"

--- a/tests/pipeline/test_complexportal.py
+++ b/tests/pipeline/test_complexportal.py
@@ -15,7 +15,7 @@ from src.babel_utils import make_local_name
 from src.datahandlers import complexportal
 from src.prefixes import COMPLEXPORTAL
 from tests.conftest import assert_labels_file_valid, assert_synonyms_file_valid
-from tests.datahandlers.test_complexportal import _assert_taxa_file_valid
+from tests.datahandlers.test_complexportal import _assert_descriptions_file_valid, _assert_taxa_file_valid
 from tests.pipeline.conftest import _download_or_fail
 
 # ---------------------------------------------------------------------------
@@ -49,13 +49,20 @@ def complexportal_pipeline_outputs(complexportal_tsv_files, regenerate):
     labels = os.path.join(download_dir, "labels")
     synonyms = os.path.join(download_dir, "synonyms")
     taxa = os.path.join(download_dir, "taxa")
+    descriptions = os.path.join(download_dir, "descriptions")
     metadata = os.path.join(download_dir, "metadata.yaml")
 
-    if regenerate or not os.path.exists(labels) or not os.path.exists(synonyms) or not os.path.exists(taxa):
+    if (
+        regenerate
+        or not os.path.exists(labels)
+        or not os.path.exists(synonyms)
+        or not os.path.exists(taxa)
+        or not os.path.exists(descriptions)
+    ):
         os.makedirs(download_dir, exist_ok=True)
-        complexportal.make_labels_synonyms_and_taxa(manifest, download_dir, labels, synonyms, taxa, metadata)
+        complexportal.make_labels_synonyms_and_taxa(manifest, download_dir, labels, synonyms, taxa, descriptions, metadata)
 
-    return {"manifest": manifest, "labels": labels, "synonyms": synonyms, "taxa": taxa}
+    return {"manifest": manifest, "labels": labels, "synonyms": synonyms, "taxa": taxa, "descriptions": descriptions}
 
 
 # ---------------------------------------------------------------------------
@@ -125,6 +132,12 @@ def test_complexportal_taxa_valid(complexportal_pipeline_outputs):
     taxa_curies = {row[0] for row in rows}
     missing = label_curies - taxa_curies
     assert not missing, f"{len(missing)} ComplexPortal identifiers have no taxon entry: {sorted(missing)[:10]}"
+
+
+@pytest.mark.pipeline
+def test_complexportal_descriptions_valid(complexportal_pipeline_outputs):
+    """Descriptions file is non-empty and every row is a valid CURIE→description pair."""
+    _assert_descriptions_file_valid(complexportal_pipeline_outputs["descriptions"])
 
 
 @pytest.mark.pipeline

--- a/tests/pipeline/test_complexportal.py
+++ b/tests/pipeline/test_complexportal.py
@@ -31,11 +31,11 @@ from tests.pipeline.conftest import _download_or_fail
 @pytest.fixture(scope="session")
 def complexportal_tsv_files():
     """Download all ComplexPortal TSV files; fail if unavailable."""
-    manifest = make_local_name(complexportal.COMPLEXPORTAL_MANIFEST, subpath=COMPLEXPORTAL)
+    download_done = make_local_name(complexportal.COMPLEXPORTAL_DOWNLOAD_DONE, subpath=COMPLEXPORTAL)
     return _download_or_fail(
         "ComplexPortal TSV files",
         complexportal.pull_complexportal,
-        manifest,
+        download_done,
     )
 
 
@@ -77,9 +77,11 @@ def complexportal_pipeline_outputs(complexportal_tsv_files, regenerate):
 
 @pytest.mark.pipeline
 def test_complexportal_tsv_files_downloaded(complexportal_tsv_files):
-    """Manifest file exists and lists at least one TSV."""
-    assert os.path.exists(complexportal_tsv_files)
-    with open(complexportal_tsv_files) as f:
+    """Sentinel and manifest files exist and the manifest lists at least one TSV."""
+    assert os.path.exists(complexportal_tsv_files), "download_done sentinel is missing"
+    download_dir = os.path.dirname(complexportal_tsv_files)
+    manifest = os.path.join(download_dir, complexportal.COMPLEXPORTAL_MANIFEST)
+    with open(manifest) as f:
         lines = [line.strip() for line in f if line.strip()]
     assert len(lines) > 0, "Manifest is empty — no TSV files were downloaded"
     assert all(fn.endswith(".tsv") for fn in lines), f"Non-TSV entry in manifest: {lines}"
@@ -92,12 +94,10 @@ def test_complexportal_tsv_header_columns(complexportal_tsv_files):
     This test is intentionally explicit about the expected column names so that
     any upstream format change is caught here rather than silently producing wrong output.
     """
-    from src.util import get_config  # deferred
+    download_dir = os.path.dirname(complexportal_tsv_files)
+    manifest = os.path.join(download_dir, complexportal.COMPLEXPORTAL_MANIFEST)
 
-    cfg = get_config()
-    download_dir = os.path.join(cfg["download_directory"], COMPLEXPORTAL)
-
-    with open(complexportal_tsv_files) as mf:
+    with open(manifest) as mf:
         first_filename = next(line.strip() for line in mf if line.strip())
 
     tsv_path = os.path.join(download_dir, first_filename)
@@ -154,13 +154,12 @@ def test_complexportal_cross_file_duplicates_handled_correctly(complexportal_tsv
     Taxa: every (CURIE, taxon) pair from every file is preserved — a complex
           conserved across species should have one taxon entry per species.
     """
-    from src.util import get_config  # deferred
     from tests.conftest import read_tsv
 
-    cfg = get_config()
-    download_dir = os.path.join(cfg["download_directory"], COMPLEXPORTAL)
+    download_dir = os.path.dirname(complexportal_tsv_files)
+    manifest = os.path.join(download_dir, complexportal.COMPLEXPORTAL_MANIFEST)
 
-    with open(complexportal_tsv_files) as mf:
+    with open(manifest) as mf:
         filenames = [line.strip() for line in mf if line.strip()]
 
     # Collect every (curie, taxon_id) pair seen across all source files.

--- a/tests/pipeline/test_complexportal.py
+++ b/tests/pipeline/test_complexportal.py
@@ -1,0 +1,127 @@
+"""ComplexPortal pipeline tests.
+
+Downloads all ComplexPortal TSV files and verifies that labels, synonyms, and
+taxa are extracted correctly.
+
+Run with:
+    uv run pytest tests/pipeline/test_complexportal.py --pipeline --no-cov -v
+"""
+
+import os
+
+import pytest
+
+from src.babel_utils import make_local_name
+from src.datahandlers import complexportal
+from src.prefixes import COMPLEXPORTAL
+from tests.conftest import assert_labels_file_valid, assert_synonyms_file_valid
+from tests.datahandlers.test_complexportal import _assert_taxa_file_valid
+from tests.pipeline.conftest import _download_or_fail
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def complexportal_tsv_files():
+    """Download all ComplexPortal TSV files; fail if unavailable."""
+    manifest = make_local_name(complexportal.COMPLEXPORTAL_MANIFEST, subpath=COMPLEXPORTAL)
+    return _download_or_fail(
+        "ComplexPortal TSV files",
+        complexportal.pull_complexportal,
+        manifest,
+    )
+
+
+@pytest.fixture(scope="session")
+def complexportal_pipeline_outputs(complexportal_tsv_files, regenerate):
+    """Run ComplexPortal label/synonym/taxa extraction; returns {manifest, labels, synonyms, taxa} paths.
+
+    Output files go to babel_downloads/ComplexPortal/.
+    Reused on subsequent runs unless --regenerate is passed.
+    """
+    from src.util import get_config  # deferred: avoid config load at import time
+
+    cfg = get_config()
+    download_dir = os.path.join(cfg["download_directory"], COMPLEXPORTAL)
+    manifest = os.path.join(download_dir, complexportal.COMPLEXPORTAL_MANIFEST)
+    labels = os.path.join(download_dir, "labels")
+    synonyms = os.path.join(download_dir, "synonyms")
+    taxa = os.path.join(download_dir, "taxa")
+    metadata = os.path.join(download_dir, "metadata.yaml")
+
+    if regenerate or not os.path.exists(labels) or not os.path.exists(synonyms) or not os.path.exists(taxa):
+        os.makedirs(download_dir, exist_ok=True)
+        complexportal.make_labels_synonyms_and_taxa(manifest, download_dir, labels, synonyms, taxa, metadata)
+
+    return {"manifest": manifest, "labels": labels, "synonyms": synonyms, "taxa": taxa}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.pipeline
+def test_complexportal_tsv_files_downloaded(complexportal_tsv_files):
+    """Manifest file exists and lists at least one TSV."""
+    assert os.path.exists(complexportal_tsv_files)
+    with open(complexportal_tsv_files) as f:
+        lines = [line.strip() for line in f if line.strip()]
+    assert len(lines) > 0, "Manifest is empty — no TSV files were downloaded"
+    assert all(fn.endswith(".tsv") for fn in lines), f"Non-TSV entry in manifest: {lines}"
+
+
+@pytest.mark.pipeline
+def test_complexportal_tsv_header_columns(complexportal_tsv_files):
+    """Verify the TSV column layout so we know which index holds the taxonomy field.
+
+    This test is intentionally explicit about the expected column names so that
+    any upstream format change is caught here rather than silently producing wrong output.
+    """
+    from src.util import get_config  # deferred
+
+    cfg = get_config()
+    download_dir = os.path.join(cfg["download_directory"], COMPLEXPORTAL)
+
+    with open(complexportal_tsv_files) as mf:
+        first_filename = next(line.strip() for line in mf if line.strip())
+
+    tsv_path = os.path.join(download_dir, first_filename)
+    with open(tsv_path) as f:
+        header = f.readline().rstrip("\n").split("\t")
+
+    # We care most about the columns Babel actually reads; assert their indices explicitly.
+    assert header[0] == "#Complex ac", f"Column 0 is {header[0]!r}, expected '#Complex ac'"
+    assert header[1] == "Recommended name", f"Column 1 is {header[1]!r}, expected 'Recommended name'"
+    assert header[2] == "Aliases for complex", f"Column 2 is {header[2]!r}, expected 'Aliases for complex'"
+    assert header[3] == "Taxonomy identifier", f"Column 3 is {header[3]!r}, expected 'Taxonomy identifier'"
+
+
+@pytest.mark.pipeline
+def test_complexportal_labels_valid(complexportal_pipeline_outputs):
+    """Labels file is non-empty and every row is a valid CURIE→name pair."""
+    rows = assert_labels_file_valid(complexportal_pipeline_outputs["labels"])
+    assert all(row[0].startswith(f"{COMPLEXPORTAL}:") for row in rows), (
+        "Some labels do not start with the ComplexPortal prefix"
+    )
+
+
+@pytest.mark.pipeline
+def test_complexportal_synonyms_valid(complexportal_pipeline_outputs):
+    """Synonyms file is non-empty and every row is a valid CURIE→predicate→synonym triple."""
+    assert_synonyms_file_valid(complexportal_pipeline_outputs["synonyms"])
+
+
+@pytest.mark.pipeline
+def test_complexportal_taxa_valid(complexportal_pipeline_outputs):
+    """Taxa file is non-empty and every row is a valid CURIE→NCBITaxon:NNNN pair."""
+    rows = _assert_taxa_file_valid(complexportal_pipeline_outputs["taxa"])
+    # Every label in the labels file should have at least one taxon entry.
+    from tests.conftest import read_tsv
+
+    label_curies = {row[0] for row in read_tsv(complexportal_pipeline_outputs["labels"])}
+    taxa_curies = {row[0] for row in rows}
+    missing = label_curies - taxa_curies
+    assert not missing, f"{len(missing)} ComplexPortal identifiers have no taxon entry: {sorted(missing)[:10]}"


### PR DESCRIPTION
The original ComplexPortal ingest pulled a single hard-coded species file and produced only
labels/synonyms for the `MacromolecularComplex` compendium. This PR downloads
**all** ComplexPortal species files, extends extraction to taxa, descriptions, and IDs, and builds
out a full unit + network + pipeline test suite around the handler. The remaining commits are
iterative hardening, simplification, and documentation worked through with Copilot and Claude. Closes #751.

## Ingest changes (`src/datahandlers/complexportal.py`)

- **Download all species files** — discover every ComplexTAB `.tsv` by scraping the EBI Apache
  autoindex listing (`fetch_complexportal_tsv_filenames`, renamed from `get_` to make the network
  call explicit) and download each over HTTPS. Raises if the listing yields zero `.tsv` files.
- **Manifest as the download sentinel** — `pull_complexportal()` writes the manifest of downloaded
  files as its last action; the Snakemake rule tracks the manifest (an earlier `download_done`
  flag was added then removed as redundant) as its output, cleanly separating the download phase
  from extraction. A missing TSV listed in the manifest raises a clear `RuntimeError`.
- **Extract taxa** — read column 3 (`Taxonomy identifier`) and write `CURIE → NCBITaxon:NNNN`,
  deduplicated by `(identifier, taxon)` so a complex conserved across species keeps all its taxa;
  rows with `-` are skipped; a defensive guard rejects an already-`NCBITaxon:`-prefixed value.
- **Extract descriptions** — read column 9 and write `CURIE → text`, deduplicated by
  `(identifier, description)` so identical text is written once but distinct descriptions
  accumulate (matching `DescriptionFactory`).
- **Generate the IDs file directly** — emit `CURIE → biolink:MacromolecularComplex` from the
  source rows so accessions with an empty recommended name are still captured, replacing the old
  `awk`-over-labels Snakemake rule.
- **Correct label dedup** — key labels on the identifier alone (first-seen wins) so the same
  accession appearing in two species files with different names can't produce a malformed labels
  file.
- **Format documentation in source** — the 19-column ComplexTAB layout now lives in
  `COMPLEXTAB_COLUMNS`/`COMPLEXTAB_HEADER` next to the code that reads it, annotating which columns
  Babel reads and which are future candidates. Plus docstrings and assorted simplification.

## Snakemake (`datacollect.snakefile`, `macromolecular_complex.snakefile`)

- New `taxa`, `descriptions`, and `ids/ComplexPortal` outputs wired through
  `make_labels_synonyms_and_taxa`; `taxafile`/`descfile` declared as explicit inputs to the
  compendium rule so the DAG reflects what `TaxonFactory`/`DescriptionFactory` read.
- Removed the redundant `macromolecular_complex_ids` awk rule; snakefmt cleanup.

## Tests

- **`tests/datahandlers/test_complexportal.py`** (unit + one network) — listing parsing, download +
  manifest, and the cross-species dedup behaviour of every output, with fixture rows built from the
  real 19-column header imported from the source module.
- **`tests/pipeline/test_complexportal.py`** (pipeline) — downloads all files and validates each
  output, including a **header-column assertion** that catches upstream format drift and a
  **cross-file consistency** check that every source `(CURIE, taxon)` pair survives into the output.
- Promoted `assert_taxa_file_valid` and `assert_descriptions_file_valid` into the shared
  `tests/conftest.py` alongside the existing `assert_*_file_valid` helpers.

## Documentation

- New `docs/sources/COMPLEXPORTAL/Ingestion.md` and `docs/sources/DownloadPatterns.md` (HTTP
  autoindex listing vs FTP `NLST`), indexed from `docs/sources/README.md`.
- `tests/README.md` updated with the new test files, the shared assert helpers, and the
  header-assertion / cross-file techniques.
- `CLAUDE.md` updated: new assert helpers, ComplexPortal in the per-source index, and two new
  conventions (pin external column layouts in source + assert headers in tests; manifest/sentinel
  as the Snakemake output of a multi-file download).