### PR TITLE
Download robustness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,7 +206,8 @@ named by its CURIE prefix); see `docs/sources/README.md` for the convention and 
 there first when working on a specific vocabulary, and add to it when you learn something
 non-obvious about how Babel ingests that source. Keep the detail in the source file — `CLAUDE.md`
 should point here, not duplicate it. Documented so far: ComplexPortal
-(`docs/sources/COMPLEXPORTAL/Ingestion.md`), MeSH (`docs/sources/MESH/Ingestion.md`), and UMLS
+(`docs/sources/COMPLEXPORTAL/Ingestion.md`), Ensembl/BioMart
+(`docs/sources/ENSEMBL/Download.md`), MeSH (`docs/sources/MESH/Ingestion.md`), and UMLS
 (`docs/sources/UMLS/Leftover.md`). Cross-cutting download/discovery patterns (HTTP autoindex
 listing vs FTP `NLST`) live in `docs/sources/DownloadPatterns.md`.
 

--- a/docs/sources/ENSEMBL/Download.md
+++ b/docs/sources/ENSEMBL/Download.md
@@ -1,0 +1,132 @@
+# Ensembl download via BioMart
+
+This document describes how Babel downloads Ensembl gene and protein identifiers, the
+quirks of the BioMart API, and how to handle datasets that fail or should be permanently
+skipped.
+
+The download handler is `src/datahandlers/ensembl.py`; the Snakemake rule is `get_ensembl`
+in `src/snakefiles/datacollect.snakefile`.
+
+## Why BioMart and why it is fragile
+
+Ensembl does not publish a simple bulk identifier dump. The only practical way to retrieve
+the full set of gene identifiers across all species is the BioMart API, accessed via the
+`apybiomart` Python library.
+
+**BioMart is unreliable and the download logic must be written defensively.** Two known
+failure modes:
+
+1. **HTML error pages instead of TSV data.** BioMart occasionally returns an HTML error
+   page (e.g. a 500 or "service unavailable") where the TSV payload is expected. This
+   causes a pandas parse error deep in `TextReader._convert_column_data`. It is transient
+   — the same dataset usually succeeds on a second or third attempt.
+
+2. **SSL certificate failures.** `apybiomart` includes a pre-flight connectivity check
+   over HTTPS that fails in some HPC environments. This check is redundant (a real
+   connectivity failure surfaces during the actual query anyway) and is disabled in
+   `ensembl.py` until the library is fixed
+   ([apybiomart#131](https://github.com/robertopreste/apybiomart/issues/131),
+   [Babel#588](https://github.com/NCATSTranslator/Babel/pull/588)).
+
+Because of these failure modes, **the download code retries each dataset up to
+`BIOMART_MAX_RETRIES` times** (currently 5) with a `BIOMART_RETRY_DELAY_SECS`-second
+pause between attempts (currently 30 s). If a dataset exhausts all retries, the error is
+recorded and the download continues with the remaining datasets — the job only fails at the
+very end. On the next Snakemake retry, only the datasets that actually failed are
+re-attempted (see "Resumability" below).
+
+**Do not remove or weaken this retry / continue-on-failure logic.** Hundreds of species
+datasets are downloaded in a single job run; aborting the whole run on the first transient
+error wastes hours of already-completed work.
+
+## Permanently broken datasets — adding to the skip list
+
+Some datasets fail on every attempt, not just transiently. Common causes: the species has
+been retired from Ensembl, the dataset has no gene identifiers, or a schema mismatch causes
+a persistent parse error.
+
+When a dataset fails repeatedly across multiple pipeline runs, **add it to
+`ensembl_datasets_to_skip` in `config.yaml`** rather than letting it block every future
+run:
+
+```yaml
+ensembl_datasets_to_skip: [elucius_gene_ensembl, hgfemale_gene_ensembl, ...]
+```
+
+The currently skipped datasets are listed there. Each entry is a BioMart dataset ID (the
+value in `apybiomart.find_datasets()["Dataset_ID"]`). Add a comment in the config or a note
+in this file if you know *why* a dataset is broken, so future maintainers can decide whether
+to retry it in a later Ensembl release.
+
+## Download structure
+
+`pull_ensembl()` enumerates all BioMart datasets via `apybiomart.find_datasets()`, skips any
+in `ensembl_datasets_to_skip`, then for each remaining dataset:
+
+1. Discovers which of the desired attributes are available for that species via
+   `apybiomart.find_attributes()`.
+2. Downloads those attributes. If more than `BIOMART_MAX_ATTRIBUTE_COUNT` (6) attributes
+   are available, they are fetched in batches of 6 (BioMart rejects larger requests;
+   see [bioconductor post](https://support.bioconductor.org/p/39744/#39751)). Each batch
+   always includes `ensembl_gene_id` so batches can be joined on `Gene stable ID`.
+3. Writes the merged DataFrame as a tab-separated file at
+   `babel_downloads/ENSEMBL/<dataset_id>/BioMart.tsv`.
+
+The desired attributes (columns) are:
+
+| Attribute | Use |
+|-----------|-----|
+| `ensembl_gene_id` | primary ENSEMBL gene CURIE |
+| `ensembl_peptide_id` | ENSEMBL protein CURIE |
+| `description` | human-readable description |
+| `external_gene_name` | gene symbol from the source authority |
+| `external_gene_source` | which authority provided the symbol |
+| `external_synonym` | alternative gene names |
+| `chromosome_name` | chromosome (used to filter alt/patch scaffolds) |
+| `source` | data source annotation |
+| `gene_biotype` | gene type (protein_coding, lncRNA, …) |
+| `entrezgene_id` | NCBI Gene cross-reference |
+| `zfin_id_id` | ZFIN cross-reference |
+| `mgi_id` | MGI cross-reference |
+| `rgd_id` | RGD cross-reference |
+| `flybase_gene_id` | FlyBase cross-reference |
+| `sgd_gene` | SGD cross-reference |
+| `wormbase_gene` | WormBase cross-reference |
+
+Not every attribute is available for every species dataset; the handler takes the
+intersection of desired and available attributes.
+
+When all datasets have been processed, `pull_ensembl()` writes a JSON summary to
+`babel_downloads/ENSEMBL/BioMartDownloadComplete`. This sentinel file is the only declared
+Snakemake output; downstream rules depend on it rather than the directory.
+
+## Resumability
+
+The Snakemake rule declares only `BioMartDownloadComplete` as its output — **not** the
+`ENSEMBL/` directory. When the rule fails, Snakemake deletes only the sentinel file.
+Already-downloaded per-dataset `BioMart.tsv` files survive and are skipped on the next run
+via the `if os.path.exists(outfile): continue` guard in `pull_ensembl()`.
+
+This means a run that fails after downloading 180 of 200 datasets will restart and only
+download the remaining 20. Do not change the rule to declare `directory(ENSEMBL)` as an
+output — that would cause Snakemake to wipe the whole directory on failure.
+
+## Downstream consumers
+
+| Rule | Function | Output |
+|------|----------|--------|
+| `get_ensembl_gene_ids` (gene.snakefile) | `gene.write_ensembl_gene_ids()` | `ids/gene/ENSEMBL` |
+| `get_ensembl_protein_ids` (protein.snakefile) | `protein.write_ensembl_protein_ids()` | `ids/protein/ENSEMBL` |
+
+Both functions walk `babel_downloads/ENSEMBL/*/BioMart.tsv`, extract the relevant
+identifier column, and write a standard Babel IDs file.
+
+## Related code and issues
+
+- `src/datahandlers/ensembl.py` — `pull_ensembl()`, retry/skip logic, BioMart attribute
+  batching.
+- `src/createcompendia/gene.py` — `write_ensembl_gene_ids()`.
+- `src/createcompendia/protein.py` — `write_ensembl_protein_ids()`.
+- `src/snakefiles/datacollect.snakefile` — `get_ensembl` rule.
+- `config.yaml` → `ensembl_datasets_to_skip` — list of permanently broken datasets.
+- [Babel#588](https://github.com/NCATSTranslator/Babel/pull/588) — SSL bypass workaround.

--- a/docs/sources/README.md
+++ b/docs/sources/README.md
@@ -19,6 +19,10 @@ letting it accumulate in `CLAUDE.md` — `CLAUDE.md` should point here, not dupl
   `MacromolecularComplex` source: which ComplexTAB columns Babel reads, downloading all species
   files, the manifest-as-download-sentinel pattern, and the per-output cross-species
   deduplication rules (labels, IDs, synonyms, taxa, descriptions).
+- **ENSEMBL** ([ENSEMBL/Download.md](./ENSEMBL/Download.md)) — how Ensembl identifiers are
+  downloaded via the BioMart API: per-dataset retry logic, permanently broken datasets and how to
+  skip them, the attribute-batching workaround, and how partial progress is preserved across
+  failed runs.
 - **MESH** ([MESH/Ingestion.md](./MESH/Ingestion.md)) — how MeSH is partitioned across compendia
   by tree letter, how Supplementary Concept Records (SCRs) are typed and routed, the
   chemical/protein D-tree split, and which MeSH branches/SCR classes we deliberately skip.

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -1,8 +1,10 @@
 import gzip
 import os
 import re
+import shutil
 import sqlite3
 import subprocess
+import tempfile
 import time
 import traceback
 import urllib
@@ -150,12 +152,19 @@ def pull_via_ftp(ftpsite, ftpdir, ftpfile, decompress_data=False, outfilename=No
             ftp.retrbinary(f"RETR {ftpfile}", ofile.write)
             ftp.quit()
     else:
-        with BytesIO() as data:
-            ftp.retrbinary(f"RETR {ftpfile}", data.write)
+        # Stream the compressed file to a temp file rather than buffering it all in
+        # memory with BytesIO+gzip.decompress — the old approach needed ~2× the
+        # uncompressed size in RAM (e.g. ~35+ GB for ChEMBL's 17 GB TTL).
+        odir = os.path.abspath(os.path.dirname(ofilename))
+        with tempfile.NamedTemporaryFile(delete=False, dir=odir, suffix=".gz") as tmp:
+            tmp_path = tmp.name
+            ftp.retrbinary(f"RETR {ftpfile}", tmp.write)
             ftp.quit()
-            value = gzip.decompress(data.getvalue()).decode()
-        with open(ofilename, "w") as ofile:
-            ofile.write(value)
+        try:
+            with gzip.open(tmp_path, "rt") as gz_in, open(ofilename, "w") as ofile:
+                shutil.copyfileobj(gz_in, ofile)
+        finally:
+            os.unlink(tmp_path)
     return ofilename
 
 
@@ -273,20 +282,25 @@ def pull_via_urllib(url: str, in_file_name: str, decompress=True, subpath=None, 
 
         # Open a fresh connection on each attempt so a truncated response doesn't
         # leave us reading from an exhausted handle on the next retry.
-        req = urllib.request.Request(download_url, headers={"User-Agent": get_user_agent()})
-        handle = opener.open(req)
-        with open(dl_file_name, "wb") as compressed_file:
-            # while there is data
-            while True:
-                # read a block of data
-                data = handle.read(1024)
+        try:
+            req = urllib.request.Request(download_url, headers={"User-Agent": get_user_agent()})
+            handle = opener.open(req)
+            with open(dl_file_name, "wb") as compressed_file:
+                # while there is data
+                while True:
+                    # read a block of data
+                    data = handle.read(1024)
 
-                # fif nothing read about
-                if len(data) == 0:
-                    break
+                    # if nothing read, abort
+                    if len(data) == 0:
+                        break
 
-                # write out the data to the output file
-                compressed_file.write(data)
+                    # write out the data to the output file
+                    compressed_file.write(data)
+        except urllib.error.URLError as e:
+            logger.warning(f"Download attempt {download_attempt} of {download_url} failed with network/HTTP error: {e}")
+            time.sleep(5 * download_attempt)
+            continue
 
         if decompress:
             out_file_name = dl_file_name[:-3]

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -155,16 +155,17 @@ def pull_via_ftp(ftpsite, ftpdir, ftpfile, decompress_data=False, outfilename=No
         # Stream the compressed file to a temp file rather than buffering it all in
         # memory with BytesIO+gzip.decompress — the old approach needed ~2× the
         # uncompressed size in RAM (e.g. ~35+ GB for ChEMBL's 17 GB TTL).
-        odir = os.path.abspath(os.path.dirname(ofilename))
-        with tempfile.NamedTemporaryFile(delete=False, dir=odir, suffix=".gz") as tmp:
-            tmp_path = tmp.name
-            ftp.retrbinary(f"RETR {ftpfile}", tmp.write)
-            ftp.quit()
+        tmp_path = None  # set before try so finally can always check it
         try:
+            with tempfile.NamedTemporaryFile(delete=False, dir=odir, suffix=".gz") as tmp:
+                tmp_path = tmp.name
+                ftp.retrbinary(f"RETR {ftpfile}", tmp.write)
+                ftp.quit()
             with gzip.open(tmp_path, "rt") as gz_in, open(ofilename, "w") as ofile:
                 shutil.copyfileobj(gz_in, ofile)
         finally:
-            os.unlink(tmp_path)
+            if tmp_path is not None and os.path.exists(tmp_path):
+                os.unlink(tmp_path)
     return ofilename
 
 

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -267,6 +267,7 @@ def pull_via_urllib(url: str, in_file_name: str, decompress=True, subpath=None, 
 
     download_url = url + in_file_name
     logger.info(f"Downloading {download_url}")
+    user_agent = get_user_agent()
 
     # create the compressed file
     download_verified = False
@@ -283,7 +284,7 @@ def pull_via_urllib(url: str, in_file_name: str, decompress=True, subpath=None, 
         # Open a fresh connection on each attempt so a truncated response doesn't
         # leave us reading from an exhausted handle on the next retry.
         try:
-            req = urllib.request.Request(download_url, headers={"User-Agent": get_user_agent()})
+            req = urllib.request.Request(download_url, headers={"User-Agent": user_agent})
             with opener.open(req) as handle, open(dl_file_name, "wb") as compressed_file:
                 # while there is data
                 while True:

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -284,8 +284,7 @@ def pull_via_urllib(url: str, in_file_name: str, decompress=True, subpath=None, 
         # leave us reading from an exhausted handle on the next retry.
         try:
             req = urllib.request.Request(download_url, headers={"User-Agent": get_user_agent()})
-            handle = opener.open(req)
-            with open(dl_file_name, "wb") as compressed_file:
+            with opener.open(req) as handle, open(dl_file_name, "wb") as compressed_file:
                 # while there is data
                 while True:
                     # read a block of data
@@ -407,7 +406,7 @@ def pull_via_wget(
     if retries > 0:
         wget_command_line.append(f"--tries={retries}")
     if connect_timeout > 0:
-        wget_command_line.append(f"--timeout={connect_timeout}")
+        wget_command_line.append(f"--connect-timeout={connect_timeout}")
     if read_timeout > 0:
         wget_command_line.append(f"--read-timeout={read_timeout}")
 

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -350,6 +350,8 @@ def pull_via_wget(
     timestamping=True,
     recurse: WgetRecursionOptions = WgetRecursionOptions.NO_RECURSION,
     retries: int = 10,
+    connect_timeout: int = 60,
+    read_timeout: int = 300,
 ):
     """
     Download a file using wget. We call wget from the command line, and use command line options to
@@ -390,6 +392,10 @@ def pull_via_wget(
         wget_command_line.append("--timestamping")
     if retries > 0:
         wget_command_line.append(f"--tries={retries}")
+    if connect_timeout > 0:
+        wget_command_line.append(f"--timeout={connect_timeout}")
+    if read_timeout > 0:
+        wget_command_line.append(f"--read-timeout={read_timeout}")
 
     # Add URL and output file.
     wget_command_line.append(url)

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -256,11 +256,8 @@ def pull_via_urllib(url: str, in_file_name: str, decompress=True, subpath=None, 
     # Add support for redirects
     opener = urllib.request.build_opener(urllib.request.HTTPRedirectHandler())
 
-    # get a handle to the ftp file
     download_url = url + in_file_name
     logger.info(f"Downloading {download_url}")
-    req = urllib.request.Request(download_url, headers={"User-Agent": get_user_agent()})
-    handle = opener.open(req)
 
     # create the compressed file
     download_verified = False
@@ -274,6 +271,10 @@ def pull_via_urllib(url: str, in_file_name: str, decompress=True, subpath=None, 
             )
         logger.info(f"Downloading {dl_file_name} using urllib, attempt {download_attempt}...")
 
+        # Open a fresh connection on each attempt so a truncated response doesn't
+        # leave us reading from an exhausted handle on the next retry.
+        req = urllib.request.Request(download_url, headers={"User-Agent": get_user_agent()})
+        handle = opener.open(req)
         with open(dl_file_name, "wb") as compressed_file:
             # while there is data
             while True:

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -29,7 +29,7 @@ from src.util import Text, get_config, get_logger, get_memory_usage_summary
 
 # Configuration items
 WRITE_COMPENDIUM_LOG_EVERY_X_CLIQUES = 1_000_000
-MAX_DOWNLOAD_ERROR = 10
+MAX_DOWNLOAD_ERROR = 1
 
 
 def get_user_agent() -> str:
@@ -363,7 +363,7 @@ def pull_via_wget(
     continue_incomplete: bool = True,
     timestamping=True,
     recurse: WgetRecursionOptions = WgetRecursionOptions.NO_RECURSION,
-    retries: int = 10,
+    retries: int = 1,
     connect_timeout: int = 60,
     read_timeout: int = 300,
 ):

--- a/src/createcompendia/publications.py
+++ b/src/createcompendia/publications.py
@@ -6,6 +6,7 @@ import os
 import time
 import xml.etree.ElementTree as ET
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from mmap import ACCESS_READ, mmap
 from pathlib import Path
 
@@ -34,25 +35,28 @@ def download_pubmed(
     # Create directories if they don't exist.
     os.makedirs(os.path.dirname(download_file), exist_ok=True)
 
-    # Step 1. Download all the files for the PubMed annual baseline.
-    pull_via_wget(
-        pubmed_base,
-        "baseline",
-        decompress=False,
-        subpath="PubMed",
-        recurse=WgetRecursionOptions.RECURSE_SUBFOLDERS,
-        timestamping=True,
-    )
+    # Download baseline and updatefiles in parallel — each directory contains ~750 files,
+    # so running them concurrently roughly halves wall time on the HPC.
+    subdirs = ["baseline", "updatefiles"]
 
-    # Step 2. Download all the files for the PubMed update files.
-    pull_via_wget(
-        pubmed_base,
-        "updatefiles",
-        decompress=False,
-        subpath="PubMed",
-        recurse=WgetRecursionOptions.RECURSE_SUBFOLDERS,
-        timestamping=True,
-    )
+    def _download_subdir(subdir):
+        pull_via_wget(
+            pubmed_base,
+            subdir,
+            decompress=False,
+            subpath="PubMed",
+            recurse=WgetRecursionOptions.RECURSE_SUBFOLDERS,
+            timestamping=True,
+        )
+
+    with ThreadPoolExecutor(max_workers=len(subdirs)) as pool:
+        futures = {pool.submit(_download_subdir, sd): sd for sd in subdirs}
+        for future in as_completed(futures):
+            subdir = futures[future]
+            exc = future.exception()
+            if exc:
+                raise RuntimeError(f"Failed to download PubMed/{subdir}: {exc}") from exc
+            logging.info(f"Finished downloading PubMed/{subdir}.")
 
     # Step 3. Download the PMC/PMID mapping file from PMC.
     # We don't actually use this file -- we currently only use the PMC IDs already included in the PubMed XML files.

--- a/src/createcompendia/publications.py
+++ b/src/createcompendia/publications.py
@@ -14,6 +14,9 @@ from src.babel_utils import WgetRecursionOptions, glom, pull_via_wget, read_iden
 from src.categories import JOURNAL_ARTICLE, PUBLICATION
 from src.metadata.provenance import write_concord_metadata
 from src.prefixes import DOI, PMC, PMID
+from src.util import get_logger
+
+logger = get_logger(__name__)
 
 
 def download_pubmed(
@@ -56,7 +59,7 @@ def download_pubmed(
             exc = future.exception()
             if exc:
                 raise RuntimeError(f"Failed to download PubMed/{subdir}: {exc}") from exc
-            logging.info(f"Finished downloading PubMed/{subdir}.")
+            logger.info(f"Finished downloading PubMed/{subdir}.")
 
     # Step 3. Download the PMC/PMID mapping file from PMC.
     # We don't actually use this file -- we currently only use the PMC IDs already included in the PubMed XML files.

--- a/src/datahandlers/ensembl.py
+++ b/src/datahandlers/ensembl.py
@@ -1,6 +1,8 @@
 import json
 import logging
 import os
+import shutil
+import time
 
 import apybiomart.classes as _apy_classes
 from apybiomart import find_attributes, find_datasets, query
@@ -20,6 +22,8 @@ _apy_classes._Server._check_connection = staticmethod(lambda: True)
 # This is the real MAX minus one: for every batch, we'll query the ensembl_gene_id so that we can
 # put the batches back together again afterward.
 BIOMART_MAX_ATTRIBUTE_COUNT = 6
+BIOMART_MAX_RETRIES = 5
+BIOMART_RETRY_DELAY_SECS = 30
 
 
 # Note that Ensembl doesn't seem to assign its own labels or synonyms to its gene identifiers.  It appears that
@@ -68,6 +72,7 @@ def pull_ensembl(
 
     # Prepare a report to return.
     report = {}
+    failed_datasets = {}
 
     # Columns to choose.
     cols_to_find = {
@@ -106,81 +111,105 @@ def pull_ensembl(
             }
             logging.info(f"Skipping {ds} as it already exists")
             continue
-        try:
-            atts = find_attributes(ds)
-            existingatts = set(atts["Attribute_ID"].to_list())
-            attsIcanGet = cols_to_find.intersection(existingatts)
+        last_exc = None
+        for attempt in range(1, BIOMART_MAX_RETRIES + 1):
+            try:
+                atts = find_attributes(ds)
+                existingatts = set(atts["Attribute_ID"].to_list())
+                attsIcanGet = cols_to_find.intersection(existingatts)
 
-            if len(attsIcanGet) <= max_attribute_count:
-                # Excellent: we can do this in one query.
-                logging.info(f"Found {len(attsIcanGet)} attributes for {ds} for single query: {attsIcanGet}")
-                df = query(attributes=list(attsIcanGet), filters={}, dataset=ds)
-                report[ds] = {
-                    "status": "downloaded",
-                    "message": f"Downloaded dataset {ds} in a single query",
-                    "batches": [],
-                    "attributes": list(attsIcanGet),
-                    "num_rows": len(df),
-                    "output_file": outfile,
-                }
-            else:
-                # We need to retrieve all the attributes in batches.
-                # We'll remove ensembl_gene_id from the list so we can use that to stitch the individual
-                # results back together again.
-                attributes_to_retrieve = list(attsIcanGet)
-                attributes_to_retrieve.remove("ensembl_gene_id")
-                df = None
-                report[ds] = {
-                    "status": "downloading",
-                    "message": f"Dataset {ds} has more than {max_attribute_count} attributes for single query, so they will be downloaded in batches.",
-                    "batches": [],
-                    "output_file": outfile,
-                }
-                # Go through the list of attributes stepping at max_attribute_count.
-                for i in range(0, len(attributes_to_retrieve), max_attribute_count):
-                    # Create a batch of attributes to query.
-                    attr_batch = attributes_to_retrieve[i : i + max_attribute_count]
-                    logging.info(
-                        f"Querying batch of {len(attr_batch)} attributes for {ds} (+ 'ensembl_gene_id'): {attr_batch}"
+                if len(attsIcanGet) <= max_attribute_count:
+                    # Excellent: we can do this in one query.
+                    logging.info(f"Found {len(attsIcanGet)} attributes for {ds} for single query: {attsIcanGet}")
+                    df = query(attributes=list(attsIcanGet), filters={}, dataset=ds)
+                    report[ds] = {
+                        "status": "downloaded",
+                        "message": f"Downloaded dataset {ds} in a single query",
+                        "batches": [],
+                        "attributes": list(attsIcanGet),
+                        "num_rows": len(df),
+                        "output_file": outfile,
+                    }
+                else:
+                    # We need to retrieve all the attributes in batches.
+                    # We'll remove ensembl_gene_id from the list so we can use that to stitch the individual
+                    # results back together again.
+                    attributes_to_retrieve = list(attsIcanGet)
+                    attributes_to_retrieve.remove("ensembl_gene_id")
+                    df = None
+                    report[ds] = {
+                        "status": "downloading",
+                        "message": f"Dataset {ds} has more than {max_attribute_count} attributes for single query, so they will be downloaded in batches.",
+                        "batches": [],
+                        "output_file": outfile,
+                    }
+                    # Go through the list of attributes stepping at max_attribute_count.
+                    for i in range(0, len(attributes_to_retrieve), max_attribute_count):
+                        # Create a batch of attributes to query.
+                        attr_batch = attributes_to_retrieve[i : i + max_attribute_count]
+                        logging.info(
+                            f"Querying batch of {len(attr_batch)} attributes for {ds} (+ 'ensembl_gene_id'): {attr_batch}"
+                        )
+
+                        # Download the list of Biomart records for this set of attributes for this dataset.
+                        batch_df = query(attributes=["ensembl_gene_id"] + list(attr_batch), filters={}, dataset=ds)
+                        report[ds]["batches"].append(
+                            {
+                                "attributes": attr_batch,
+                                "num_rows": len(batch_df),
+                            }
+                        )
+                        if df is None:
+                            # If we're the first df, we don't need to merge anything.
+                            df = batch_df
+                        else:
+                            # Merge these new results with the earlier results.
+                            df = df.merge(batch_df, on="Gene stable ID", how="outer", sort=True)
+
+                    # Note that we downloaded all the batches.
+                    report[ds]["status"] = "downloaded"
+                    report[ds]["message"] = (
+                        f"Dataset {ds} has more than {max_attribute_count} attributes for single query, so they were downloaded in batches."
                     )
+                    report[ds]["attributes"] = list(attsIcanGet)
+                    report[ds]["num_rows"] = len(df)
 
-                    # Download the list of Biomart records for this set of attributes for this dataset.
-                    batch_df = query(attributes=["ensembl_gene_id"] + list(attr_batch), filters={}, dataset=ds)
-                    report[ds]["batches"].append(
-                        {
-                            "attributes": attr_batch,
-                            "num_rows": len(batch_df),
-                        }
-                    )
-                    if df is None:
-                        # If we're the first df, we don't need to merge anything.
-                        df = batch_df
-                    else:
-                        # Merge these new results with the earlier results.
-                        df = df.merge(batch_df, on="Gene stable ID", how="outer", sort=True)
+                # Write out the data frame after sorting it by Gene stable ID.
+                df.sort_values(by=["Gene stable ID"], inplace=True)
+                os.makedirs(os.path.dirname(outfile), exist_ok=True)
+                df.to_csv(outfile, index=False, sep="\t")
+                last_exc = None
+                break
+            except Exception as exc:
+                last_exc = exc
+                biomart_dir = os.path.dirname(outfile)
+                logging.warning(f"Failed to download dataset {ds} (attempt {attempt}/{BIOMART_MAX_RETRIES}): {exc}")
+                if os.path.exists(outfile):
+                    logging.warning(f"Deleting partial download file {outfile}")
+                    os.remove(outfile)
+                if os.path.exists(biomart_dir):
+                    logging.warning(f"Deleting BioMart directory {biomart_dir}")
+                    shutil.rmtree(biomart_dir)
+                if attempt < BIOMART_MAX_RETRIES:
+                    logging.info(f"Retrying dataset {ds} in {BIOMART_RETRY_DELAY_SECS}s...")
+                    time.sleep(BIOMART_RETRY_DELAY_SECS)
 
-                # Note that we downloaded all the batches.
-                report[ds]["status"] = "downloaded"
-                report[ds]["message"] = (
-                    f"Dataset {ds} has more than {max_attribute_count} attributes for single query, so they were downloaded in batches."
-                )
-                report[ds]["attributes"] = list(attsIcanGet)
-                report[ds]["num_rows"] = len(df)
-
-            # Write out the data frame after sorting it by Gene stable ID.
-            df.sort_values(by=["Gene stable ID"], inplace=True)
-            os.makedirs(os.path.dirname(outfile))
-            df.to_csv(outfile, index=False, sep="\t")
-        except Exception as exc:
-            biomart_dir = os.path.dirname(outfile)
-            print(f"Deleting BioMart directory {biomart_dir} so its clear it needs to be downloaded again.")
-            if os.path.exists(biomart_dir):
-                os.rmdir(biomart_dir)
-            raise exc
+        if last_exc is not None:
+            report[ds] = {"status": "failed", "message": str(last_exc), "output_file": outfile}
+            failed_datasets[ds] = last_exc
+            logging.error(
+                f"Dataset {ds} failed all {BIOMART_MAX_RETRIES} attempts; continuing with remaining datasets."
+            )
 
     # Write out a complete file with the report as a JSON object.
     with open(complete_file, "w") as outf:
         json.dump(report, outf, indent=2, sort_keys=True)
+
+    if failed_datasets:
+        failed_list = ", ".join(failed_datasets)
+        raise RuntimeError(
+            f"{len(failed_datasets)} dataset(s) failed after {BIOMART_MAX_RETRIES} attempts each: {failed_list}"
+        )
 
     return report
 

--- a/src/datahandlers/ensembl.py
+++ b/src/datahandlers/ensembl.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import os
 import shutil
 import time
@@ -7,7 +6,9 @@ import time
 import apybiomart.classes as _apy_classes
 from apybiomart import find_attributes, find_datasets, query
 
-from src.util import get_config
+from src.util import get_config, get_logger
+
+logger = get_logger(__name__)
 
 # apybiomart's pre-flight connectivity check uses HTTPS and fails with SSL
 # certificate errors in some environments (see
@@ -94,7 +95,7 @@ def pull_ensembl(
         "wormbase_gene",
     }
     for ds in dataset_ids:
-        logging.info(f"Downloading ENSEMBL dataset {ds}")
+        logger.info(f"Downloading ENSEMBL dataset {ds}")
         if ds in skip_dataset_ids:
             print(f"Skipping {ds} as it is included in skip_dataset_ids: {skip_dataset_ids}")
             continue
@@ -109,7 +110,7 @@ def pull_ensembl(
                 "batches": [],
                 "message": f"Output file already exists for dataset {ds}, skipping.",
             }
-            logging.info(f"Skipping {ds} as it already exists")
+            logger.info(f"Skipping {ds} as it already exists")
             continue
         last_exc = None
         for attempt in range(1, BIOMART_MAX_RETRIES + 1):
@@ -120,7 +121,7 @@ def pull_ensembl(
 
                 if len(attsIcanGet) <= max_attribute_count:
                     # Excellent: we can do this in one query.
-                    logging.info(f"Found {len(attsIcanGet)} attributes for {ds} for single query: {attsIcanGet}")
+                    logger.info(f"Found {len(attsIcanGet)} attributes for {ds} for single query: {attsIcanGet}")
                     df = query(attributes=list(attsIcanGet), filters={}, dataset=ds)
                     report[ds] = {
                         "status": "downloaded",
@@ -147,7 +148,7 @@ def pull_ensembl(
                     for i in range(0, len(attributes_to_retrieve), max_attribute_count):
                         # Create a batch of attributes to query.
                         attr_batch = attributes_to_retrieve[i : i + max_attribute_count]
-                        logging.info(
+                        logger.info(
                             f"Querying batch of {len(attr_batch)} attributes for {ds} (+ 'ensembl_gene_id'): {attr_batch}"
                         )
 
@@ -182,17 +183,17 @@ def pull_ensembl(
             except Exception as exc:
                 last_exc = exc
                 biomart_dir = os.path.dirname(outfile)
-                logging.warning(f"Failed to download dataset {ds} (attempt {attempt}/{BIOMART_MAX_RETRIES}): {exc}")
+                logger.warning(f"Failed to download dataset {ds} (attempt {attempt}/{BIOMART_MAX_RETRIES}): {exc}")
                 if os.path.exists(biomart_dir):
-                    logging.warning(f"Deleting BioMart directory {biomart_dir}")
+                    logger.warning(f"Deleting BioMart directory {biomart_dir}")
                     shutil.rmtree(biomart_dir)
                 if attempt < BIOMART_MAX_RETRIES:
-                    logging.info(f"Retrying dataset {ds} in {BIOMART_RETRY_DELAY_SECS}s...")
+                    logger.info(f"Retrying dataset {ds} in {BIOMART_RETRY_DELAY_SECS}s...")
                     time.sleep(BIOMART_RETRY_DELAY_SECS)
         else:
             report[ds] = {"status": "failed", "message": str(last_exc), "output_file": outfile}
             failed_datasets[ds] = last_exc
-            logging.error(
+            logger.error(
                 f"Dataset {ds} failed all {BIOMART_MAX_RETRIES} attempts; continuing with remaining datasets."
             )
 

--- a/src/datahandlers/ensembl.py
+++ b/src/datahandlers/ensembl.py
@@ -193,9 +193,7 @@ def pull_ensembl(
         else:
             report[ds] = {"status": "failed", "message": str(last_exc), "output_file": outfile}
             failed_datasets[ds] = last_exc
-            logger.error(
-                f"Dataset {ds} failed all {BIOMART_MAX_RETRIES} attempts; continuing with remaining datasets."
-            )
+            logger.error(f"Dataset {ds} failed all {BIOMART_MAX_RETRIES} attempts; continuing with remaining datasets.")
 
     # Write out a complete file with the report as a JSON object.
     with open(complete_file, "w") as outf:

--- a/src/datahandlers/ensembl.py
+++ b/src/datahandlers/ensembl.py
@@ -178,23 +178,18 @@ def pull_ensembl(
                 df.sort_values(by=["Gene stable ID"], inplace=True)
                 os.makedirs(os.path.dirname(outfile), exist_ok=True)
                 df.to_csv(outfile, index=False, sep="\t")
-                last_exc = None
                 break
             except Exception as exc:
                 last_exc = exc
                 biomart_dir = os.path.dirname(outfile)
                 logging.warning(f"Failed to download dataset {ds} (attempt {attempt}/{BIOMART_MAX_RETRIES}): {exc}")
-                if os.path.exists(outfile):
-                    logging.warning(f"Deleting partial download file {outfile}")
-                    os.remove(outfile)
                 if os.path.exists(biomart_dir):
                     logging.warning(f"Deleting BioMart directory {biomart_dir}")
                     shutil.rmtree(biomart_dir)
                 if attempt < BIOMART_MAX_RETRIES:
                     logging.info(f"Retrying dataset {ds} in {BIOMART_RETRY_DELAY_SECS}s...")
                     time.sleep(BIOMART_RETRY_DELAY_SECS)
-
-        if last_exc is not None:
+        else:
             report[ds] = {"status": "failed", "message": str(last_exc), "output_file": outfile}
             failed_datasets[ds] = last_exc
             logging.error(

--- a/src/datahandlers/ensembl.py
+++ b/src/datahandlers/ensembl.py
@@ -22,7 +22,7 @@ _apy_classes._Server._check_connection = staticmethod(lambda: True)
 # This is the real MAX minus one: for every batch, we'll query the ensembl_gene_id so that we can
 # put the batches back together again afterward.
 BIOMART_MAX_ATTRIBUTE_COUNT = 6
-BIOMART_MAX_RETRIES = 5
+BIOMART_MAX_RETRIES = 1
 BIOMART_RETRY_DELAY_SECS = 30
 
 

--- a/src/datahandlers/ensembl.py
+++ b/src/datahandlers/ensembl.py
@@ -22,7 +22,7 @@ _apy_classes._Server._check_connection = staticmethod(lambda: True)
 # This is the real MAX minus one: for every batch, we'll query the ensembl_gene_id so that we can
 # put the batches back together again afterward.
 BIOMART_MAX_ATTRIBUTE_COUNT = 6
-BIOMART_MAX_RETRIES = 1
+BIOMART_MAX_RETRIES = 5
 BIOMART_RETRY_DELAY_SECS = 30
 
 

--- a/src/datahandlers/kegg.py
+++ b/src/datahandlers/kegg.py
@@ -28,7 +28,7 @@ from src.prefixes import KEGGCOMPOUND
 def pull_kegg_compound_labels(outfile):
     try:
         request_session = requests.Session()
-        request_adapter = requests.adapters.HTTPAdapter(max_retries=10)
+        request_adapter = requests.adapters.HTTPAdapter(max_retries=0)
         request_session.mount("http://", request_adapter)
         request_session.mount("https://", request_adapter)
 

--- a/src/datahandlers/pantherfamily.py
+++ b/src/datahandlers/pantherfamily.py
@@ -26,7 +26,7 @@ def pull_pantherfamily():
     try:
         pull_via_ftp(FTP_HOST, FTP_DIR, FTP_FILE, outfilename=outfile)
         return
-    except (ftplib.Error, OSError, EOFError, TimeoutError) as e:
+    except ftplib.all_errors as e:
         logger.warning(f"FTP download from {FTP_HOST} failed ({e}); falling back to HTTP mirror.")
 
     http_url = HTTP_BASE + FTP_FILE

--- a/src/datahandlers/pantherfamily.py
+++ b/src/datahandlers/pantherfamily.py
@@ -1,18 +1,52 @@
-from src.babel_utils import pull_via_ftp
+import ftplib
+import os
+import urllib.error
+import urllib.request
+
+from src.babel_utils import get_config, get_user_agent, pull_via_ftp
 from src.metadata.provenance import write_metadata
 from src.prefixes import PANTHERFAMILY
+from src.util import get_logger
+
+logger = get_logger(__name__)
+
+FTP_HOST = "ftp.pantherdb.org"
+FTP_DIR = "/sequence_classifications/current_release/PANTHER_Sequence_Classification_files/"
+FTP_FILE = "PTHR19.0_human"
+HTTP_BASE = (
+    "http://data.pantherdb.org/ftp/sequence_classifications/current_release/PANTHER_Sequence_Classification_files/"
+)
 
 
 def pull_pantherfamily():
     outfile = f"{PANTHERFAMILY}/family.csv"
-    pull_via_ftp(
-        "ftp.pantherdb.org",
-        "/sequence_classifications/current_release/PANTHER_Sequence_Classification_files/",
-        "PTHR19.0_human",
-        outfilename=outfile,
-    )
-    # If you need to check this quickly, it's also available on HTTP at:
-    # - http://data.pantherdb.org/ftp/sequence_classifications/current_release/PANTHER_Sequence_Classification_files/
+    config = get_config()
+    ofilename = os.path.join(config["download_directory"], outfile)
+
+    try:
+        pull_via_ftp(FTP_HOST, FTP_DIR, FTP_FILE, outfilename=outfile)
+        return
+    except (ftplib.Error, OSError, EOFError, TimeoutError) as e:
+        logger.warning(f"FTP download from {FTP_HOST} failed ({e}); falling back to HTTP mirror.")
+
+    http_url = HTTP_BASE + FTP_FILE
+    logger.info(f"Downloading {http_url} → {ofilename}")
+    os.makedirs(os.path.dirname(ofilename), exist_ok=True)
+    req = urllib.request.Request(http_url, headers={"User-Agent": get_user_agent()})
+    try:
+        with urllib.request.urlopen(req, timeout=300) as resp, open(ofilename, "wb") as outf:
+            while True:
+                chunk = resp.read(65536)
+                if not chunk:
+                    break
+                outf.write(chunk)
+    except (urllib.error.URLError, TimeoutError) as e:
+        raise RuntimeError(
+            f"Both FTP and HTTP downloads failed for PANTHER family file.\n"
+            f"  URL: {http_url}\n"
+            f"  Local path: {ofilename}\n"
+            f"  To download manually: wget '{http_url}' -O '{ofilename}'"
+        ) from e
 
 
 def pull_labels(infile, outfile, metadata_yaml):

--- a/src/snakefiles/anatomy.snakefile
+++ b/src/snakefiles/anatomy.snakefile
@@ -73,7 +73,7 @@ rule get_anatomy_obo_relationships:
         go_metadata=config["intermediate_directory"] + "/anatomy/concords/metadata-GO.yaml",
     benchmark:
         config["output_directory"] + "/benchmarks/get_anatomy_obo_relationships.tsv"
-    retries: 10  # Ubergraph sometimes fails mid-download, and then we need to retry.
+    retries: 3  # Ubergraph sometimes fails mid-download and needs a retry.
     run:
         anatomy.build_anatomy_obo_relationships(
             config["intermediate_directory"] + "/anatomy/concords",

--- a/src/snakefiles/chemical.snakefile
+++ b/src/snakefiles/chemical.snakefile
@@ -124,7 +124,7 @@ rule chemical_chebi_ids:
         outfile=config["intermediate_directory"] + "/chemicals/ids/CHEBI",
     benchmark:
         config["output_directory"] + "/benchmarks/chemical_chebi_ids.tsv"
-    retries: 10  # Ubergraph sometimes fails mid-download, and then we need to retry.
+    retries: 3  # Ubergraph sometimes fails mid-download and needs a retry.
     run:
         chemicals.write_chebi_ids(output.outfile)
 

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -54,6 +54,7 @@ rule get_EFO:
         config["download_directory"] + "/EFO" + "/efo.owl",
     benchmark:
         config["output_directory"] + "/benchmarks/get_EFO.tsv"
+    retries: 3  # EFO OWL download occasionally fails transiently.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -82,6 +83,7 @@ rule get_complexportal:
         manifest=config["download_directory"] + "/ComplexPortal/" + complexportal.COMPLEXPORTAL_MANIFEST,
     benchmark:
         config["output_directory"] + "/benchmarks/get_complexportal.tsv"
+    retries: 3  # ComplexPortal downloads occasionally fail transiently.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -126,6 +128,7 @@ rule get_mods:
         ),
     benchmark:
         config["output_directory"] + "/benchmarks/get_mods.tsv"
+    retries: 3  # MOD gene-description downloads occasionally fail transiently.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -156,6 +159,7 @@ rule get_uniprotkb_idmapping:
         idmapping=config["download_directory"] + "/UniProtKB/idmapping.dat",
     benchmark:
         config["output_directory"] + "/benchmarks/get_uniprotkb_idmapping.tsv"
+    retries: 3  # Large UniProtKB FTP download may be interrupted transiently.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -174,6 +178,7 @@ rule get_uniprotkb_sprot:
         uniprot_sprot=config["download_directory"] + "/UniProtKB/uniprot_sprot.fasta",
     benchmark:
         config["output_directory"] + "/benchmarks/get_uniprotkb_sprot.tsv"
+    retries: 3  # UniProtKB FTP download may be interrupted transiently.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -191,6 +196,7 @@ rule get_uniprotkb_trembl:
         uniprot_trembl=config["download_directory"] + "/UniProtKB/uniprot_trembl.fasta",
     benchmark:
         config["output_directory"] + "/benchmarks/get_uniprotkb_trembl.tsv"
+    retries: 3  # Large UniProtKB TrEMBL FTP download may be interrupted transiently.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -224,6 +230,7 @@ rule get_mesh:
         config["download_directory"] + "/MESH/mesh.nt",
     benchmark:
         config["output_directory"] + "/benchmarks/get_mesh.tsv"
+    retries: 3  # MeSH FTP download occasionally fails transiently.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -261,6 +268,7 @@ rule download_umls:
         config["download_directory"] + "/UMLS/UMLS.metadata.yaml",
     benchmark:
         config["output_directory"] + "/benchmarks/download_umls.tsv"
+    retries: 3  # UMLS download from NLM API occasionally fails transiently.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -373,6 +381,7 @@ rule get_ncbigene:
         ),
     benchmark:
         config["output_directory"] + "/benchmarks/get_ncbigene.tsv"
+    retries: 3  # NCBIGene FTP download occasionally fails transiently.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -429,6 +438,7 @@ rule get_hgnc:
         outfile=config["download_directory"] + "/HGNC/hgnc_complete_set.json",
     benchmark:
         config["output_directory"] + "/benchmarks/get_hgnc.tsv"
+    retries: 3  # HGNC download occasionally fails transiently.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -456,6 +466,7 @@ rule get_hgncfamily:
         outfile=config["download_directory"] + "/HGNC.FAMILY/family.csv",
     benchmark:
         config["output_directory"] + "/benchmarks/get_hgncfamily.tsv"
+    retries: 3  # HGNC family download occasionally fails transiently.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -512,6 +523,7 @@ rule get_omim:
         outfile=config["download_directory"] + "/OMIM/mim2gene.txt",
     benchmark:
         config["output_directory"] + "/benchmarks/get_omim.tsv"
+    retries: 3  # OMIM download occasionally fails transiently.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -541,6 +553,7 @@ rule get_ncit:
         outfile=config["download_directory"] + "/NCIT/NCIt-SwissProt_Mapping.txt",
     benchmark:
         config["output_directory"] + "/benchmarks/get_ncit.tsv"
+    retries: 3  # NCI Thesaurus download occasionally fails transiently.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -556,6 +569,7 @@ rule get_doid:
         outfile=config["download_directory"] + "/DOID/doid.json",
     benchmark:
         config["output_directory"] + "/benchmarks/get_doid.tsv"
+    retries: 3  # Disease Ontology download occasionally fails transiently.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -583,6 +597,7 @@ rule get_orphanet:
         outfile=config["download_directory"] + "/Orphanet/Orphanet_Nomenclature_Pack_EN.zip",
     benchmark:
         config["output_directory"] + "/benchmarks/get_orphanet.tsv"
+    retries: 3  # Orphanet download occasionally fails transiently.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -610,6 +625,7 @@ rule get_reactome:
         outfile=config["download_directory"] + "/REACT/Events.json",
     benchmark:
         config["output_directory"] + "/benchmarks/get_reactome.tsv"
+    retries: 3  # Reactome download occasionally fails transiently.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -636,6 +652,7 @@ rule get_rhea:
         outfile=config["download_directory"] + "/RHEA/rhea.rdf",
     benchmark:
         config["output_directory"] + "/benchmarks/get_rhea.tsv"
+    retries: 3  # RHEA download occasionally fails transiently.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -662,6 +679,7 @@ rule get_EC:
         outfile=config["download_directory"] + "/EC/enzyme.rdf",
     benchmark:
         config["output_directory"] + "/benchmarks/get_EC.tsv"
+    retries: 3  # Enzyme Classification download occasionally fails transiently.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -689,6 +707,7 @@ rule get_SMPDB:
         outfile=config["download_directory"] + "/SMPDB/smpdb_pathways.csv",
     benchmark:
         config["output_directory"] + "/benchmarks/get_SMPDB.tsv"
+    retries: 3  # SMPDB download occasionally fails transiently.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -715,6 +734,7 @@ rule get_panther_pathways:
         outfile=config["download_directory"] + "/PANTHER.PATHWAY/SequenceAssociationPathway3.6.8.txt",
     benchmark:
         config["output_directory"] + "/benchmarks/get_panther_pathways.tsv"
+    retries: 3  # PANTHER pathway download occasionally fails transiently.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -805,6 +825,7 @@ rule get_drugbank_labels_and_synonyms:
         synonyms=config["download_directory"] + "/DRUGBANK/synonyms",
     benchmark:
         config["output_directory"] + "/benchmarks/get_drugbank_labels_and_synonyms.tsv"
+    retries: 3  # DrugBank download occasionally fails transiently.
     run:
         drugbank.download_drugbank_vocabulary(config["drugbank_version"], output.outfile)
         drugbank.extract_drugbank_labels_and_synonyms(output.outfile, output.labels, output.synonyms)
@@ -818,6 +839,7 @@ rule get_gtopdb:
         outfile=config["download_directory"] + "/GTOPDB/ligands.tsv",
     benchmark:
         config["output_directory"] + "/benchmarks/get_gtopdb.tsv"
+    retries: 3  # Guide to Pharmacology download occasionally fails transiently.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -846,6 +868,7 @@ rule keggcompound_labels:
         labelfile=config["download_directory"] + "/KEGG.COMPOUND/labels",
     benchmark:
         config["output_directory"] + "/benchmarks/keggcompound_labels.tsv"
+    retries: 3  # KEGG REST API calls occasionally fail transiently.
     run:
         kegg.pull_kegg_compound_labels(output.labelfile)
 
@@ -859,6 +882,7 @@ rule get_unii:
         config["download_directory"] + "/UNII/Latest_UNII_Records.txt",
     benchmark:
         config["output_directory"] + "/benchmarks/get_unii.tsv"
+    retries: 3  # UNII download occasionally fails transiently.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -917,6 +941,7 @@ rule get_pubchem:
         config["download_directory"] + "/PUBCHEM.COMPOUND/CID-Title.gz",
     benchmark:
         config["output_directory"] + "/benchmarks/get_pubchem.tsv"
+    retries: 3  # PubChem FTP download occasionally fails transiently.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -930,6 +955,7 @@ rule get_pubchem_structures:
         config["download_directory"] + "/PUBCHEM.COMPOUND/CID-SMILES.gz",
     benchmark:
         config["output_directory"] + "/benchmarks/get_pubchem_structures.tsv"
+    retries: 3  # PubChem FTP download occasionally fails transiently.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -965,6 +991,7 @@ rule download_rxnorm:
         config["download_directory"] + "/RxNorm/RXNREL.RRF",
     benchmark:
         config["output_directory"] + "/benchmarks/download_rxnorm.tsv"
+    retries: 3  # RxNorm download from NLM API occasionally fails transiently.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -977,6 +1004,7 @@ rule pubchem_rxnorm_annotations:
         outfile=config["download_directory"] + "/PUBCHEM.COMPOUND/RXNORM.json",
     benchmark:
         config["output_directory"] + "/benchmarks/pubchem_rxnorm_annotations.tsv"
+    retries: 3  # PubChem RxNorm annotation API occasionally fails transiently.
     run:
         pubchem.pull_rxnorm_annotations(output.outfile)
 
@@ -991,6 +1019,7 @@ rule get_drugcentral:
         xreffile=config["download_directory"] + "/DrugCentral/xrefs",
     benchmark:
         config["output_directory"] + "/benchmarks/get_drugcentral.tsv"
+    retries: 3  # DrugCentral download occasionally fails transiently.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -1006,6 +1035,7 @@ rule get_ncbitaxon:
         config["download_directory"] + "/NCBITaxon/taxdump.tar",
     benchmark:
         config["output_directory"] + "/benchmarks/get_ncbitaxon.tsv"
+    retries: 3  # NCBITaxon FTP download occasionally fails transiently.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -1035,6 +1065,7 @@ rule get_chebi:
         config["download_directory"] + "/CHEBI/database_accession.tsv",
     benchmark:
         config["output_directory"] + "/benchmarks/get_chebi.tsv"
+    retries: 3  # ChEBI FTP download occasionally fails transiently.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -1051,6 +1082,7 @@ rule get_clo:
         metadata=config["download_directory"] + "/CLO/metadata.yaml",
     benchmark:
         config["output_directory"] + "/benchmarks/get_clo.tsv"
+    retries: 3  # Cell Line Ontology download occasionally fails transiently.
     resources:
         mem="8G",
         cpus_per_task=1,

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -299,7 +299,7 @@ rule get_obo_labels:
         ),
     benchmark:
         config["output_directory"] + "/benchmarks/get_obo_labels.tsv"
-    retries: 10  # Ubergraph sometimes fails mid-download, and then we need to retry.
+    retries: 3  # Ubergraph sometimes fails mid-download and needs a retry.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -320,7 +320,7 @@ rule get_obo_synonyms:
         ),
     benchmark:
         config["output_directory"] + "/benchmarks/get_obo_synonyms.tsv"
-    retries: 10  # Ubergraph sometimes fails mid-download, and then we need to retry.
+    retries: 3  # Ubergraph sometimes fails mid-download and needs a retry.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -333,7 +333,7 @@ rule get_obo_descriptions:
         obo_descriptions=config["download_directory"] + "/common/ubergraph/descriptions.jsonl",
     benchmark:
         config["output_directory"] + "/benchmarks/get_obo_descriptions.tsv"
-    retries: 10  # Ubergraph sometimes fails mid-download, and then we need to retry.
+    retries: 3  # Ubergraph sometimes fails mid-download and needs a retry.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -354,7 +354,7 @@ rule get_icrdf:
         icrdf_filename=config["download_directory"] + "/icRDF.tsv",
     benchmark:
         config["output_directory"] + "/benchmarks/get_icrdf.tsv"
-    retries: 10  # Ubergraph sometimes fails mid-download, and then we need to retry.
+    retries: 3  # Ubergraph sometimes fails mid-download and needs a retry.
     run:
         obo.pull_uber_icRDF(output.icrdf_filename)
         # Try to load the icRDF.tsv file (this will produce an error if the file can't be read).
@@ -742,7 +742,7 @@ rule get_unichem:
         config["download_directory"] + "/UNICHEM/reference.tsv.gz",
     benchmark:
         config["output_directory"] + "/benchmarks/get_unichem.tsv"
-    retries: 5
+    retries: 3
     resources:
         mem="8G",
         cpus_per_task=1,

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -405,7 +405,9 @@ rule get_ncbigene_labels_synonyms_and_taxa:
 
 rule get_ensembl:
     output:
-        ensembl_dir=directory(config["download_directory"] + "/ENSEMBL"),
+        # Declare only the sentinel file, not the directory. Snakemake deletes all declared
+        # outputs on failure; keeping the directory out of outputs preserves already-downloaded
+        # per-dataset TSV files so the job can resume from where it left off on retry.
         complete_file=config["download_directory"] + "/ENSEMBL/BioMartDownloadComplete",
     benchmark:
         config["output_directory"] + "/benchmarks/get_ensembl.tsv"
@@ -415,7 +417,8 @@ rule get_ensembl:
         cpus_per_task=1,
         runtime="6h",
     run:
-        ensembl.pull_ensembl(output.ensembl_dir, output.complete_file)
+        ensembl_dir = config["download_directory"] + "/ENSEMBL"
+        ensembl.pull_ensembl(ensembl_dir, output.complete_file)
 
 
 ### HGNC

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -409,6 +409,7 @@ rule get_ensembl:
         complete_file=config["download_directory"] + "/ENSEMBL/BioMartDownloadComplete",
     benchmark:
         config["output_directory"] + "/benchmarks/get_ensembl.tsv"
+    retries: 3  # BioMart occasionally returns an HTML error page instead of TSV data.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -480,6 +481,7 @@ rule get_pantherfamily:
         outfile=config["download_directory"] + "/PANTHER.FAMILY/family.csv",
     benchmark:
         config["output_directory"] + "/benchmarks/get_pantherfamily.tsv"
+    retries: 3  # FTP connections to pantherdb.org are occasionally refused or dropped.
     resources:
         mem="8G",
         cpus_per_task=1,
@@ -765,11 +767,9 @@ rule get_chembl:
         ccofile=config["download_directory"] + "/CHEMBL.COMPOUND/cco.ttl",
     benchmark:
         config["output_directory"] + "/benchmarks/get_chembl.tsv"
+    retries: 3  # FTP to EBI is occasionally refused or dropped.
     resources:
-        # pull_via_ftp buffers the full compressed file then decompresses it in memory
-        # before writing; ~17 GB TTL needs ~20+ GB peak. Reduce once pull_via_ftp
-        # is fixed to stream-decompress (see GitHub issue).
-        mem="32G",
+        mem="8G",
         cpus_per_task=1,
     run:
         chembl.pull_chembl(output.moleculefile)
@@ -883,6 +883,7 @@ rule get_HMDB:
         outfile=config["download_directory"] + "/HMDB/hmdb_metabolites.xml",
     benchmark:
         config["output_directory"] + "/benchmarks/get_HMDB.tsv"
+    retries: 3  # HMDB occasionally returns HTTP errors; transient network failures need a retry.
     resources:
         mem="8G",
         cpus_per_task=1,

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -766,7 +766,10 @@ rule get_chembl:
     benchmark:
         config["output_directory"] + "/benchmarks/get_chembl.tsv"
     resources:
-        mem="8G",
+        # pull_via_ftp buffers the full compressed file then decompresses it in memory
+        # before writing; ~17 GB TTL needs ~20+ GB peak. Reduce once pull_via_ftp
+        # is fixed to stream-decompress (see GitHub issue).
+        mem="32G",
         cpus_per_task=1,
     run:
         chembl.pull_chembl(output.moleculefile)

--- a/src/snakefiles/protein.snakefile
+++ b/src/snakefiles/protein.snakefile
@@ -89,7 +89,7 @@ rule get_protein_pr_uniprotkb_relationships:
     benchmark:
         config["output_directory"] + "/benchmarks/get_protein_pr_uniprotkb_relationships.tsv"
     # Because we get this from UberGraph, we sometimes end up with incomplete/failed transfers and need to retry.
-    retries: 10
+    retries: 3
     run:
         protein.build_pr_uniprot_relationships(output.outfile, metadata_yaml=output.metadata_yaml)
 

--- a/src/snakefiles/publications.snakefile
+++ b/src/snakefiles/publications.snakefile
@@ -23,6 +23,9 @@ rule download_pubmed:
     resources:
         mem="8G",
         cpus_per_task=1,
+        # Two hours got ~50% through ~1500 files; parallelizing baseline+updatefiles should halve
+        # that, so 6h is conservative. Tighten once benchmark TSVs give real-world data.
+        runtime="6h",
     run:
         publications.download_pubmed(output.done_file)
 

--- a/src/triplestore.py
+++ b/src/triplestore.py
@@ -4,6 +4,7 @@ from string import Template
 
 from SPARQLWrapper import JSON, POST, POSTDIRECTLY, SPARQLWrapper2
 
+from src.babel_utils import get_user_agent
 from src.util import LoggingUtil
 
 logger = LoggingUtil.init_logging(__name__, logging.ERROR)
@@ -14,6 +15,7 @@ class TripleStore:
 
     def __init__(self, hostname):
         self.service = SPARQLWrapper2(hostname)
+        self.service.addCustomHttpHeader("User-Agent", get_user_agent())
 
     def get_template(self, query_name):
         """Load a template given a template name"""

--- a/tests/datahandlers/test_ensembl.py
+++ b/tests/datahandlers/test_ensembl.py
@@ -5,6 +5,8 @@ import logging
 import os
 
 import pytest
+import requests
+from apybiomart import find_datasets
 
 from src.datahandlers.ensembl import pull_ensembl
 
@@ -103,3 +105,53 @@ def test_pull_ensembl(tmp_path):
         unsplit_rows_normalized = normalize_list_of_dictionaries(unsplit_rows)
         split_rows_normalized = normalize_list_of_dictionaries(split_rows)
         assert unsplit_rows_normalized == split_rows_normalized
+
+
+@pytest.mark.network
+@pytest.mark.timeout(120)
+def test_biomart_find_datasets_response_format():
+    """
+    Diagnose the 'Too many columns specified: expected 9 and found 1' error from
+    apybiomart.find_datasets().  That call parses the BioMart ?type=datasets response
+    as a 9-column TSV; if the API is returning an error page (HTML/JSON) instead of
+    tab-separated text the parse will fail.
+
+    This test hits the live BioMart HTTPS endpoint, prints the raw response so we can
+    see what the server actually returns, and then checks that the response looks like
+    the tab-separated text that apybiomart expects.
+
+    apybiomart uses http:// internally; Ensembl now redirects / blocks HTTP, so we
+    probe https:// here to see the actual current server response.
+    """
+    url = "https://www.ensembl.org/biomart/martservice"
+    try:
+        resp = requests.get(url, params={"type": "datasets", "mart": "ENSEMBL_MART_ENSEMBL"}, timeout=90)
+    except requests.exceptions.Timeout:
+        pytest.skip("BioMart endpoint timed out — service may be down or unreachable from this host")
+
+    raw = resp.text
+    first_500 = raw[:500]
+    print(f"\n--- BioMart find_datasets raw response (first 500 chars) ---\n{first_500}\n---")
+    print(f"HTTP status: {resp.status_code}")
+    print(f"Content-Type: {resp.headers.get('Content-Type', '(none)')}")
+
+    # Count tab-separated columns in the first non-empty line.
+    first_line = next((ln for ln in raw.splitlines() if ln.strip()), "")
+    tab_count = first_line.count("\t")
+    print(f"First non-empty line tab count: {tab_count}")
+    print(f"First line: {first_line[:200]!r}")
+
+    # apybiomart expects 9 tab-separated columns per row.
+    assert tab_count == 8, (
+        f"BioMart ?type=datasets response has changed: expected 8 tabs (9 columns) per row "
+        f"but found {tab_count} tabs in the first line.\n"
+        f"Content-Type: {resp.headers.get('Content-Type', '(none)')!r}\n"
+        f"First line: {first_line[:200]!r}\n"
+        f"Full response prefix: {first_500!r}"
+    )
+
+    # Also confirm apybiomart.find_datasets() itself can parse without raising.
+    df = find_datasets()
+    print(f"\nfind_datasets() returned {len(df)} rows with columns: {list(df.columns)}")
+    assert "Dataset_ID" in df.columns, f"Expected 'Dataset_ID' column, got: {list(df.columns)}"
+    assert len(df) > 0, "find_datasets() returned an empty dataframe"

--- a/tests/datahandlers/test_hmdb.py
+++ b/tests/datahandlers/test_hmdb.py
@@ -1,0 +1,52 @@
+"""Network tests for the HMDB download.
+
+These verify that HMDB's download URL is reachable with the User-Agent Babel sends.
+Run with: uv run pytest --network tests/datahandlers/test_hmdb.py
+"""
+
+import urllib.error
+import urllib.request
+
+import pytest
+
+from src.babel_utils import get_user_agent
+
+pytestmark = [pytest.mark.network]
+
+HMDB_ZIP_URL = "https://hmdb.ca/system/downloads/current/hmdb_metabolites.zip"
+
+
+def test_hmdb_url_accessible_with_user_agent():
+    """HMDB download URL should be reachable with our User-Agent (not 403)."""
+    req = urllib.request.Request(HMDB_ZIP_URL, headers={"User-Agent": get_user_agent()})
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            # Read just the first 1 KB to confirm the body streams without error.
+            chunk = resp.read(1024)
+        assert len(chunk) > 0, "HMDB returned an empty body"
+    except urllib.error.HTTPError as e:
+        pytest.fail(
+            f"HMDB download URL returned HTTP {e.code} with User-Agent '{get_user_agent()}'. "
+            "The server may be blocking non-browser clients or the HPC egress IP."
+        )
+
+
+def test_hmdb_url_rejects_no_user_agent():
+    """HMDB returns 403 when no User-Agent is set (raw urllib default).
+
+    This documents the known behaviour that motivates always setting our User-Agent.
+    If HMDB changes policy and starts accepting bare requests, this test will fail
+    and should be removed.
+    """
+    # urllib's default User-Agent is "Python-urllib/<version>", which HMDB rejects.
+    req = urllib.request.Request(HMDB_ZIP_URL)
+    try:
+        with urllib.request.urlopen(req, timeout=30):
+            pass
+        # If we get here the server accepted the bare request — document the change.
+        pytest.xfail("HMDB no longer rejects bare Python-urllib requests; remove this test.")
+    except urllib.error.HTTPError as e:
+        if e.code == 403:
+            pass  # expected — server rejects bare requests
+        else:
+            pytest.fail(f"Unexpected HTTP {e.code} from HMDB (expected 403 for bare UA)")

--- a/tests/datahandlers/test_pantherfamily.py
+++ b/tests/datahandlers/test_pantherfamily.py
@@ -14,11 +14,9 @@ import pytest
 
 import src.datahandlers.pantherfamily as pantherfamily
 from src.babel_utils import get_user_agent
-from src.datahandlers.pantherfamily import FTP_FILE, FTP_HOST, HTTP_BASE
+from src.datahandlers.pantherfamily import FTP_DIR, FTP_FILE, FTP_HOST, HTTP_BASE
 
 pytestmark = [pytest.mark.network]
-
-FTP_DIR = "/sequence_classifications/current_release/PANTHER_Sequence_Classification_files/"
 
 
 def test_panther_ftp_accessible():

--- a/tests/datahandlers/test_pantherfamily.py
+++ b/tests/datahandlers/test_pantherfamily.py
@@ -12,16 +12,13 @@ import urllib.request
 
 import pytest
 
+import src.datahandlers.pantherfamily as pantherfamily
 from src.babel_utils import get_user_agent
+from src.datahandlers.pantherfamily import FTP_FILE, FTP_HOST, HTTP_BASE
 
 pytestmark = [pytest.mark.network]
 
-FTP_HOST = "ftp.pantherdb.org"
 FTP_DIR = "/sequence_classifications/current_release/PANTHER_Sequence_Classification_files/"
-FTP_FILE = "PTHR19.0_human"
-
-HTTP_BASE = "http://data.pantherdb.org/ftp/sequence_classifications/current_release/PANTHER_Sequence_Classification_files/"
-HTTP_FILE = "PTHR19.0_human"
 
 
 def test_panther_ftp_accessible():
@@ -51,17 +48,39 @@ def test_panther_http_accessible_with_user_agent():
 
     This is the fallback when FTP is blocked (e.g. on HPC). If this test passes
     and test_panther_ftp_accessible xfails, the pull_pantherfamily() function
-    should be updated to use pull_via_urllib/pull_via_wget instead of pull_via_ftp.
+    falls back to HTTP automatically.
     """
-    url = HTTP_BASE + HTTP_FILE
+    url = HTTP_BASE + FTP_FILE
     req = urllib.request.Request(url, headers={"User-Agent": get_user_agent()})
     try:
         with urllib.request.urlopen(req, timeout=60) as resp:
             chunk = resp.read(1024)
         assert len(chunk) > 0, "PANTHER HTTP endpoint returned an empty body"
     except urllib.error.HTTPError as e:
-        pytest.fail(
-            f"PANTHER HTTP URL {url} returned HTTP {e.code} with User-Agent '{get_user_agent()}'"
-        )
+        pytest.fail(f"PANTHER HTTP URL {url} returned HTTP {e.code} with User-Agent '{get_user_agent()}'")
     except (TimeoutError, urllib.error.URLError) as e:
         pytest.xfail(f"PANTHER HTTP endpoint unreachable: {e}")
+
+
+def test_pull_pantherfamily_falls_back_to_http_when_ftp_blocked(tmp_path, monkeypatch):
+    """pull_pantherfamily() must fall back to HTTP when FTP is blocked (HPC firewall scenario).
+
+    Simulates the HPC environment where port 21 is refused, confirms the HTTP mirror
+    is tried and produces a non-empty output file at the expected path.
+    """
+
+    def ftp_refused(*args, **kwargs):
+        raise OSError("Connection refused (simulating HPC FTP firewall)")
+
+    monkeypatch.setattr("src.datahandlers.pantherfamily.pull_via_ftp", ftp_refused)
+    monkeypatch.setattr("src.datahandlers.pantherfamily.get_config", lambda: {"download_directory": str(tmp_path)})
+    monkeypatch.setattr("src.datahandlers.pantherfamily.get_user_agent", lambda: "Babel/test")
+
+    try:
+        pantherfamily.pull_pantherfamily()
+    except (TimeoutError, urllib.error.URLError) as e:
+        pytest.xfail(f"HTTP fallback also unreachable (no network?): {e}")
+
+    outfile = tmp_path / "PANTHER.FAMILY" / "family.csv"
+    assert outfile.exists(), f"Expected output file {outfile} was not created"
+    assert outfile.stat().st_size > 0, f"Output file {outfile} is empty"

--- a/tests/datahandlers/test_pantherfamily.py
+++ b/tests/datahandlers/test_pantherfamily.py
@@ -1,0 +1,67 @@
+"""Network tests for the PANTHER family download.
+
+The pipeline uses FTP (ftp.pantherdb.org), but FTP is often blocked by HPC firewalls.
+PANTHER also exposes the same files over HTTP; these tests check both endpoints.
+
+Run with: uv run pytest --network tests/datahandlers/test_pantherfamily.py
+"""
+
+import ftplib
+import urllib.error
+import urllib.request
+
+import pytest
+
+from src.babel_utils import get_user_agent
+
+pytestmark = [pytest.mark.network]
+
+FTP_HOST = "ftp.pantherdb.org"
+FTP_DIR = "/sequence_classifications/current_release/PANTHER_Sequence_Classification_files/"
+FTP_FILE = "PTHR19.0_human"
+
+HTTP_BASE = "http://data.pantherdb.org/ftp/sequence_classifications/current_release/PANTHER_Sequence_Classification_files/"
+HTTP_FILE = "PTHR19.0_human"
+
+
+def test_panther_ftp_accessible():
+    """PANTHER FTP endpoint should be reachable and list the expected file.
+
+    This test is expected to fail on HPC nodes where outbound FTP (port 21) is
+    firewalled — in that case the pipeline should use the HTTP endpoint instead.
+    """
+    try:
+        ftp = ftplib.FTP(FTP_HOST, timeout=30)
+        ftp.login()
+        ftp.cwd(FTP_DIR)
+        names = ftp.nlst()
+        ftp.quit()
+    except (TimeoutError, OSError) as e:
+        pytest.xfail(f"FTP connection to {FTP_HOST} timed out or was refused — likely firewalled: {e}")
+    except ftplib.all_errors as e:
+        pytest.xfail(f"FTP error connecting to {FTP_HOST}: {e}")
+
+    assert any(FTP_FILE in n for n in names), (
+        f"Expected to find '{FTP_FILE}' in FTP listing of {FTP_HOST}{FTP_DIR}; got: {names[:10]}"
+    )
+
+
+def test_panther_http_accessible_with_user_agent():
+    """PANTHER HTTP endpoint should be reachable with our User-Agent.
+
+    This is the fallback when FTP is blocked (e.g. on HPC). If this test passes
+    and test_panther_ftp_accessible xfails, the pull_pantherfamily() function
+    should be updated to use pull_via_urllib/pull_via_wget instead of pull_via_ftp.
+    """
+    url = HTTP_BASE + HTTP_FILE
+    req = urllib.request.Request(url, headers={"User-Agent": get_user_agent()})
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            chunk = resp.read(1024)
+        assert len(chunk) > 0, "PANTHER HTTP endpoint returned an empty body"
+    except urllib.error.HTTPError as e:
+        pytest.fail(
+            f"PANTHER HTTP URL {url} returned HTTP {e.code} with User-Agent '{get_user_agent()}'"
+        )
+    except (TimeoutError, urllib.error.URLError) as e:
+        pytest.xfail(f"PANTHER HTTP endpoint unreachable: {e}")

--- a/tests/datahandlers/test_unichem.py
+++ b/tests/datahandlers/test_unichem.py
@@ -1,0 +1,52 @@
+"""Network tests for the UniChem download.
+
+These verify that the UniChem FTP mirror URLs are reachable with the User-Agent
+Babel sends and that each file is a valid gzip archive.
+Run with: uv run pytest --network tests/datahandlers/test_unichem.py
+"""
+
+import urllib.error
+import urllib.request
+
+import pytest
+
+from src.babel_utils import get_user_agent
+
+pytestmark = [pytest.mark.network]
+
+UNICHEM_BASE = "http://ftp.ebi.ac.uk/pub/databases/chembl/UniChem/data/table_dumps/"
+UNICHEM_FILES = ["structure.tsv.gz", "reference.tsv.gz"]
+
+
+@pytest.mark.parametrize("filename", UNICHEM_FILES)
+def test_unichem_url_accessible_with_user_agent(filename):
+    """UniChem file should be reachable and return a valid gzip stream."""
+    url = UNICHEM_BASE + filename
+    req = urllib.request.Request(url, headers={"User-Agent": get_user_agent()})
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            # Read the first 64 KB and confirm it decompresses without error.
+            raw = resp.read(65536)
+    except urllib.error.HTTPError as e:
+        pytest.fail(
+            f"UniChem {filename} returned HTTP {e.code} with User-Agent '{get_user_agent()}'. "
+            "The server may be unreachable or blocking this client."
+        )
+
+    assert len(raw) > 0, f"UniChem {filename} returned an empty body"
+
+    # Confirm the bytes are a valid gzip stream (magic bytes 0x1f 0x8b).
+    assert raw[:2] == b"\x1f\x8b", (
+        f"UniChem {filename} does not appear to be a gzip file (got {raw[:2]!r})"
+    )
+
+    # Try to decompress the partial chunk to catch obviously truncated/corrupt files.
+    try:
+        # wbits=47 tells zlib to accept gzip format; partial streams raise EOFError,
+        # which we allow — we only care that the header and first block are valid.
+        import zlib
+
+        d = zlib.decompressobj(wbits=47)
+        d.decompress(raw)
+    except zlib.error as exc:
+        pytest.fail(f"UniChem {filename} first 64 KB failed gzip decompression: {exc}")

--- a/tests/datahandlers/test_unichem.py
+++ b/tests/datahandlers/test_unichem.py
@@ -1,6 +1,6 @@
 """Network tests for the UniChem download.
 
-These verify that the UniChem FTP mirror URLs are reachable with the User-Agent
+These verify that the UniChem HTTP mirror URLs are reachable with the User-Agent
 Babel sends and that each file is a valid gzip archive.
 Run with: uv run pytest --network tests/datahandlers/test_unichem.py
 """

--- a/tests/datahandlers/test_unichem.py
+++ b/tests/datahandlers/test_unichem.py
@@ -37,9 +37,7 @@ def test_unichem_url_accessible_with_user_agent(filename):
     assert len(raw) > 0, f"UniChem {filename} returned an empty body"
 
     # Confirm the bytes are a valid gzip stream (magic bytes 0x1f 0x8b).
-    assert raw[:2] == b"\x1f\x8b", (
-        f"UniChem {filename} does not appear to be a gzip file (got {raw[:2]!r})"
-    )
+    assert raw[:2] == b"\x1f\x8b", f"UniChem {filename} does not appear to be a gzip file (got {raw[:2]!r})"
 
     # Try to decompress the partial chunk to catch obviously truncated/corrupt files.
     try:

--- a/tests/datahandlers/test_unichem.py
+++ b/tests/datahandlers/test_unichem.py
@@ -7,6 +7,7 @@ Run with: uv run pytest --network tests/datahandlers/test_unichem.py
 
 import urllib.error
 import urllib.request
+import zlib
 
 import pytest
 
@@ -44,8 +45,6 @@ def test_unichem_url_accessible_with_user_agent(filename):
     try:
         # wbits=47 tells zlib to accept gzip format; partial streams raise EOFError,
         # which we allow — we only care that the header and first block are valid.
-        import zlib
-
         d = zlib.decompressobj(wbits=47)
         d.decompress(raw)
     except zlib.error as exc:


### PR DESCRIPTION
All the download-resilience work that came out of the 1.17 run hitting flaky/blocked endpoints on the HPC cluster. Grouped because they all touch the shared download helpers (`pull_via_ftp`, `pull_via_urllib`) and per-source retry behaviour.

## What's here
- Retries moved out of internal Python loops and into Snakemake; retry count reduced 10/5 → 3.
- `pull_via_ftp` stream-decompresses to avoid the 2× RAM spike on large files (e.g. ChEMBL's 17 GB TTL); temp file is cleaned up on failure.
- `pull_via_urllib` reopens the HTTP handle on each retry.
- `get_pantherfamily` falls back to HTTP when FTP is blocked.
- Ensembl/BioMart per-dataset retry that preserves partial progress on failure.
- PubMed download parallelized with runtime + wget timeouts.
- Babel User-Agent sent on all SPARQL requests to Ubergraph.
- Network tests (HMDB, PANTHER, and a BioMart-returns-HTML-instead-of-TSV detector).

Docs (`docs/sources/ENSEMBL/Download.md`) travel with the code.

## Test plan
- `uv run ruff check && uv run ruff format --check`
- `uv run snakefmt --check --compact-diff .`
- `uv run rumdl check .`
- `uv run pytest -m unit`  (network tests opt-in via `--network`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)