### PR TITLE
leftover_umls: type handling, coverage reports, and no-MRSTY tracking

### DIFF
--- a/docs/sources/UMLS/Leftover.md
+++ b/docs/sources/UMLS/Leftover.md
@@ -26,8 +26,9 @@ Biolink says (or `None` if Biolink has no mapping). For each concept:
    fully type) and reported as `NO_UMLS_TYPE`.
 3. Rejected semantic types simply drop out. If nothing is left, the concept is skipped and reported
    as `REJECTED`.
-4. If the surviving Biolink types disagree, `TYPE_COMBO_OVERRIDES` is consulted to pick one;
-   otherwise the concept is skipped and reported as `MULTIPLE_UMLS_TYPES`.
+4. If the surviving Biolink types disagree, generic types in `GENERIC_TYPES` are dropped first (so a
+   specific co-type wins), then `TYPE_COMBO_OVERRIDES` is consulted to pick one; if more than one
+   type still remains the concept is skipped and reported as `MULTIPLE_UMLS_TYPES`.
 
 ## The override tables
 
@@ -51,8 +52,36 @@ to anticipate how a Biolink change will land in real Babel data. The two tables 
   - `T122` "Biomedical or Dental Material" → `biolink:ChemicalEntity` (#421; no STY mapping in
     Biolink).
   - `T168` "Food" → `biolink:Food` (#421; no STY mapping in Biolink).
+  - `T072` "Physical Object" and `T073` "Manufactured Object" → `biolink:PhysicalEntity` (#840). bmt
+    already maps these to `biolink:PhysicalEntity`, so the override is an intentional pin (see
+    `GENERIC_TYPES` below) rather than a correction.
 - **`TYPE_COMBO_OVERRIDES: dict[frozenset[str], str]`** — when a concept resolves to more than one
   Biolink type, pick a single one (e.g. `{Device, Drug} → Drug`).
+- **`GENERIC_TYPES: frozenset[str]`** — very high-level types (currently `biolink:PhysicalEntity`)
+  that must never shadow a more specific co-type. When a concept resolves to more than one Biolink
+  type and one is generic, the generic type is dropped so the specific one wins. A concept typed
+  *only* as a generic type still keeps it. This is the successor to rejecting `T072`/`T073` with
+  `None`: rejection kept the specific type only by contributing no type at all, which also dropped
+  concepts whose *only* type was `T072`/`T073`.
+
+### Prefix-less Biolink types are still writable here
+
+Some of these target types (`biolink:Phenomenon`, `biolink:ClinicalFinding`,
+`biolink:PhysicalEntity`) carry no `id_prefixes` in the Biolink Model. They are nonetheless writable
+in *this* compendium because every leftover clique is a single `UMLS:` identifier and the rule
+passes `extra_prefixes=[UMLS]` to `write_compendium()`. `NodeFactory.create_node()` raises "No
+Biolink prefixes for ..." only when a type has no `id_prefixes` **and** no `extra_prefixes` are
+supplied. (Previously `create_node()` raised on the bare `get_prefixes()` call before it considered
+`extra_prefixes`, which crashed the rule after ~5h on the HPC.)
+
+### Preflight: failing fast
+
+`write_leftover_umls()` runs a preflight before loading any compendia, MRSTY or MRCONSO: it calls
+`create_node(input_identifiers=[], node_type=T, extra_prefixes=[UMLS])` for every type in
+`writable_output_types()` (all non-`None` `STY_OVERRIDES` values, all `TYPE_COMBO_OVERRIDES` values,
+and `biolink:NamedThing`). If any type is unwritable the rule aborts in seconds with a clear message
+instead of after the multi-hour MRCONSO scan. The companion test
+`test_all_override_target_types_are_writable` guards the same set in CI.
 
 Every `STY_OVERRIDES` entry must cite the GitHub issue that motivates it.
 

--- a/docs/sources/UMLS/Leftover.md
+++ b/docs/sources/UMLS/Leftover.md
@@ -6,9 +6,7 @@ built, `src/createcompendia/leftover_umls.py` (Snakemake rule `leftover_umls`) g
 writing each one as a single-identifier clique into `babel_outputs/compendia/umls.txt`. The point is
 coverage: even when Babel can't merge a UMLS concept into a richer clique, downstream services (Node
 Normalization, Name Resolver) can still return its label and a Biolink type. This addresses
-[#579](https://github.com/NCATSTranslator/Babel/issues/579), and the typing corrections below
-address [#569](https://github.com/NCATSTranslator/Babel/issues/569) and the umbrella
-[#410](https://github.com/NCATSTranslator/Babel/issues/410).
+[#579], and the typing corrections below address [#569] and the umbrella [#410].
 
 ## How a leftover concept gets its Biolink type
 
@@ -38,22 +36,22 @@ to anticipate how a Biolink change will land in real Babel data. The two tables 
 
 - **`STY_OVERRIDES: dict[str, str | None]`** — override the Biolink type bmt assigns to a single
   semantic type. `None` means "deliberately reject". Current entries:
-  - `T033` "Finding" → `biolink:Phenomenon` (#569; Biolink has no STY mapping for it, so without
+  - `T033` "Finding" → `biolink:Phenomenon` ([#569]; Biolink has no STY mapping for it, so without
     this the concepts would be dropped as unmapped).
-  - `T034` "Laboratory or Test Result" → `biolink:ClinicalFinding` (#569; Biolink maps it to the
+  - `T034` "Laboratory or Test Result" → `biolink:ClinicalFinding` ([#569]; Biolink maps it to the
     broader `biolink:Phenomenon`).
-  - `T058` "Health Care Activity" → `biolink:ClinicalIntervention` (#90; bmt assigns the generic
+  - `T058` "Health Care Activity" → `biolink:ClinicalIntervention` ([#90]; bmt assigns the generic
     `biolink:Activity`).
-  - `T045` "Genetic Function" → `biolink:BiologicalProcess` (#421; no STY mapping in Biolink).
-  - `T021` "Fully Formed Anatomical Structure" → `biolink:GrossAnatomicalStructure` (#421; no STY
+  - `T045` "Genetic Function" → `biolink:BiologicalProcess` ([#421]; no STY mapping in Biolink).
+  - `T021` "Fully Formed Anatomical Structure" → `biolink:GrossAnatomicalStructure` ([#421]; no STY
     mapping in Biolink).
-  - `T120` "Chemical Viewed Functionally" → `biolink:ChemicalEntity` (#421; no STY mapping in
+  - `T120` "Chemical Viewed Functionally" → `biolink:ChemicalEntity` ([#421]; no STY mapping in
     Biolink).
-  - `T122` "Biomedical or Dental Material" → `biolink:ChemicalEntity` (#421; no STY mapping in
+  - `T122` "Biomedical or Dental Material" → `biolink:ChemicalEntity` ([#421]; no STY mapping in
     Biolink).
-  - `T168` "Food" → `biolink:Food` (#421; no STY mapping in Biolink).
-  - `T072` "Physical Object" and `T073` "Manufactured Object" → `biolink:PhysicalEntity` (#840). bmt
-    already maps these to `biolink:PhysicalEntity`, so the override is an intentional pin (see
+  - `T168` "Food" → `biolink:Food` ([#421]; no STY mapping in Biolink).
+  - `T072` "Physical Object" and `T073` "Manufactured Object" → `biolink:PhysicalEntity` ([#840]).
+    bmt already maps these to `biolink:PhysicalEntity`, so the override is an intentional pin (see
     `GENERIC_TYPES` below) rather than a correction.
 - **`TYPE_COMBO_OVERRIDES: dict[frozenset[str], str]`** — when a concept resolves to more than one
   Biolink type, pick a single one (e.g. `{Device, Drug} → Drug`).
@@ -131,14 +129,14 @@ The rule writes all UMLS reports to `babel_outputs/reports/umls/`. The human-rea
   data; keep whichever ordering suits the question at hand.
 - `duplicate-curies.csv` — UMLS CURIEs that landed in **more than one compendium clique**: either
   across two different compendium files (**cross-file**) or in two distinct cliques of one file with
-  different clique leaders (**within-file**). Both are clique-merge bugs
-  ([#276](https://github.com/NCATSTranslator/Babel/issues/276)). One row per duplicated CURIE:
-  `umls_curie`, `umls_label`, `tui_set`, `tui_set_labels`, `num_compendia`, `num_distinct_cliques`,
-  `duplicate_scope` (`cross-file`/`within-file`/`both`), and an `occurrences` column rendering each
-  landing as `compendium[biolink_type, leader=CURIE, name=...]`. The clique leaders are the key to
-  tracing the cause: they show which two cliques the CURIE was glommed into, so you can work back to
-  the upstream concords that pulled it both ways. The leftover `umls.txt` compendium never appears
-  here because it only claims CURIEs that no other compendium took.
+  different clique leaders (**within-file**). Both are clique-merge bugs ([#276]). One row per
+  duplicated CURIE: `umls_curie`, `umls_label`, `tui_set`, `tui_set_labels`, `num_compendia`,
+  `num_distinct_cliques`, `duplicate_scope` (`cross-file`/`within-file`/`both`), and an
+  `occurrences` column rendering each landing as `compendium[biolink_type, leader=CURIE, name=...]`.
+  The clique leaders are the key to tracing the cause: they show which two cliques the CURIE was
+  glommed into, so you can work back to the upstream concords that pulled it both ways. The leftover
+  `umls.txt` compendium never appears here because it only claims CURIEs that no other compendium
+  took.
 - `unmapped-types.csv` — per semantic type that was unmapped or rejected: status, exact affected
   CUI count, and sample CURIEs.
 - `multi-type-curies.csv` — CURIEs that resolved to multiple Biolink types even after
@@ -171,3 +169,11 @@ So the split is deliberate: **`log.txt` is the complete per-CURIE record, the CS
 counts plus a handful of illustrative examples.** If the samples ever feel like noise, the right
 change is to drop the `sample_curies` columns entirely (the log already has every CURIE), not to
 expand them into full per-bucket CURIE lists held in memory.
+
+[#90]: https://github.com/NCATSTranslator/Babel/issues/90
+[#276]: https://github.com/NCATSTranslator/Babel/issues/276
+[#410]: https://github.com/NCATSTranslator/Babel/issues/410
+[#421]: https://github.com/NCATSTranslator/Babel/issues/421
+[#569]: https://github.com/NCATSTranslator/Babel/issues/569
+[#579]: https://github.com/NCATSTranslator/Babel/issues/579
+[#840]: https://github.com/NCATSTranslator/Babel/issues/840

--- a/docs/sources/UMLS/Leftover.md
+++ b/docs/sources/UMLS/Leftover.md
@@ -106,25 +106,48 @@ important time to run it is when bumping `biolink_version`.
 The rule writes all UMLS reports to `babel_outputs/reports/umls/`. The human-readable log is
 `log.txt`; the machine-readable CSVs are:
 
-- `compendium-coverage.csv` — where UMLS lands inside Babel, broken down by semantic type. One row
-  per (compendium, most-specific UMLS semantic-type set): `compendium`, `tui_set`, `tree_set`,
-  `curie_count`, `single_umls_clique_count` (cliques whose only identifier is a single UMLS CURIE),
-  and sample `CURIE=label`s. The semantic types are emitted as **codes, not labels** — `tui_set` is
-  the pipe-joined TUIs and `tree_set` the matching `MRSTY` tree numbers — so the type grouping is
-  scannable at a glance (use `tui-sty.tsv` to decode a code). Each concept's TUIs are reduced to the
-  *most specific* ones first (a TUI that is a tree-number ancestor of another TUI on the same
-  concept is dropped), via `babel_utils.reduce_to_most_specific_tree_codes()`. Summing `curie_count`
-  over a compendium reproduces its total unique UMLS count. The file spans every compendium that
-  consumes UMLS **plus** the leftover `umls.txt` compendium itself (whose rows tend to be the most
-  type-diverse); filter on the `compendium` column to focus on one. An empty semantic-type set (a
-  UMLS CURIE absent from `MRSTY`) is written as `(none)`.
-- `types-coverage.csv` — per Biolink type of the leftover cliques: exact count and a few
-  sample `CURIE=label`s.
+- `compendium-coverage.csv` — where UMLS lands inside Babel, broken down by Biolink type and
+  semantic type. One row per (compendium, Biolink type, most-specific UMLS semantic-type set):
+  `compendium`, `biolink_type`, `tui_set`, `tui_set_labels`, `tree_set`, `curie_count`,
+  `single_umls_clique_count` (cliques whose only identifier is a single UMLS CURIE), and sample
+  `CURIE=label`s. The `biolink_type` is read directly from each clique's `type` field as the file is
+  parsed (falling back to the compendium filename, e.g. `MolecularMixture.txt` →
+  `biolink:MolecularMixture`, for any clique lacking one), so when one semantic type is split across
+  two Biolink types it gets one row per type. The semantic types are emitted as **codes** in
+  `tui_set`/`tree_set` (pipe-joined TUIs and matching `MRSTY` tree numbers) with their names in
+  `tui_set_labels`, so the type grouping is scannable at a glance (use `tui-sty.tsv` to decode a
+  code). Each concept's TUIs are reduced to the *most specific* ones first (a TUI that is a
+  tree-number ancestor of another TUI on the same concept is dropped), via
+  `babel_utils.reduce_to_most_specific_tree_codes()`. Summing `curie_count` over a compendium
+  reproduces its total unique UMLS count. The file spans every compendium that consumes UMLS
+  **plus** the leftover `umls.txt` compendium itself (whose rows tend to be the most type-diverse);
+  filter on the `compendium` column to focus on one. An empty semantic-type set (a UMLS CURIE absent
+  from `MRSTY`) is written as `(none)`.
+- `tui-coverage.csv` — the **same rows** as `compendium-coverage.csv` (same columns, reordered to
+  `tui_set`, `tui_set_labels`, `tree_set`, `compendium`, `biolink_type`, `curie_count`,
+  `single_umls_clique_count`, `sample_curies`) but sorted **TUI-set first**, so the file answers
+  "where does semantic type `T047` go across all of Babel, and which Biolink types does it get?"
+  rather than "what's in compendium X". It is the transpose of `compendium-coverage.csv`, not new
+  data; keep whichever ordering suits the question at hand.
+- `duplicate-curies.csv` — UMLS CURIEs that landed in **more than one compendium clique**: either
+  across two different compendium files (**cross-file**) or in two distinct cliques of one file with
+  different clique leaders (**within-file**). Both are clique-merge bugs
+  ([#276](https://github.com/NCATSTranslator/Babel/issues/276)). One row per duplicated CURIE:
+  `umls_curie`, `umls_label`, `tui_set`, `tui_set_labels`, `num_compendia`, `num_distinct_cliques`,
+  `duplicate_scope` (`cross-file`/`within-file`/`both`), and an `occurrences` column rendering each
+  landing as `compendium[biolink_type, leader=CURIE, name=...]`. The clique leaders are the key to
+  tracing the cause: they show which two cliques the CURIE was glommed into, so you can work back to
+  the upstream concords that pulled it both ways. The leftover `umls.txt` compendium never appears
+  here because it only claims CURIEs that no other compendium took.
 - `unmapped-types.csv` — per semantic type that was unmapped or rejected: status, exact affected
   CUI count, and sample CURIEs.
 - `multi-type-curies.csv` — CURIEs that resolved to multiple Biolink types even after
   `TYPE_COMBO_OVERRIDES`: the type combo, exact count, and sample CURIEs.
 - `tui-sty.tsv` — the raw STY-code → semantic-type-name dump from `MRSTY.RRF`.
+
+The old `types-coverage.csv` (per Biolink type of the leftover cliques only) has been removed: it is
+derivable from `compendium-coverage.csv` by filtering to `compendium == umls.txt` and summing
+`curie_count` per `biolink_type`.
 
 ### Counts vs. samples: why the CSVs carry both
 

--- a/docs/sources/UMLS/Leftover.md
+++ b/docs/sources/UMLS/Leftover.md
@@ -106,8 +106,18 @@ important time to run it is when bumping `biolink_version`.
 The rule writes all UMLS reports to `babel_outputs/reports/umls/`. The human-readable log is
 `log.txt`; the machine-readable CSVs are:
 
-- `compendium-coverage.csv` — per input compendium: `total_umls_curies` and
-  `single_umls_clique_count` (cliques whose only identifier is a single UMLS CURIE).
+- `compendium-coverage.csv` — where UMLS lands inside Babel, broken down by semantic type. One row
+  per (compendium, most-specific UMLS semantic-type set): `compendium`, `tui_set`, `tree_set`,
+  `curie_count`, `single_umls_clique_count` (cliques whose only identifier is a single UMLS CURIE),
+  and sample `CURIE=label`s. The semantic types are emitted as **codes, not labels** — `tui_set` is
+  the pipe-joined TUIs and `tree_set` the matching `MRSTY` tree numbers — so the type grouping is
+  scannable at a glance (use `tui-sty.tsv` to decode a code). Each concept's TUIs are reduced to the
+  *most specific* ones first (a TUI that is a tree-number ancestor of another TUI on the same
+  concept is dropped), via `babel_utils.reduce_to_most_specific_tree_codes()`. Summing `curie_count`
+  over a compendium reproduces its total unique UMLS count. The file spans every compendium that
+  consumes UMLS **plus** the leftover `umls.txt` compendium itself (whose rows tend to be the most
+  type-diverse); filter on the `compendium` column to focus on one. An empty semantic-type set (a
+  UMLS CURIE absent from `MRSTY`) is written as `(none)`.
 - `types-coverage.csv` — per Biolink type of the leftover cliques: exact count and a few
   sample `CURIE=label`s.
 - `unmapped-types.csv` — per semantic type that was unmapped or rejected: status, exact affected

--- a/docs/sources/UMLS/Leftover.md
+++ b/docs/sources/UMLS/Leftover.md
@@ -141,6 +141,11 @@ The rule writes all UMLS reports to `babel_outputs/reports/umls/`. The human-rea
   CUI count, and sample CURIEs.
 - `multi-type-curies.csv` — CURIEs that resolved to multiple Biolink types even after
   `TYPE_COMBO_OVERRIDES`: the type combo, exact count, and sample CURIEs.
+- `no-mrsty-curies.csv` — CURIEs that had **no entry in `MRSTY.RRF`** and were therefore typed as
+  `biolink:NamedThing` as a fallback. Columns: `umls_curie`, `label`, `biolink_type` (always
+  `biolink:NamedThing`), `source_count`, and `sources` (pipe-joined MRCONSO SAB abbreviations for
+  that CUI). The SAB list shows which vocabularies reference the CURIE even though UMLS carries no
+  semantic-type annotation for it — useful for tracing CUIs from older or superseded releases.
 - `tui-sty.tsv` — the raw STY-code → semantic-type-name dump from `MRSTY.RRF`.
 
 The old `types-coverage.csv` (per Biolink type of the leftover cliques only) has been removed: it is

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -81,6 +81,45 @@ def parse_rdf_literal(literal: str) -> str:
     return literal[1:-1]
 
 
+def reduce_to_most_specific_tree_codes(codes, code_to_tree):
+    """Reduce a set of hierarchy codes to only the most specific ones.
+
+    Given an iterable of ``codes`` and a ``code_to_tree`` map from each code to its
+    dot-delimited tree number (e.g. a UMLS TUI ``"T116"`` -> ``"A1.4.1.2.1.7"``, or a MeSH
+    tree number like ``"C04.557"``), return the subset of codes whose tree number is NOT a
+    proper ancestor of another code's tree number in the set.
+
+    A tree number is a proper ancestor of another when it is a strict dot-*component* prefix
+    of it: ``"A1.2"`` is an ancestor of ``"A1.2.3"`` but NOT of ``"A1.20"`` (comparison is on
+    ``tree.split(".")`` component lists, not raw string prefixes). Unrelated codes (siblings or
+    codes in different subtrees) all survive. A code with no entry in ``code_to_tree`` -- or an
+    empty tree number -- has no ancestor relationship to anything and is always kept.
+
+    This is vocabulary-agnostic: it only needs a code -> tree-number mapping, so it works for
+    UMLS semantic-type tree numbers (MRSTY STN) and MeSH tree numbers alike.
+
+    :param codes: An iterable of codes to reduce.
+    :param code_to_tree: A mapping from code to its dot-delimited tree number string.
+    :return: A set of the most-specific codes.
+    """
+    codes = set(codes)
+    tree_components = {code: code_to_tree.get(code, "").split(".") if code_to_tree.get(code) else [] for code in codes}
+    survivors = set()
+    for code in codes:
+        components = tree_components[code]
+        # Keep this code unless its tree number is a proper ancestor of some other code's.
+        is_ancestor_of_other = any(
+            other != code
+            and components
+            and len(tree_components[other]) > len(components)
+            and tree_components[other][: len(components)] == components
+            for other in codes
+        )
+        if not is_ancestor_of_other:
+            survivors.add(code)
+    return survivors
+
+
 def make_local_name(fname, subpath=None):
     config = get_config()
     if subpath is None:

--- a/src/createcompendia/leftover_umls.py
+++ b/src/createcompendia/leftover_umls.py
@@ -516,6 +516,13 @@ def write_leftover_umls(
         multi_type_counts: dict[frozenset, int] = defaultdict(int)
         multi_type_samples: dict[frozenset, list] = defaultdict(list)
 
+        # UMLS CURIEs with no MRSTY entry -- typed as NAMED_THING as a fallback. Maps each CURIE to
+        # the set of MRCONSO source abbreviations (SAB) seen for it, as a traceability aid: CURIEs that
+        # appear in no MRSTY row are often from older or superseded UMLS releases, so knowing which
+        # vocabularies reference them helps trace where they originated.
+        no_mrsty_curie_sources: dict[str, set[str]] = {}
+        no_mrsty_curie_label: dict[str, str] = {}
+
         with open(mrconso) as inf:
             for line in inf:
                 if not umls.check_mrconso_line(line):
@@ -524,8 +531,13 @@ def write_leftover_umls(
                 x = line.strip().split("|")
                 cui = x[0]
                 umls_id = f"{UMLS}:{cui}"
+                sab = x[11]
                 if umls_id in umls_ids_in_other_compendia:
                     logger.debug(f"UMLS ID {umls_id} is in another compendium, skipping.")
+                    continue
+                if umls_id in no_mrsty_curie_sources:
+                    # Already typed as NAMED_THING on a prior MRCONSO row; just accumulate the SAB.
+                    no_mrsty_curie_sources[umls_id].add(sab)
                     continue
                 if umls_id in umls_ids_in_this_compendium:
                     logger.debug(f"UMLS ID {umls_id} has already been included in this compendium, skipping.")
@@ -549,6 +561,8 @@ def write_leftover_umls(
                     # Concept has no MRSTY entry: no semantic type annotation. Fall back to NAMED_THING
                     # rather than treating the absence as an unmapped or rejected TUI.
                     mapped_types.add(NAMED_THING)
+                    no_mrsty_curie_sources[umls_id] = {sab}
+                    no_mrsty_curie_label[umls_id] = label
                 else:
                     for tui in tuis_for_id.keys():
                         if tui in STY_OVERRIDES:
@@ -644,6 +658,12 @@ def write_leftover_umls(
         reportf.write(
             f"COUNT Found {len(curies_no_umls_type)} UMLS IDs without a Biolink type, "
             f"{len(curies_rejected)} deliberately rejected, and {len(curies_multiple_umls_type)} with multiple Biolink types.\n"
+        )
+        logger.info(
+            f"Found {len(no_mrsty_curie_sources)} UMLS IDs with no MRSTY entry, typed as {NAMED_THING} (see no-mrsty-curies.csv)."
+        )
+        reportf.write(
+            f"COUNT Found {len(no_mrsty_curie_sources)} UMLS IDs with no MRSTY entry, typed as {NAMED_THING}.\n"
         )
 
         logger.info(f"Writing {len(leftover_umls_cliques)} leftover UMLS cliques with write_compendium().")
@@ -753,6 +773,17 @@ def write_leftover_umls(
                 writer.writerow(
                     ["|".join(sorted(key)), multi_type_counts[key], _format_samples(multi_type_samples[key])]
                 )
+
+        # UMLS CURIEs with no MRSTY entry, typed as NAMED_THING as a fallback. The `sources` column
+        # lists all MRCONSO SAB abbreviations seen for the CURIE -- useful for tracing which vocabularies
+        # reference it when the UMLS semantic-type index has no entry (often a sign of an outdated release
+        # or a CUI retained for backward compatibility but no longer annotated in MRSTY).
+        with open(report_dir / "no-mrsty-curies.csv", "w", newline="") as csvf:
+            writer = csv.writer(csvf)
+            writer.writerow(["umls_curie", "label", "biolink_type", "source_count", "sources"])
+            for curie in sorted(no_mrsty_curie_sources.keys()):
+                sources = sorted(no_mrsty_curie_sources[curie])
+                writer.writerow([curie, no_mrsty_curie_label.get(curie, ""), NAMED_THING, len(sources), "|".join(sources)])
 
         # UMLS CURIEs that landed in more than one compendium clique -- either across two compendium
         # files (cross-file) or in two distinct cliques of one file (within-file). Both are glom/merge

--- a/src/createcompendia/leftover_umls.py
+++ b/src/createcompendia/leftover_umls.py
@@ -78,6 +78,13 @@ STY_OVERRIDES: dict[str, str | None] = {
     "T090": POPULATION_OF_INDIVIDUAL_ORGANISMS,
     "T091": POPULATION_OF_INDIVIDUAL_ORGANISMS,
     "T097": POPULATION_OF_INDIVIDUAL_ORGANISMS,
+    # "Physical Object" (T072) and "Manufactured Object" (T073) both map to biolink:PhysicalEntity,
+    # which has no id_prefixes in the Biolink Model and therefore cannot be written to a compendium
+    # (node.py raises RuntimeError). Reject both so concepts typed only as physical objects are
+    # skipped cleanly rather than crashing the pipeline. Concepts that carry T072/T073 alongside
+    # another semantic type retain the other type via the normal mapping path.
+    "T072": None,
+    "T073": None,
 }
 
 # Disambiguation applied when a single UMLS concept resolves to more than one Biolink type (because

--- a/src/createcompendia/leftover_umls.py
+++ b/src/createcompendia/leftover_umls.py
@@ -16,11 +16,13 @@ from src.categories import (
     GROSS_ANATOMICAL_STRUCTURE,
     NAMED_THING,
     PHENOMENON,
+    PHYSICAL_ENTITY,
     POPULATION_OF_INDIVIDUAL_ORGANISMS,
     PROCEDURE,
     SMALL_MOLECULE,
 )
 from src.datahandlers import umls
+from src.node import NodeFactory
 from src.prefixes import UMLS
 from src.util import get_biolink_model_toolkit, get_logger
 
@@ -77,13 +79,22 @@ STY_OVERRIDES: dict[str, str | None] = {
     "T097": POPULATION_OF_INDIVIDUAL_ORGANISMS,
     # https://github.com/NCATSTranslator/Babel/issues/840
     # "Physical Object" (T072) and "Manufactured Object" (T073) both map to biolink:PhysicalEntity,
-    # which has no id_prefixes in the Biolink Model and therefore cannot be written to a compendium
-    # (node.py raises RuntimeError). Reject both so concepts typed only as physical objects are
-    # skipped cleanly rather than crashing the pipeline. Concepts that carry T072/T073 alongside
-    # another semantic type retain the other type via the normal mapping path.
-    "T072": None,
-    "T073": None,
+    # which has no id_prefixes in the Biolink Model. write_compendium() can nonetheless write these
+    # because the leftover UMLS rule passes extra_prefixes=[UMLS] (see Change in node.create_node),
+    # so we keep them typed as PhysicalEntity rather than dropping them. PhysicalEntity is listed in
+    # GENERIC_TYPES below, so a concept that carries T072/T073 *alongside* a more specific semantic
+    # type keeps the specific type instead of being dropped as multiply-typed.
+    "T072": PHYSICAL_ENTITY,
+    "T073": PHYSICAL_ENTITY,
 }
+
+# Very high-level Biolink types that should never shadow a more specific co-type. When a UMLS concept
+# resolves to more than one Biolink type and one of them is generic (e.g. biolink:PhysicalEntity from
+# T072/T073 "Physical Object"/"Manufactured Object"), the generic type is dropped so the specific
+# type wins. This is the cleaner successor to the old approach of rejecting T072/T073 with None (which
+# kept the specific type only by contributing no type at all, at the cost of dropping concepts whose
+# *only* type was T072/T073). A concept typed solely as a generic type still keeps it and is written.
+GENERIC_TYPES: frozenset[str] = frozenset({PHYSICAL_ENTITY})
 
 # Disambiguation applied when a single UMLS concept resolves to more than one Biolink type (because
 # it carries multiple semantic types). Keyed by the frozenset of resolved Biolink types; the value is
@@ -101,6 +112,23 @@ TYPE_COMBO_OVERRIDES: dict[frozenset[str], str] = {
     # diseasephenotype.py -- would resolve to two types and be dropped.
     frozenset({PHENOMENON, CLINICAL_FINDING}): CLINICAL_FINDING,
 }
+
+
+def writable_output_types() -> set[str]:
+    """
+    Every Biolink type the leftover UMLS rule can emit from its manual override tables: all non-None
+    STY_OVERRIDES values, all TYPE_COMBO_OVERRIDES values, and NAMED_THING (the fallback type used
+    when a concept has no MRSTY semantic type). Used by the preflight check in write_leftover_umls()
+    and by the regression test to confirm each type is writable with extra_prefixes=[UMLS] -- some of
+    them (e.g. biolink:Phenomenon, biolink:PhysicalEntity) have no id_prefixes of their own.
+
+    The dynamic, Biolink-mapped TUIs are not enumerated here because they are made crash-proof by
+    node.create_node() tolerating prefix-less types when extra_prefixes is supplied.
+    """
+    types = {t for t in STY_OVERRIDES.values() if t is not None}
+    types.update(TYPE_COMBO_OVERRIDES.values())
+    types.add(NAMED_THING)
+    return types
 
 
 def tui_to_biolink_type(umls_tui: str, toolkit=None, biolink_version: str | None = None) -> str | None:
@@ -171,6 +199,22 @@ def write_leftover_umls(
 
     report_dir = Path(report).parent
     report_dir.mkdir(parents=True, exist_ok=True)
+
+    # Preflight: confirm every Biolink type this rule can emit from its manual override tables can
+    # actually be written with extra_prefixes=[UMLS], before we spend hours loading the compendia,
+    # MRSTY and MRCONSO. create_node() with empty identifiers exercises get_prefixes() (the call that
+    # historically crashed write_compendium after ~5h on a prefix-less type) and then returns None
+    # without touching any labels or files. Fail fast here with a clear message instead.
+    preflight_factory = NodeFactory(label_dir=None, biolink_version=biolink_version)
+    for output_type in sorted(writable_output_types()):
+        try:
+            preflight_factory.create_node(input_identifiers=[], node_type=output_type, labels={}, extra_prefixes=[UMLS])
+        except RuntimeError as e:
+            raise RuntimeError(
+                f"leftover_umls preflight failed: Biolink type {output_type} is not writable even with "
+                f"extra_prefixes=[UMLS] ({e}). Fix the override tables in leftover_umls.py before running the rule."
+            ) from e
+    logger.info(f"Preflight passed: all {len(writable_output_types())} override output types are writable.")
 
     # For now, we have many more UMLS entities in MRCONSO than in the compendia, so
     # we'll make an in-memory list of those first. Once that flips, this should be
@@ -361,6 +405,13 @@ def write_leftover_umls(
 
                 # Disambiguate when a concept resolves to multiple Biolink types.
                 biolink_types = mapped_types
+                # Drop very high-level types (e.g. PhysicalEntity) when a more specific co-type is
+                # present, so the generic type never shadows it. A concept typed *only* as a generic
+                # type keeps it.
+                if len(biolink_types) > 1:
+                    specific_types = biolink_types - GENERIC_TYPES
+                    if specific_types:
+                        biolink_types = specific_types
                 if len(biolink_types) > 1 and frozenset(biolink_types) in TYPE_COMBO_OVERRIDES:
                     biolink_types = {TYPE_COMBO_OVERRIDES[frozenset(biolink_types)]}
 

--- a/src/createcompendia/leftover_umls.py
+++ b/src/createcompendia/leftover_umls.py
@@ -303,7 +303,7 @@ def summarize_compendium_umls_by_semantic_type(
             if not curie.startswith(_UMLS_PREFIX):
                 continue
             label = identifier.get("l", "")
-            if curie not in labels_by_id:
+            if curie not in labels_by_id or (not labels_by_id[curie] and label):
                 labels_by_id[curie] = label
             occ_by_curie[curie].add((biolink_type, leader, preferred_name, label))
             pair = (biolink_type, curie)
@@ -363,11 +363,11 @@ def write_leftover_umls(
     # MRSTY and MRCONSO. create_node() with empty identifiers exercises get_prefixes() (the call that
     # historically crashed write_compendium after ~5h on a prefix-less type) and then returns None
     # without touching any labels or files. Fail fast here with a clear message instead.
-    preflight_factory = NodeFactory(label_dir=None, biolink_version=biolink_version)
+    node_factory = NodeFactory(label_dir=None, biolink_version=biolink_version)
     output_types = writable_output_types()
     for output_type in sorted(output_types):
         try:
-            preflight_factory.create_node(input_identifiers=[], node_type=output_type, labels={}, extra_prefixes=[UMLS])
+            node_factory.create_node(input_identifiers=[], node_type=output_type, labels={}, extra_prefixes=[UMLS])
         except RuntimeError as e:
             raise RuntimeError(
                 f"leftover_umls preflight failed: Biolink type {output_type} is not writable even with "
@@ -386,8 +386,8 @@ def write_leftover_umls(
     umls_ids_in_this_compendium = set()
 
     with open(report, "w") as reportf:
-        # This defaults to the version of the Biolink model that is included with this BMT.
-        biolink_toolkit = get_biolink_model_toolkit(biolink_version)
+        # Reuse the toolkit built by node_factory above to avoid a redundant parse.
+        biolink_toolkit = node_factory.toolkit
 
         # Load all the semantic types first: the per-compendium coverage breakdown below needs to
         # look up each UMLS CURIE's semantic types, and the MRCONSO sweep needs them to type each
@@ -541,23 +541,28 @@ def write_leftover_umls(
                 # Resolve every semantic type (STY/TUI) on this concept into one of three outcomes:
                 # a Biolink type, an explicit rejection (STY_OVERRIDES -> None), or unmapped (Biolink
                 # has no mapping and there is no override).
-                umls_type_results = types_by_id.get(umls_id, {NAMED_THING: {"Named thing"}})
+                tuis_for_id = types_by_id.get(umls_id)
                 mapped_types = set()
                 rejected_tuis = set()
                 unmapped_tuis = set()
-                for tui in umls_type_results.keys():
-                    if tui in STY_OVERRIDES:
-                        override = STY_OVERRIDES[tui]
-                        if override is None:
-                            rejected_tuis.add(tui)
+                if tuis_for_id is None:
+                    # Concept has no MRSTY entry: no semantic type annotation. Fall back to NAMED_THING
+                    # rather than treating the absence as an unmapped or rejected TUI.
+                    mapped_types.add(NAMED_THING)
+                else:
+                    for tui in tuis_for_id.keys():
+                        if tui in STY_OVERRIDES:
+                            override = STY_OVERRIDES[tui]
+                            if override is None:
+                                rejected_tuis.add(tui)
+                            else:
+                                mapped_types.add(override)
                         else:
-                            mapped_types.add(override)
-                    else:
-                        biolink_type = resolve_sty_biolink(tui)
-                        if biolink_type is None:
-                            unmapped_tuis.add(tui)
-                        else:
-                            mapped_types.add(biolink_type)
+                            biolink_type = resolve_sty_biolink(tui)
+                            if biolink_type is None:
+                                unmapped_tuis.add(tui)
+                            else:
+                                mapped_types.add(biolink_type)
 
                 # An unmapped semantic type means we can't fully type this concept, so we skip it
                 # entirely (the existing conservative behavior) and report it as unmapped.
@@ -565,10 +570,10 @@ def write_leftover_umls(
                     if umls_id not in curies_no_umls_type:
                         curies_no_umls_type.add(umls_id)
                         logger.warning(
-                            f"No Biolink type for {umls_id}: unmapped STY {sorted(unmapped_tuis)} in {umls_type_results}, skipping"
+                            f"No Biolink type for {umls_id}: unmapped STY {sorted(unmapped_tuis)} in {tuis_for_id}, skipping"
                         )
                         reportf.write(
-                            f"NO_UMLS_TYPE [{umls_id}]: unmapped STY {sorted(unmapped_tuis)} in {umls_type_results}\n"
+                            f"NO_UMLS_TYPE [{umls_id}]: unmapped STY {sorted(unmapped_tuis)} in {tuis_for_id}\n"
                         )
                         for tui in unmapped_tuis:
                             unmapped_tui_counts[tui] += 1
@@ -582,11 +587,9 @@ def write_leftover_umls(
                     if umls_id not in curies_rejected:
                         curies_rejected.add(umls_id)
                         logger.info(
-                            f"Rejected {umls_id}: rejected STY {sorted(rejected_tuis)} in {umls_type_results}, skipping"
+                            f"Rejected {umls_id}: rejected STY {sorted(rejected_tuis)} in {tuis_for_id}, skipping"
                         )
-                        reportf.write(
-                            f"REJECTED [{umls_id}]: rejected STY {sorted(rejected_tuis)} in {umls_type_results}\n"
-                        )
+                        reportf.write(f"REJECTED [{umls_id}]: rejected STY {sorted(rejected_tuis)} in {tuis_for_id}\n")
                         for tui in rejected_tuis:
                             rejected_tui_counts[tui] += 1
                             if len(rejected_tui_examples[tui]) < _SAMPLE_LIMIT:
@@ -604,9 +607,9 @@ def write_leftover_umls(
                         curies_multiple_umls_type.add(umls_id)
                         biolink_types_as_str = "|".join(sorted(biolink_types))
                         logger.warning(
-                            f"Multiple Biolink types not yet supported for {umls_id}: {umls_type_results} -> {biolink_types_as_str}, skipping"
+                            f"Multiple Biolink types not yet supported for {umls_id}: {tuis_for_id} -> {biolink_types_as_str}, skipping"
                         )
-                        reportf.write(f"MULTIPLE_UMLS_TYPES [{umls_id}]\t{biolink_types_as_str}\t{umls_type_results}\n")
+                        reportf.write(f"MULTIPLE_UMLS_TYPES [{umls_id}]\t{biolink_types_as_str}\t{tuis_for_id}\n")
                         key = frozenset(biolink_types)
                         multi_type_counts[key] += 1
                         if len(multi_type_samples[key]) < _SAMPLE_LIMIT:

--- a/src/createcompendia/leftover_umls.py
+++ b/src/createcompendia/leftover_umls.py
@@ -783,7 +783,9 @@ def write_leftover_umls(
             writer.writerow(["umls_curie", "label", "biolink_type", "source_count", "sources"])
             for curie in sorted(no_mrsty_curie_sources.keys()):
                 sources = sorted(no_mrsty_curie_sources[curie])
-                writer.writerow([curie, no_mrsty_curie_label.get(curie, ""), NAMED_THING, len(sources), "|".join(sources)])
+                writer.writerow(
+                    [curie, no_mrsty_curie_label.get(curie, ""), NAMED_THING, len(sources), "|".join(sources)]
+                )
 
         # UMLS CURIEs that landed in more than one compendium clique -- either across two compendium
         # files (cross-file) or in two distinct cliques of one file (within-file). Both are glom/merge

--- a/src/createcompendia/leftover_umls.py
+++ b/src/createcompendia/leftover_umls.py
@@ -78,6 +78,7 @@ STY_OVERRIDES: dict[str, str | None] = {
     "T090": POPULATION_OF_INDIVIDUAL_ORGANISMS,
     "T091": POPULATION_OF_INDIVIDUAL_ORGANISMS,
     "T097": POPULATION_OF_INDIVIDUAL_ORGANISMS,
+    # https://github.com/NCATSTranslator/Babel/issues/840
     # "Physical Object" (T072) and "Manufactured Object" (T073) both map to biolink:PhysicalEntity,
     # which has no id_prefixes in the Biolink Model and therefore cannot be written to a compendium
     # (node.py raises RuntimeError). Reject both so concepts typed only as physical objects are

--- a/src/createcompendia/leftover_umls.py
+++ b/src/createcompendia/leftover_umls.py
@@ -544,14 +544,15 @@ def write_leftover_umls(
         with open(report_dir / "compendium-coverage.csv", "w", newline="") as csvf:
             writer = csv.writer(csvf)
             writer.writerow(
-                ["compendium", "tui_set", "tree_set", "curie_count", "single_umls_clique_count", "sample_curies"]
+                ["compendium", "tui_set", "tui_set_labels", "tree_set", "curie_count", "single_umls_clique_count", "sample_curies"]
             )
             for name, key in sorted(semantic_breakdown.keys(), key=lambda nk: (nk[0], sorted(nk[1]))):
                 curie_count, single_count, samples = semantic_breakdown[(name, key)]
                 sorted_tuis = sorted(key)
                 tui_set = "|".join(sorted_tuis) if sorted_tuis else "(none)"
+                tui_set_labels = "|".join("/".join(sorted(types_by_tui.get(tui, {""}))) for tui in sorted_tuis) if sorted_tuis else "(none)"
                 tree_set = "|".join(tui_to_tree.get(tui, "") for tui in sorted_tuis)
-                writer.writerow([name, tui_set, tree_set, curie_count, single_count, _format_samples(samples)])
+                writer.writerow([name, tui_set, tui_set_labels, tree_set, curie_count, single_count, _format_samples(samples)])
 
         # Per-Biolink-type leftover clique coverage, with a few sample CURIEs and labels.
         with open(report_dir / "types-coverage.csv", "w", newline="") as csvf:

--- a/src/createcompendia/leftover_umls.py
+++ b/src/createcompendia/leftover_umls.py
@@ -114,6 +114,18 @@ TYPE_COMBO_OVERRIDES: dict[frozenset[str], str] = {
 }
 
 
+def apply_generic_demotion(biolink_types: set[str]) -> set[str]:
+    """
+    Drop GENERIC_TYPES from biolink_types when a more specific co-type is present; keep them when
+    they are the only type. This is a pure function used both in write_leftover_umls() and in tests.
+    """
+    if len(biolink_types) > 1:
+        specific_types = biolink_types - GENERIC_TYPES
+        if specific_types:
+            return specific_types
+    return biolink_types
+
+
 def writable_output_types() -> set[str]:
     """
     Every Biolink type the leftover UMLS rule can emit from its manual override tables: all non-None
@@ -206,7 +218,8 @@ def write_leftover_umls(
     # historically crashed write_compendium after ~5h on a prefix-less type) and then returns None
     # without touching any labels or files. Fail fast here with a clear message instead.
     preflight_factory = NodeFactory(label_dir=None, biolink_version=biolink_version)
-    for output_type in sorted(writable_output_types()):
+    output_types = writable_output_types()
+    for output_type in sorted(output_types):
         try:
             preflight_factory.create_node(input_identifiers=[], node_type=output_type, labels={}, extra_prefixes=[UMLS])
         except RuntimeError as e:
@@ -214,7 +227,7 @@ def write_leftover_umls(
                 f"leftover_umls preflight failed: Biolink type {output_type} is not writable even with "
                 f"extra_prefixes=[UMLS] ({e}). Fix the override tables in leftover_umls.py before running the rule."
             ) from e
-    logger.info(f"Preflight passed: all {len(writable_output_types())} override output types are writable.")
+    logger.info(f"Preflight passed: all {len(output_types)} override output types are writable.")
 
     # For now, we have many more UMLS entities in MRCONSO than in the compendia, so
     # we'll make an in-memory list of those first. Once that flips, this should be
@@ -404,14 +417,7 @@ def write_leftover_umls(
                     continue
 
                 # Disambiguate when a concept resolves to multiple Biolink types.
-                biolink_types = mapped_types
-                # Drop very high-level types (e.g. PhysicalEntity) when a more specific co-type is
-                # present, so the generic type never shadows it. A concept typed *only* as a generic
-                # type keeps it.
-                if len(biolink_types) > 1:
-                    specific_types = biolink_types - GENERIC_TYPES
-                    if specific_types:
-                        biolink_types = specific_types
+                biolink_types = apply_generic_demotion(mapped_types)
                 if len(biolink_types) > 1 and frozenset(biolink_types) in TYPE_COMBO_OVERRIDES:
                     biolink_types = {TYPE_COMBO_OVERRIDES[frozenset(biolink_types)]}
 

--- a/src/createcompendia/leftover_umls.py
+++ b/src/createcompendia/leftover_umls.py
@@ -3,7 +3,7 @@ import json
 from collections import defaultdict
 from pathlib import Path
 
-from src.babel_utils import TypedClique, write_compendium
+from src.babel_utils import TypedClique, reduce_to_most_specific_tree_codes, write_compendium
 from src.categories import (
     ACTIVITY,
     BIOLOGICAL_PROCESS,
@@ -29,6 +29,10 @@ from src.util import get_biolink_model_toolkit, get_logger
 logger = get_logger(__name__)
 
 _UMLS_PREFIX = UMLS + ":"
+
+# Up to this many (CURIE, label) samples are kept per report bucket -- enough to eyeball what a
+# bucket contains without unbounded memory across millions of MRCONSO lines.
+_SAMPLE_LIMIT = 5
 
 
 # Manual overrides of the Biolink type that bmt assigns to a UMLS semantic type. bmt looks these up
@@ -178,6 +182,46 @@ def _format_samples(pairs):
     return "; ".join(f"{curie}={label}" for curie, label in pairs)
 
 
+def summarize_compendium_umls_by_semantic_type(clusters, semantic_key, sample_limit=_SAMPLE_LIMIT):
+    """Group one compendium's UMLS members by their most-specific UMLS semantic-type set.
+
+    Each unique UMLS CURIE in the compendium is bucketed by ``semantic_key(curie)`` (a frozenset of
+    the concept's most-specific TUIs). A CURIE is counted once even if it appears in several cliques;
+    it counts toward ``single_umls_clique_count`` if it is ever seen in a clique whose only member is
+    that single UMLS identifier.
+
+    :param clusters: iterable of compendium clique dicts, each with an ``"identifiers"`` list of
+        ``{"i": curie, "l": label, ...}`` entries.
+    :param semantic_key: callable mapping a UMLS CURIE to a frozenset of TUIs.
+    :param sample_limit: max ``(curie, label)`` samples kept per bucket.
+    :return: ``(breakdown, umls_ids)`` where ``breakdown`` maps ``frozenset(TUIs)`` to
+        ``[unique_curie_count, single_umls_clique_count, [(curie, label), ...]]`` and ``umls_ids`` is
+        the set of every UMLS CURIE seen in this compendium.
+    """
+    umls_ids = set()
+    single_umls_ids = set()
+    labels_by_id = dict()
+    for cluster in clusters:
+        identifiers = cluster["identifiers"]
+        umls_in_clique = [identifier["i"] for identifier in identifiers if identifier["i"].startswith(_UMLS_PREFIX)]
+        umls_ids.update(umls_in_clique)
+        for identifier in identifiers:
+            if identifier["i"].startswith(_UMLS_PREFIX) and identifier["i"] not in labels_by_id:
+                labels_by_id[identifier["i"]] = identifier.get("l", "")
+        if len(identifiers) == 1 and len(umls_in_clique) == 1:
+            single_umls_ids.add(umls_in_clique[0])
+
+    breakdown = defaultdict(lambda: [0, 0, []])
+    for umls_id in umls_ids:
+        entry = breakdown[semantic_key(umls_id)]
+        entry[0] += 1
+        if umls_id in single_umls_ids:
+            entry[1] += 1
+        if len(entry[2]) < sample_limit:
+            entry[2].append((umls_id, labels_by_id.get(umls_id, "")))
+    return breakdown, umls_ids
+
+
 def write_leftover_umls(
     metadata_yamls, compendia, mrconso, mrsty, umls_compendium, umls_synonyms, report, biolink_version, icrdf_filename
 ):
@@ -244,43 +288,22 @@ def write_leftover_umls(
         # This defaults to the version of the Biolink model that is included with this BMT.
         biolink_toolkit = get_biolink_model_toolkit(biolink_version)
 
-        # Per-compendium UMLS coverage: how many UMLS CURIEs each input compendium contributes, and
-        # how many of those sit in a clique consisting solely of a single UMLS identifier.
-        compendium_umls_counts = []
-
-        for compendium in compendia:
-            logger.info(f"Starting compendium: {compendium}")
-            umls_ids = set()
-            single_umls_clique_count = 0
-
-            with open(compendium) as f:
-                for row in f:
-                    cluster = json.loads(row)
-                    identifiers = cluster["identifiers"]
-                    umls_in_clique = [
-                        identifier["i"] for identifier in identifiers if identifier["i"].startswith(_UMLS_PREFIX)
-                    ]
-                    umls_ids.update(umls_in_clique)
-                    if len(identifiers) == 1 and len(umls_in_clique) == 1:
-                        single_umls_clique_count += 1
-
-            logger.info(f"Completed compendium {compendium} with {len(umls_ids)} UMLS IDs")
-            compendium_umls_counts.append((Path(compendium).name, len(umls_ids), single_umls_clique_count))
-            umls_ids_in_other_compendia.update(umls_ids)
-
-        logger.info(f"Completed all compendia with {len(umls_ids_in_other_compendia)} UMLS IDs.")
-        reportf.write(f"COMPLETED All compendia with {len(umls_ids_in_other_compendia)} UMLS IDs.\n")
-
-        # Load all the semantic types.
+        # Load all the semantic types first: the per-compendium coverage breakdown below needs to
+        # look up each UMLS CURIE's semantic types, and the MRCONSO sweep needs them to type each
+        # leftover concept. types_by_id maps each UMLS CURIE to {TUI: {STY name}}; types_by_tui maps
+        # each TUI to its STY name(s); tui_to_tree maps each TUI to its semantic-type tree number
+        # (MRSTY STN, e.g. T116 -> A1.4.1.2.1.7), used to reduce a concept's TUIs to the most
+        # specific ones.
         preferred_name_by_id = dict()
         types_by_id = dict()
         types_by_tui = dict()
+        tui_to_tree = dict()
         with open(mrsty) as inf:
             for line in inf:
                 x = line.strip().split("|")
                 umls_id = f"{UMLS}:{x[0]}"
                 tui = x[1]
-                # stn = x[2]
+                tree = x[2]
                 sty = x[3]
 
                 if umls_id not in types_by_id:
@@ -293,6 +316,10 @@ def write_leftover_umls(
                     types_by_tui[tui] = set()
                 types_by_tui[tui].add(sty)
 
+                # A TUI has a single, fixed tree number; record the first one we see.
+                if tui not in tui_to_tree:
+                    tui_to_tree[tui] = tree
+
         logger.info(f"Completed loading {len(types_by_id.keys())} UMLS IDs from MRSTY.RRF.")
         reportf.write(f"COMPLETED Loading {len(types_by_id.keys())} UMLS IDs from MRSTY.RRF.\n")
 
@@ -300,6 +327,45 @@ def write_leftover_umls(
             for tui in sorted(types_by_tui.keys()):
                 for sty in sorted(list(types_by_tui[tui])):
                     outf.write(f"{tui}\t{sty}\n")
+
+        def semantic_key(umls_id: str) -> frozenset:
+            """The most-specific set of UMLS semantic types (TUIs) for a UMLS CURIE.
+
+            Looks up every TUI on the concept and drops any that is a proper ancestor of another
+            TUI on the same concept (via tree-number prefixing), so co-types in the same lineage
+            collapse to the leaf. Returns an empty frozenset if the CURIE has no MRSTY entry.
+            """
+            tuis = set(types_by_id.get(umls_id, {}).keys())
+            return frozenset(reduce_to_most_specific_tree_codes(tuis, tui_to_tree))
+
+        # Per-compendium UMLS coverage, broken down by most-specific semantic-type set. The key is
+        # (compendium name, frozenset of TUIs); the value is [unique CURIE count, single-UMLS-clique
+        # count, up to _SAMPLE_LIMIT (CURIE, label) samples]. This answers "where does UMLS go inside
+        # Babel, by semantic type" -- summing curie_count over a compendium reproduces its total. The
+        # leftover umls.txt compendium is added in the MRCONSO sweep below, so this one CSV spans every
+        # compendium that consumes UMLS.
+        semantic_breakdown: dict[tuple[str, frozenset], list] = defaultdict(lambda: [0, 0, []])
+
+        for compendium in compendia:
+            logger.info(f"Starting compendium: {compendium}")
+            name = Path(compendium).name
+            with open(compendium) as f:
+                breakdown, umls_ids = summarize_compendium_umls_by_semantic_type(
+                    (json.loads(row) for row in f), semantic_key
+                )
+            for key, (count, single_count, samples) in breakdown.items():
+                entry = semantic_breakdown[(name, key)]
+                entry[0] += count
+                entry[1] += single_count
+                entry[2].extend(samples[: _SAMPLE_LIMIT - len(entry[2])])
+
+            logger.info(f"Completed compendium {compendium} with {len(umls_ids)} UMLS IDs")
+            umls_ids_in_other_compendia.update(umls_ids)
+
+        logger.info(f"Completed all compendia with {len(umls_ids_in_other_compendia)} UMLS IDs.")
+        reportf.write(f"COMPLETED All compendia with {len(umls_ids_in_other_compendia)} UMLS IDs.\n")
+
+        leftover_compendium_name = Path(umls_compendium).name
 
         # Resolve a UMLS semantic type (STY/TUI) to a Biolink type via Biolink, memoizing because the
         # same TUI recurs across many concepts. STY_OVERRIDES is applied separately (see below) so
@@ -328,8 +394,7 @@ def write_leftover_umls(
         # CSVs). The cap is not an approximation of the counts -- it only bounds memory across millions
         # of MRCONSO lines. The exhaustive per-CURIE record lives elsewhere: kept concepts in
         # compendia/umls.txt, skipped concepts in log.txt (NO_UMLS_TYPE / REJECTED / MULTIPLE_UMLS_TYPES).
-        # See docs/sources/UMLS/Leftover.md ("Counts vs. samples").
-        _SAMPLE_LIMIT = 5
+        # See docs/sources/UMLS/Leftover.md ("Counts vs. samples"). (_SAMPLE_LIMIT defined above.)
         type_counts: dict[str, int] = defaultdict(int)
         type_samples: dict[str, list] = defaultdict(list)
         unmapped_tui_counts: dict[str, int] = defaultdict(int)
@@ -446,6 +511,15 @@ def write_leftover_umls(
                 if len(type_samples[biolink_type]) < _SAMPLE_LIMIT:
                     type_samples[biolink_type].append((umls_id, label))
 
+                # Also record this leftover concept in the per-compendium semantic-type breakdown, so
+                # umls.txt appears alongside the input compendia. Every leftover clique is a single
+                # UMLS identifier, so it counts toward single_umls_clique_count too.
+                leftover_entry = semantic_breakdown[(leftover_compendium_name, semantic_key(umls_id))]
+                leftover_entry[0] += 1
+                leftover_entry[1] += 1
+                if len(leftover_entry[2]) < _SAMPLE_LIMIT:
+                    leftover_entry[2].append((umls_id, label))
+
         logger.info(f"Wrote out {len(umls_ids_in_this_compendium)} UMLS IDs into the leftover UMLS compendium.")
         reportf.write(
             f"COMPLETED Wrote out {len(umls_ids_in_this_compendium)} UMLS IDs into the leftover UMLS compendium.\n"
@@ -463,12 +537,21 @@ def write_leftover_umls(
         logger.info(f"Writing {len(leftover_umls_cliques)} leftover UMLS cliques with write_compendium().")
         reportf.write(f"COUNT Writing {len(leftover_umls_cliques)} leftover UMLS cliques with write_compendium().\n")
 
-        # Per-compendium UMLS coverage.
+        # Per-compendium UMLS coverage, broken down by most-specific UMLS semantic-type set. One row
+        # per (compendium, TUI set). TUIs and tree numbers are emitted as codes (no labels) so the
+        # grouping is scannable at a glance; tui-sty.tsv is the code -> label lookup. Summing
+        # curie_count over a compendium reproduces its total unique UMLS count.
         with open(report_dir / "compendium-coverage.csv", "w", newline="") as csvf:
             writer = csv.writer(csvf)
-            writer.writerow(["compendium", "total_umls_curies", "single_umls_clique_count"])
-            for name, total, singles in sorted(compendium_umls_counts):
-                writer.writerow([name, total, singles])
+            writer.writerow(
+                ["compendium", "tui_set", "tree_set", "curie_count", "single_umls_clique_count", "sample_curies"]
+            )
+            for name, key in sorted(semantic_breakdown.keys(), key=lambda nk: (nk[0], sorted(nk[1]))):
+                curie_count, single_count, samples = semantic_breakdown[(name, key)]
+                sorted_tuis = sorted(key)
+                tui_set = "|".join(sorted_tuis) if sorted_tuis else "(none)"
+                tree_set = "|".join(tui_to_tree.get(tui, "") for tui in sorted_tuis)
+                writer.writerow([name, tui_set, tree_set, curie_count, single_count, _format_samples(samples)])
 
         # Per-Biolink-type leftover clique coverage, with a few sample CURIEs and labels.
         with open(report_dir / "types-coverage.csv", "w", newline="") as csvf:

--- a/src/createcompendia/leftover_umls.py
+++ b/src/createcompendia/leftover_umls.py
@@ -19,7 +19,7 @@ from src.categories import (
     PHYSICAL_ENTITY,
     POPULATION_OF_INDIVIDUAL_ORGANISMS,
     PROCEDURE,
-    SMALL_MOLECULE,
+    SMALL_MOLECULE, ANATOMICAL_ENTITY,
 )
 from src.datahandlers import umls
 from src.node import NodeFactory
@@ -106,6 +106,8 @@ GENERIC_TYPES: frozenset[str] = frozenset({PHYSICAL_ENTITY})
 # write_leftover_umls().
 TYPE_COMBO_OVERRIDES: dict[frozenset[str], str] = {
     frozenset({DEVICE, DRUG}): DRUG,
+    frozenset({CHEMICAL_ENTITY, DRUG}): DRUG,
+    frozenset({ANATOMICAL_ENTITY, DRUG}): DRUG,             # e.g. fecal microbiota
     frozenset({DRUG, SMALL_MOLECULE}): SMALL_MOLECULE,
     frozenset({ACTIVITY, PROCEDURE}): PROCEDURE,
     frozenset({DRUG, FOOD}): FOOD,

--- a/src/createcompendia/leftover_umls.py
+++ b/src/createcompendia/leftover_umls.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from src.babel_utils import TypedClique, reduce_to_most_specific_tree_codes, write_compendium
 from src.categories import (
     ACTIVITY,
+    ANATOMICAL_ENTITY,
     BIOLOGICAL_PROCESS,
     CHEMICAL_ENTITY,
     CLINICAL_FINDING,
@@ -19,7 +20,7 @@ from src.categories import (
     PHYSICAL_ENTITY,
     POPULATION_OF_INDIVIDUAL_ORGANISMS,
     PROCEDURE,
-    SMALL_MOLECULE, ANATOMICAL_ENTITY,
+    SMALL_MOLECULE,
 )
 from src.datahandlers import umls
 from src.node import NodeFactory
@@ -107,7 +108,7 @@ GENERIC_TYPES: frozenset[str] = frozenset({PHYSICAL_ENTITY})
 TYPE_COMBO_OVERRIDES: dict[frozenset[str], str] = {
     frozenset({DEVICE, DRUG}): DRUG,
     frozenset({CHEMICAL_ENTITY, DRUG}): DRUG,
-    frozenset({ANATOMICAL_ENTITY, DRUG}): DRUG,             # e.g. fecal microbiota
+    frozenset({ANATOMICAL_ENTITY, DRUG}): DRUG,  # e.g. fecal microbiota
     frozenset({DRUG, SMALL_MOLECULE}): SMALL_MOLECULE,
     frozenset({ACTIVITY, PROCEDURE}): PROCEDURE,
     frozenset({DRUG, FOOD}): FOOD,
@@ -184,44 +185,143 @@ def _format_samples(pairs):
     return "; ".join(f"{curie}={label}" for curie, label in pairs)
 
 
-def summarize_compendium_umls_by_semantic_type(clusters, semantic_key, sample_limit=_SAMPLE_LIMIT):
-    """Group one compendium's UMLS members by their most-specific UMLS semantic-type set.
+def _format_tui_set(sorted_tuis, types_by_tui, tui_to_tree):
+    """Render a sorted list of TUIs as ``(tui_set, tui_set_labels, tree_set)`` display strings.
 
-    Each unique UMLS CURIE in the compendium is bucketed by ``semantic_key(curie)`` (a frozenset of
-    the concept's most-specific TUIs). A CURIE is counted once even if it appears in several cliques;
-    it counts toward ``single_umls_clique_count`` if it is ever seen in a clique whose only member is
-    that single UMLS identifier.
-
-    :param clusters: iterable of compendium clique dicts, each with an ``"identifiers"`` list of
-        ``{"i": curie, "l": label, ...}`` entries.
-    :param semantic_key: callable mapping a UMLS CURIE to a frozenset of TUIs.
-    :param sample_limit: max ``(curie, label)`` samples kept per bucket.
-    :return: ``(breakdown, umls_ids)`` where ``breakdown`` maps ``frozenset(TUIs)`` to
-        ``[unique_curie_count, single_umls_clique_count, [(curie, label), ...]]`` and ``umls_ids`` is
-        the set of every UMLS CURIE seen in this compendium.
+    ``tui_set`` is the pipe-joined codes; ``tui_set_labels`` joins each TUI's STY name(s)
+    (slash-joined when a TUI has several); ``tree_set`` is the pipe-joined MRSTY tree numbers. An
+    empty list renders as ``"(none)"`` for the code/label columns and ``""`` for the tree column.
+    Shared by the ``compendium-coverage.csv``, ``tui-coverage.csv`` and ``duplicate-curies.csv``
+    writers so the TUI-set formatting lives in one place.
     """
-    umls_ids = set()
-    single_umls_ids = set()
+    if not sorted_tuis:
+        return "(none)", "(none)", ""
+    tui_set = "|".join(sorted_tuis)
+    tui_set_labels = "|".join("/".join(sorted(types_by_tui.get(tui, {""}))) for tui in sorted_tuis)
+    tree_set = "|".join(tui_to_tree.get(tui, "") for tui in sorted_tuis)
+    return tui_set, tui_set_labels, tree_set
+
+
+class DuplicateUmlsTracker:
+    """Track which compendium cliques each UMLS CURIE lands in, to surface duplicate-CURIE bugs.
+
+    A CURIE is "duplicated" when its occurrences span more than one compendium file (**cross-file**)
+    or more than one distinct clique leader within a single file (**within-file**) -- both indicate a
+    glom/merge problem worth tracing upstream (see https://github.com/NCATSTranslator/Babel/issues/276).
+
+    To stay close to the memory of a plain membership set over the millions of CURIEs in the input
+    compendia, only the *first* occurrence of each CURIE is retained until a second occurrence with a
+    distinct ``(compendium, leader)`` promotes it into the duplicates map. The tracker also doubles as
+    the "is this CURIE already claimed by another compendium" membership set (``curie in tracker``)
+    used to skip already-claimed concepts during the MRCONSO sweep.
+
+    An occurrence is the tuple ``(compendium, biolink_type, leader, preferred_name, label)``.
+    """
+
+    def __init__(self):
+        # Every CURIE -> its first-seen occurrence (kept even after promotion to a duplicate).
+        self._first: dict[str, tuple] = {}
+        # Only duplicated CURIEs -> all their distinct occurrences.
+        self._dups: dict[str, list[tuple]] = {}
+
+    def record(self, curie, compendium, biolink_type, leader, preferred_name, label):
+        """Record that ``curie`` appears in clique ``leader`` of ``compendium`` (typed ``biolink_type``)."""
+        occ = (compendium, biolink_type, leader, preferred_name, label)
+        if curie in self._dups:
+            if (compendium, leader) not in {(o[0], o[2]) for o in self._dups[curie]}:
+                self._dups[curie].append(occ)
+            return
+        if curie not in self._first:
+            self._first[curie] = occ
+            return
+        prev = self._first[curie]
+        if (prev[0], prev[2]) == (compendium, leader):
+            # Same CURIE re-seen in the same clique (e.g. another MRCONSO row); not a duplicate.
+            return
+        self._dups[curie] = [prev, occ]
+
+    def __contains__(self, curie):
+        return curie in self._first
+
+    def __len__(self):
+        return len(self._first)
+
+    def duplicates(self):
+        """Yield ``(curie, occurrences, scope)`` for each duplicated CURIE, sorted by CURIE.
+
+        ``scope`` is ``"cross-file"`` (occurrences span 2+ compendia), ``"within-file"`` (2+ distinct
+        clique leaders within one compendium), or ``"both"``.
+        """
+        for curie in sorted(self._dups):
+            occs = self._dups[curie]
+            compendia = {o[0] for o in occs}
+            cross = len(compendia) > 1
+            within = any(len({o[2] for o in occs if o[0] == comp}) > 1 for comp in compendia)
+            scope = "both" if (cross and within) else ("cross-file" if cross else "within-file")
+            yield curie, occs, scope
+
+
+def summarize_compendium_umls_by_semantic_type(
+    clusters, semantic_key, fallback_biolink_type=None, sample_limit=_SAMPLE_LIMIT
+):
+    """Group one compendium's UMLS members by Biolink type and most-specific UMLS semantic-type set.
+
+    Each UMLS CURIE in the compendium is bucketed by ``(biolink_type, semantic_key(curie))`` where
+    ``biolink_type`` is the owning clique's ``"type"`` field (falling back to
+    ``fallback_biolink_type`` when a clique lacks one) and ``semantic_key`` maps the CURIE to a
+    frozenset of its most-specific TUIs. A CURIE is counted once per Biolink type even if it appears
+    in several cliques of that type; it counts toward ``single_umls_clique_count`` if it is ever seen
+    in a clique whose only member is that single UMLS identifier.
+
+    :param clusters: iterable of compendium clique dicts, each with a ``"type"`` (Biolink type),
+        optional ``"preferred_name"``, and an ``"identifiers"`` list of ``{"i": curie, "l": label,
+        ...}`` entries.
+    :param semantic_key: callable mapping a UMLS CURIE to a frozenset of TUIs.
+    :param fallback_biolink_type: Biolink type to use for a clique missing a ``"type"`` field
+        (normally the filename-derived type, e.g. ``MolecularMixture.txt`` -> ``biolink:MolecularMixture``).
+    :param sample_limit: max ``(curie, label)`` samples kept per bucket.
+    :return: ``(breakdown, occ_by_curie)`` where ``breakdown`` maps ``(biolink_type, frozenset(TUIs))``
+        to ``[unique_curie_count, single_umls_clique_count, [(curie, label), ...]]`` and
+        ``occ_by_curie`` maps each UMLS CURIE seen in this compendium to the set of its occurrences
+        ``(biolink_type, clique_leader, preferred_name, label)`` (one per distinct clique it lands in,
+        for cross-/within-compendium duplicate detection).
+    """
+    occ_by_curie = defaultdict(set)
     labels_by_id = dict()
+    seen_pairs = set()  # (biolink_type, curie) already counted toward a bucket
+    single_pairs = set()  # (biolink_type, curie) ever seen in a single-UMLS clique
+    ordered_pairs = []  # (biolink_type, curie) in first-seen order, for stable sampling
     for cluster in clusters:
         identifiers = cluster["identifiers"]
+        biolink_type = cluster.get("type") or fallback_biolink_type
+        leader = identifiers[0]["i"] if identifiers else ""
+        preferred_name = cluster.get("preferred_name", "")
         umls_in_clique = [identifier["i"] for identifier in identifiers if identifier["i"].startswith(_UMLS_PREFIX)]
-        umls_ids.update(umls_in_clique)
+        is_single = len(identifiers) == 1 and len(umls_in_clique) == 1
         for identifier in identifiers:
-            if identifier["i"].startswith(_UMLS_PREFIX) and identifier["i"] not in labels_by_id:
-                labels_by_id[identifier["i"]] = identifier.get("l", "")
-        if len(identifiers) == 1 and len(umls_in_clique) == 1:
-            single_umls_ids.add(umls_in_clique[0])
+            curie = identifier["i"]
+            if not curie.startswith(_UMLS_PREFIX):
+                continue
+            label = identifier.get("l", "")
+            if curie not in labels_by_id:
+                labels_by_id[curie] = label
+            occ_by_curie[curie].add((biolink_type, leader, preferred_name, label))
+            pair = (biolink_type, curie)
+            if pair not in seen_pairs:
+                seen_pairs.add(pair)
+                ordered_pairs.append(pair)
+            if is_single:
+                single_pairs.add(pair)
 
     breakdown = defaultdict(lambda: [0, 0, []])
-    for umls_id in umls_ids:
-        entry = breakdown[semantic_key(umls_id)]
+    for biolink_type, curie in ordered_pairs:
+        entry = breakdown[(biolink_type, semantic_key(curie))]
         entry[0] += 1
-        if umls_id in single_umls_ids:
+        if (biolink_type, curie) in single_pairs:
             entry[1] += 1
         if len(entry[2]) < sample_limit:
-            entry[2].append((umls_id, labels_by_id.get(umls_id, "")))
-    return breakdown, umls_ids
+            entry[2].append((curie, labels_by_id.get(curie, "")))
+    return breakdown, occ_by_curie
 
 
 def write_leftover_umls(
@@ -275,11 +375,10 @@ def write_leftover_umls(
             ) from e
     logger.info(f"Preflight passed: all {len(output_types)} override output types are writable.")
 
-    # For now, we have many more UMLS entities in MRCONSO than in the compendia, so
-    # we'll make an in-memory list of those first. Once that flips, this should be
-    # switched to the other way around (or perhaps written into an in-memory database
-    # of some sort).
-    umls_ids_in_other_compendia = set()
+    # For now, we have many more UMLS entities in MRCONSO than in the compendia, so we'll collect the
+    # latter first (into the DuplicateUmlsTracker built below, which doubles as the membership set).
+    # Once that flips, this should be switched to the other way around (or perhaps written into an
+    # in-memory database of some sort).
 
     # If we were interested in keeping all UMLS labels, we would create an identifier file as described in
     # babel_utils.read_identifier_file() and then glom them with babel_utils.glom(). However, for this initial
@@ -340,30 +439,41 @@ def write_leftover_umls(
             tuis = set(types_by_id.get(umls_id, {}).keys())
             return frozenset(reduce_to_most_specific_tree_codes(tuis, tui_to_tree))
 
-        # Per-compendium UMLS coverage, broken down by most-specific semantic-type set. The key is
-        # (compendium name, frozenset of TUIs); the value is [unique CURIE count, single-UMLS-clique
-        # count, up to _SAMPLE_LIMIT (CURIE, label) samples]. This answers "where does UMLS go inside
-        # Babel, by semantic type" -- summing curie_count over a compendium reproduces its total. The
-        # leftover umls.txt compendium is added in the MRCONSO sweep below, so this one CSV spans every
-        # compendium that consumes UMLS.
-        semantic_breakdown: dict[tuple[str, frozenset], list] = defaultdict(lambda: [0, 0, []])
+        # Per-compendium UMLS coverage, broken down by Biolink type and most-specific semantic-type
+        # set. The key is (compendium name, biolink_type, frozenset of TUIs); the value is [unique
+        # CURIE count, single-UMLS-clique count, up to _SAMPLE_LIMIT (CURIE, label) samples]. This
+        # answers "where does UMLS go inside Babel, by Biolink type and semantic type" -- summing
+        # curie_count over a compendium reproduces its total. The leftover umls.txt compendium is added
+        # in the MRCONSO sweep below, so this one CSV spans every compendium that consumes UMLS.
+        semantic_breakdown: dict[tuple[str, str, frozenset], list] = defaultdict(lambda: [0, 0, []])
+
+        # Cross-/within-compendium duplicate-CURIE detector; also serves as the membership set used to
+        # skip already-claimed UMLS concepts during the MRCONSO sweep below.
+        duplicate_tracker = DuplicateUmlsTracker()
 
         for compendium in compendia:
             logger.info(f"Starting compendium: {compendium}")
             name = Path(compendium).name
+            # Biolink type to assume for any clique missing a "type" field (each compendium file is
+            # named for its Biolink type, e.g. MolecularMixture.txt -> biolink:MolecularMixture).
+            fallback_biolink_type = "biolink:" + name.removesuffix(".txt")
             with open(compendium) as f:
-                breakdown, umls_ids = summarize_compendium_umls_by_semantic_type(
-                    (json.loads(row) for row in f), semantic_key
+                breakdown, occ_by_curie = summarize_compendium_umls_by_semantic_type(
+                    (json.loads(row) for row in f), semantic_key, fallback_biolink_type=fallback_biolink_type
                 )
-            for key, (count, single_count, samples) in breakdown.items():
-                entry = semantic_breakdown[(name, key)]
+            for (biolink_type, key), (count, single_count, samples) in breakdown.items():
+                entry = semantic_breakdown[(name, biolink_type, key)]
                 entry[0] += count
                 entry[1] += single_count
                 entry[2].extend(samples[: _SAMPLE_LIMIT - len(entry[2])])
 
-            logger.info(f"Completed compendium {compendium} with {len(umls_ids)} UMLS IDs")
-            umls_ids_in_other_compendia.update(umls_ids)
+            for curie, occurrences in occ_by_curie.items():
+                for biolink_type, leader, preferred_name, label in occurrences:
+                    duplicate_tracker.record(curie, name, biolink_type, leader, preferred_name, label)
 
+            logger.info(f"Completed compendium {compendium} with {len(occ_by_curie)} UMLS IDs")
+
+        umls_ids_in_other_compendia = duplicate_tracker
         logger.info(f"Completed all compendia with {len(umls_ids_in_other_compendia)} UMLS IDs.")
         reportf.write(f"COMPLETED All compendia with {len(umls_ids_in_other_compendia)} UMLS IDs.\n")
 
@@ -397,8 +507,8 @@ def write_leftover_umls(
         # of MRCONSO lines. The exhaustive per-CURIE record lives elsewhere: kept concepts in
         # compendia/umls.txt, skipped concepts in log.txt (NO_UMLS_TYPE / REJECTED / MULTIPLE_UMLS_TYPES).
         # See docs/sources/UMLS/Leftover.md ("Counts vs. samples"). (_SAMPLE_LIMIT defined above.)
-        type_counts: dict[str, int] = defaultdict(int)
-        type_samples: dict[str, list] = defaultdict(list)
+        # The per-Biolink-type leftover counts are no longer accumulated here: they are derivable from
+        # compendium-coverage.csv (filter compendium == umls.txt, sum curie_count per biolink_type).
         unmapped_tui_counts: dict[str, int] = defaultdict(int)
         unmapped_tui_examples: dict[str, list] = defaultdict(list)
         rejected_tui_counts: dict[str, int] = defaultdict(int)
@@ -509,14 +619,11 @@ def write_leftover_umls(
                 # Let write_compendium() generate this singleton's compendium and synonym JSON.
                 leftover_umls_cliques.append(TypedClique(node_type=biolink_type, identifiers=[umls_id]))
                 umls_ids_in_this_compendium.add(umls_id)
-                type_counts[biolink_type] += 1
-                if len(type_samples[biolink_type]) < _SAMPLE_LIMIT:
-                    type_samples[biolink_type].append((umls_id, label))
 
                 # Also record this leftover concept in the per-compendium semantic-type breakdown, so
                 # umls.txt appears alongside the input compendia. Every leftover clique is a single
                 # UMLS identifier, so it counts toward single_umls_clique_count too.
-                leftover_entry = semantic_breakdown[(leftover_compendium_name, semantic_key(umls_id))]
+                leftover_entry = semantic_breakdown[(leftover_compendium_name, biolink_type, semantic_key(umls_id))]
                 leftover_entry[0] += 1
                 leftover_entry[1] += 1
                 if len(leftover_entry[2]) < _SAMPLE_LIMIT:
@@ -539,29 +646,89 @@ def write_leftover_umls(
         logger.info(f"Writing {len(leftover_umls_cliques)} leftover UMLS cliques with write_compendium().")
         reportf.write(f"COUNT Writing {len(leftover_umls_cliques)} leftover UMLS cliques with write_compendium().\n")
 
-        # Per-compendium UMLS coverage, broken down by most-specific UMLS semantic-type set. One row
-        # per (compendium, TUI set). TUIs and tree numbers are emitted as codes (no labels) so the
-        # grouping is scannable at a glance; tui-sty.tsv is the code -> label lookup. Summing
-        # curie_count over a compendium reproduces its total unique UMLS count.
+        # Per-compendium UMLS coverage, broken down by Biolink type and most-specific UMLS
+        # semantic-type set. One row per (compendium, biolink_type, TUI set). TUIs and tree numbers are
+        # emitted as codes (no labels) so the grouping is scannable at a glance; tui-sty.tsv is the
+        # code -> label lookup. Summing curie_count over a compendium reproduces its total unique UMLS
+        # count. The same rows are written twice with different sort orders: compendium-coverage.csv is
+        # grouped compendium-first ("what's in compendium X, by type?"); tui-coverage.csv is grouped
+        # TUI-set-first ("where does semantic type T047 go across Babel?").
+        coverage_rows = []
+        for name, biolink_type, key in semantic_breakdown.keys():
+            curie_count, single_count, samples = semantic_breakdown[(name, biolink_type, key)]
+            sorted_tuis = sorted(key)
+            tui_set, tui_set_labels, tree_set = _format_tui_set(sorted_tuis, types_by_tui, tui_to_tree)
+            coverage_rows.append(
+                (
+                    name,
+                    biolink_type,
+                    sorted_tuis,
+                    tui_set,
+                    tui_set_labels,
+                    tree_set,
+                    curie_count,
+                    single_count,
+                    _format_samples(samples),
+                )
+            )
+
         with open(report_dir / "compendium-coverage.csv", "w", newline="") as csvf:
             writer = csv.writer(csvf)
             writer.writerow(
-                ["compendium", "tui_set", "tui_set_labels", "tree_set", "curie_count", "single_umls_clique_count", "sample_curies"]
+                [
+                    "compendium",
+                    "biolink_type",
+                    "tui_set",
+                    "tui_set_labels",
+                    "tree_set",
+                    "curie_count",
+                    "single_umls_clique_count",
+                    "sample_curies",
+                ]
             )
-            for name, key in sorted(semantic_breakdown.keys(), key=lambda nk: (nk[0], sorted(nk[1]))):
-                curie_count, single_count, samples = semantic_breakdown[(name, key)]
-                sorted_tuis = sorted(key)
-                tui_set = "|".join(sorted_tuis) if sorted_tuis else "(none)"
-                tui_set_labels = "|".join("/".join(sorted(types_by_tui.get(tui, {""}))) for tui in sorted_tuis) if sorted_tuis else "(none)"
-                tree_set = "|".join(tui_to_tree.get(tui, "") for tui in sorted_tuis)
-                writer.writerow([name, tui_set, tui_set_labels, tree_set, curie_count, single_count, _format_samples(samples)])
+            for (
+                name,
+                biolink_type,
+                _sorted_tuis,
+                tui_set,
+                tui_set_labels,
+                tree_set,
+                curie_count,
+                single_count,
+                samples,
+            ) in sorted(coverage_rows, key=lambda r: (r[0], r[1], r[2])):
+                writer.writerow(
+                    [name, biolink_type, tui_set, tui_set_labels, tree_set, curie_count, single_count, samples]
+                )
 
-        # Per-Biolink-type leftover clique coverage, with a few sample CURIEs and labels.
-        with open(report_dir / "types-coverage.csv", "w", newline="") as csvf:
+        with open(report_dir / "tui-coverage.csv", "w", newline="") as csvf:
             writer = csv.writer(csvf)
-            writer.writerow(["biolink_type", "leftover_clique_count", "sample_curies"])
-            for biolink_type in sorted(type_counts.keys()):
-                writer.writerow([biolink_type, type_counts[biolink_type], _format_samples(type_samples[biolink_type])])
+            writer.writerow(
+                [
+                    "tui_set",
+                    "tui_set_labels",
+                    "tree_set",
+                    "compendium",
+                    "biolink_type",
+                    "curie_count",
+                    "single_umls_clique_count",
+                    "sample_curies",
+                ]
+            )
+            for (
+                name,
+                biolink_type,
+                _sorted_tuis,
+                tui_set,
+                tui_set_labels,
+                tree_set,
+                curie_count,
+                single_count,
+                samples,
+            ) in sorted(coverage_rows, key=lambda r: (r[2], r[0], r[1])):
+                writer.writerow(
+                    [tui_set, tui_set_labels, tree_set, name, biolink_type, curie_count, single_count, samples]
+                )
 
         # Semantic types we couldn't map or deliberately rejected, with affected CUI counts and samples.
         with open(report_dir / "unmapped-types.csv", "w", newline="") as csvf:
@@ -583,6 +750,45 @@ def write_leftover_umls(
                 writer.writerow(
                     ["|".join(sorted(key)), multi_type_counts[key], _format_samples(multi_type_samples[key])]
                 )
+
+        # UMLS CURIEs that landed in more than one compendium clique -- either across two compendium
+        # files (cross-file) or in two distinct cliques of one file (within-file). Both are glom/merge
+        # bugs (https://github.com/NCATSTranslator/Babel/issues/276); the occurrences column carries the
+        # provenance (compendium, Biolink type, clique leader, preferred name) needed to trace each one
+        # back to the upstream concord that pulled the CURIE into two cliques. One row per CURIE.
+        duplicate_count = 0
+        with open(report_dir / "duplicate-curies.csv", "w", newline="") as csvf:
+            writer = csv.writer(csvf)
+            writer.writerow(
+                [
+                    "umls_curie",
+                    "umls_label",
+                    "tui_set",
+                    "tui_set_labels",
+                    "num_compendia",
+                    "num_distinct_cliques",
+                    "duplicate_scope",
+                    "occurrences",
+                ]
+            )
+            for curie, occurrences, scope in duplicate_tracker.duplicates():
+                duplicate_count += 1
+                # The CURIE's own UMLS label, taken from any occurrence that recorded one.
+                umls_label = next((occ[4] for occ in occurrences if occ[4]), "")
+                sorted_tuis = sorted(semantic_key(curie))
+                tui_set, tui_set_labels, _tree_set = _format_tui_set(sorted_tuis, types_by_tui, tui_to_tree)
+                num_compendia = len({occ[0] for occ in occurrences})
+                num_distinct_cliques = len({(occ[0], occ[2]) for occ in occurrences})
+                rendered = "; ".join(
+                    f"{comp}[{btype}, leader={leader}, name={pref_name}]"
+                    for comp, btype, leader, pref_name, _label in sorted(occurrences)
+                )
+                writer.writerow(
+                    [curie, umls_label, tui_set, tui_set_labels, num_compendia, num_distinct_cliques, scope, rendered]
+                )
+
+        logger.info(f"Found {duplicate_count} UMLS CURIEs duplicated across or within compendia.")
+        reportf.write(f"COUNT Found {duplicate_count} UMLS CURIEs duplicated across or within compendia.\n")
 
     write_compendium(
         metadata_yamls,

--- a/src/createcompendia/leftover_umls.py
+++ b/src/createcompendia/leftover_umls.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from src.babel_utils import TypedClique, write_compendium
 from src.categories import (
     ACTIVITY,
-    AGENT,
     BIOLOGICAL_PROCESS,
     CHEMICAL_ENTITY,
     CLINICAL_FINDING,
@@ -17,10 +16,8 @@ from src.categories import (
     GROSS_ANATOMICAL_STRUCTURE,
     NAMED_THING,
     PHENOMENON,
-    PHYSICAL_ENTITY,
     POPULATION_OF_INDIVIDUAL_ORGANISMS,
     PROCEDURE,
-    PUBLICATION,
     SMALL_MOLECULE,
 )
 from src.datahandlers import umls
@@ -95,8 +92,6 @@ STY_OVERRIDES: dict[str, str | None] = {
 TYPE_COMBO_OVERRIDES: dict[frozenset[str], str] = {
     frozenset({DEVICE, DRUG}): DRUG,
     frozenset({DRUG, SMALL_MOLECULE}): SMALL_MOLECULE,
-    frozenset({AGENT, PHYSICAL_ENTITY}): AGENT,
-    frozenset({PHYSICAL_ENTITY, PUBLICATION}): PUBLICATION,
     frozenset({ACTIVITY, PROCEDURE}): PROCEDURE,
     frozenset({DRUG, FOOD}): FOOD,
     # https://github.com/NCATSTranslator/Babel/issues/569

--- a/src/node.py
+++ b/src/node.py
@@ -464,14 +464,21 @@ class NodeFactory:
         self.ancestor_map[input_type] = ancs
         return ancs
 
-    def get_prefixes(self, input_type):
+    def get_prefixes(self, input_type, allow_empty=False):
         if input_type in self.prefix_map:
             return self.prefix_map[input_type]
         logger.info(f"NodeFactory({self.label_dir}, {self.biolink_version}).get_prefixes({input_type}) called")
         j = self.toolkit.get_element(input_type)
         prefs = j["id_prefixes"]
         if len(prefs) == 0:
-            raise RuntimeError(f"No Biolink prefixes for {input_type}")
+            if not allow_empty:
+                raise RuntimeError(f"No Biolink prefixes for {input_type}")
+            # Some Biolink types (e.g. biolink:Phenomenon, biolink:PhysicalEntity) carry no id_prefixes
+            # at all. A caller that supplies extra_prefixes (e.g. leftover_umls, which writes UMLS:xxx
+            # singletons with extra_prefixes=[UMLS]) can still write such a node, so we return [] instead
+            # of raising. We deliberately do NOT cache this empty result, so a later strict caller
+            # (allow_empty=False) for the same type still raises.
+            return []
         # The pref are in a particular order, but apparently they can have dups (ugh)
         # We de-duplicate those here.
         prefixes_deduplicated = list()
@@ -610,14 +617,20 @@ class NodeFactory:
         # This is where we will normalize, i.e. choose the best id, and add types in accord with BL.
         # we should also include provenance and version information for the node set build.
         # make sure prefixes list does not include duplicate prefixes
+        # When extra_prefixes are supplied, a node_type with no id_prefixes of its own is still
+        # writable, so we tolerate an empty get_prefixes() result and rely on extra_prefixes. The
+        # combined list is validated as non-empty below.
+        node_prefixes = self.get_prefixes(node_type, allow_empty=bool(extra_prefixes))
         prefixes = []
         seen_prefixes = set()
-        for prefix in self.get_prefixes(node_type) + extra_prefixes:
+        for prefix in node_prefixes + extra_prefixes:
             prefix_upper = prefix.upper()
             if prefix_upper in seen_prefixes:
                 continue
             prefixes.append(prefix)
             seen_prefixes.add(prefix_upper)
+        if len(prefixes) == 0:
+            raise RuntimeError(f"No Biolink prefixes for {node_type} and no extra_prefixes supplied")
 
         if len(input_identifiers) == 0:
             return None

--- a/src/node.py
+++ b/src/node.py
@@ -630,7 +630,7 @@ class NodeFactory:
             prefixes.append(prefix)
             seen_prefixes.add(prefix_upper)
         if len(prefixes) == 0:
-            raise RuntimeError(f"No Biolink prefixes for {node_type} and no extra_prefixes supplied")
+            raise RuntimeError(f"No Biolink prefixes for {node_type}: id_prefixes is empty and extra_prefixes is empty")
 
         if len(input_identifiers) == 0:
             return None

--- a/src/node.py
+++ b/src/node.py
@@ -466,18 +466,20 @@ class NodeFactory:
 
     def get_prefixes(self, input_type, allow_empty=False):
         if input_type in self.prefix_map:
-            return self.prefix_map[input_type]
+            cached = self.prefix_map[input_type]
+            if not cached and not allow_empty:
+                raise RuntimeError(f"No Biolink prefixes for {input_type}")
+            return cached
         logger.info(f"NodeFactory({self.label_dir}, {self.biolink_version}).get_prefixes({input_type}) called")
         j = self.toolkit.get_element(input_type)
         prefs = j["id_prefixes"]
         if len(prefs) == 0:
+            # Some Biolink types (e.g. biolink:Phenomenon, biolink:PhysicalEntity) carry no id_prefixes.
+            # Cache [] so repeated calls skip the toolkit lookup; strict callers (allow_empty=False)
+            # still raise, both on first call and from cache.
+            self.prefix_map[input_type] = []
             if not allow_empty:
                 raise RuntimeError(f"No Biolink prefixes for {input_type}")
-            # Some Biolink types (e.g. biolink:Phenomenon, biolink:PhysicalEntity) carry no id_prefixes
-            # at all. A caller that supplies extra_prefixes (e.g. leftover_umls, which writes UMLS:xxx
-            # singletons with extra_prefixes=[UMLS]) can still write such a node, so we return [] instead
-            # of raising. We deliberately do NOT cache this empty result, so a later strict caller
-            # (allow_empty=False) for the same type still raises.
             return []
         # The pref are in a particular order, but apparently they can have dups (ugh)
         # We de-duplicate those here.
@@ -617,10 +619,10 @@ class NodeFactory:
         # This is where we will normalize, i.e. choose the best id, and add types in accord with BL.
         # we should also include provenance and version information for the node set build.
         # make sure prefixes list does not include duplicate prefixes
-        # When extra_prefixes are supplied, a node_type with no id_prefixes of its own is still
-        # writable, so we tolerate an empty get_prefixes() result and rely on extra_prefixes. The
-        # combined list is validated as non-empty below.
-        node_prefixes = self.get_prefixes(node_type, allow_empty=bool(extra_prefixes))
+        # Always allow an empty get_prefixes() result here: a node_type with no id_prefixes of its
+        # own is still writable when extra_prefixes covers the gap. The combined list is validated
+        # as non-empty below, which produces a clearer error than an early raise inside get_prefixes.
+        node_prefixes = self.get_prefixes(node_type, allow_empty=True)
         prefixes = []
         seen_prefixes = set()
         for prefix in node_prefixes + extra_prefixes:

--- a/src/node.py
+++ b/src/node.py
@@ -629,7 +629,7 @@ class NodeFactory:
                 continue
             prefixes.append(prefix)
             seen_prefixes.add(prefix_upper)
-        if len(prefixes) == 0:
+        if not prefixes:
             raise RuntimeError(f"No Biolink prefixes for {node_type}: id_prefixes is empty and extra_prefixes is empty")
 
         if len(input_identifiers) == 0:

--- a/tests/createcompendia/test_leftover_umls.py
+++ b/tests/createcompendia/test_leftover_umls.py
@@ -8,7 +8,7 @@ These are marked ``network`` because they build a Biolink Model Toolkit, which f
 
 import pytest
 
-from src.categories import ACTIVITY, COHORT, PHENOMENON
+from src.categories import ACTIVITY, COHORT, PHENOMENON, PHYSICAL_ENTITY
 from src.createcompendia.leftover_umls import (
     STY_OVERRIDES,
     TYPE_COMBO_OVERRIDES,
@@ -35,6 +35,8 @@ RECORDED_STY_BASELINE: dict[str, str | None] = {
     "T090": None,  # https://github.com/NCATSTranslator/Babel/issues/817 -- "Occupation or Discipline": no STY mapping.
     "T091": None,  # https://github.com/NCATSTranslator/Babel/issues/817 -- "Biomedical Occupation or Discipline": no STY mapping.
     "T097": COHORT,  # https://github.com/NCATSTranslator/Babel/issues/817 -- "Professional or Occupational Group": bmt maps to Cohort, overridden to PopulationOfIndividualOrganisms for consistency.
+    "T072": PHYSICAL_ENTITY,  # "Physical Object": bmt maps to PhysicalEntity, which has no id_prefixes — rejected.
+    "T073": PHYSICAL_ENTITY,  # "Manufactured Object": bmt maps to PhysicalEntity, which has no id_prefixes — rejected.
 }
 
 

--- a/tests/createcompendia/test_leftover_umls.py
+++ b/tests/createcompendia/test_leftover_umls.py
@@ -13,6 +13,7 @@ from src.createcompendia.leftover_umls import (
     STY_OVERRIDES,
     TYPE_COMBO_OVERRIDES,
     apply_generic_demotion,
+    summarize_compendium_umls_by_semantic_type,
     tui_to_biolink_type,
     writable_output_types,
 )
@@ -134,3 +135,64 @@ def test_all_override_target_types_are_writable():
     for output_type in sorted(writable_output_types()):
         # Must not raise. (Returns None because input_identifiers is empty.)
         factory.create_node(input_identifiers=[], node_type=output_type, labels={}, extra_prefixes=[UMLS])
+
+
+@pytest.mark.unit
+def test_summarize_compendium_umls_by_semantic_type():
+    """The per-compendium semantic-type breakdown: unique CURIE counts, single-clique attribution,
+    sample capping, and bucketing by the (injected) most-specific TUI set. Offline -- semantic_key is
+    a stub, so no Biolink/MRSTY access is needed."""
+    # Stub semantic_key: a fixed CURIE -> most-specific TUI set mapping.
+    tuis_by_curie = {
+        "UMLS:C1": frozenset({"T047"}),
+        "UMLS:C2": frozenset({"T047"}),
+        "UMLS:C3": frozenset({"T047", "T191"}),
+        "UMLS:C4": frozenset(),  # no MRSTY entry
+    }
+
+    def semantic_key(curie):
+        return tuis_by_curie[curie]
+
+    clusters = [
+        # Single-identifier UMLS-only clique -> counts as a single clique.
+        {"identifiers": [{"i": "UMLS:C1", "l": "c1"}]},
+        # C2 sits with a non-UMLS partner -> not a single UMLS clique. C1 reappears (deduped).
+        {"identifiers": [{"i": "UMLS:C1", "l": "c1"}, {"i": "MESH:D2", "l": "m2"}, {"i": "UMLS:C2", "l": "c2"}]},
+        # Multi-TUI concept, single clique.
+        {"identifiers": [{"i": "UMLS:C3", "l": "c3"}]},
+        # Untyped concept, single clique; label intentionally missing.
+        {"identifiers": [{"i": "UMLS:C4"}]},
+    ]
+
+    breakdown, umls_ids = summarize_compendium_umls_by_semantic_type(clusters, semantic_key)
+
+    assert umls_ids == {"UMLS:C1", "UMLS:C2", "UMLS:C3", "UMLS:C4"}
+
+    # {T047}: C1 (single) + C2 (not single) = 2 CURIEs, 1 single.
+    count, single, samples = breakdown[frozenset({"T047"})]
+    assert count == 2
+    assert single == 1
+    assert sorted(samples) == [("UMLS:C1", "c1"), ("UMLS:C2", "c2")]
+
+    # {T047, T191}: just C3, in a single clique.
+    assert breakdown[frozenset({"T047", "T191"})] == [1, 1, [("UMLS:C3", "c3")]]
+
+    # Empty set (untyped): C4, missing label rendered as "".
+    assert breakdown[frozenset()] == [1, 1, [("UMLS:C4", "")]]
+
+    # Per-compendium total is reproduced by summing curie_count over buckets.
+    assert sum(entry[0] for entry in breakdown.values()) == len(umls_ids)
+
+
+@pytest.mark.unit
+def test_summarize_compendium_umls_caps_samples():
+    """Samples are capped at the module sample limit even when a bucket has many CURIEs."""
+    from src.createcompendia.leftover_umls import _SAMPLE_LIMIT
+
+    n = _SAMPLE_LIMIT + 4
+    clusters = [{"identifiers": [{"i": f"UMLS:C{i}", "l": f"c{i}"}]} for i in range(n)]
+    breakdown, umls_ids = summarize_compendium_umls_by_semantic_type(clusters, lambda curie: frozenset({"T047"}))
+    count, single, samples = breakdown[frozenset({"T047"})]
+    assert count == n
+    assert single == n
+    assert len(samples) == _SAMPLE_LIMIT

--- a/tests/createcompendia/test_leftover_umls.py
+++ b/tests/createcompendia/test_leftover_umls.py
@@ -35,8 +35,8 @@ RECORDED_STY_BASELINE: dict[str, str | None] = {
     "T090": None,  # https://github.com/NCATSTranslator/Babel/issues/817 -- "Occupation or Discipline": no STY mapping.
     "T091": None,  # https://github.com/NCATSTranslator/Babel/issues/817 -- "Biomedical Occupation or Discipline": no STY mapping.
     "T097": COHORT,  # https://github.com/NCATSTranslator/Babel/issues/817 -- "Professional or Occupational Group": bmt maps to Cohort, overridden to PopulationOfIndividualOrganisms for consistency.
-    "T072": PHYSICAL_ENTITY,  # "Physical Object": bmt maps to PhysicalEntity, which has no id_prefixes — rejected.
-    "T073": PHYSICAL_ENTITY,  # "Manufactured Object": bmt maps to PhysicalEntity, which has no id_prefixes — rejected.
+    "T072": PHYSICAL_ENTITY,  # https://github.com/NCATSTranslator/Babel/issues/840 -- "Physical Object": bmt maps to PhysicalEntity, which has no id_prefixes — rejected.
+    "T073": PHYSICAL_ENTITY,  # https://github.com/NCATSTranslator/Babel/issues/840 -- "Manufactured Object": bmt maps to PhysicalEntity, which has no id_prefixes — rejected.
 }
 
 

--- a/tests/createcompendia/test_leftover_umls.py
+++ b/tests/createcompendia/test_leftover_umls.py
@@ -10,9 +10,9 @@ import pytest
 
 from src.categories import ACTIVITY, COHORT, DRUG, PHENOMENON, PHYSICAL_ENTITY
 from src.createcompendia.leftover_umls import (
-    GENERIC_TYPES,
     STY_OVERRIDES,
     TYPE_COMBO_OVERRIDES,
+    apply_generic_demotion,
     tui_to_biolink_type,
     writable_output_types,
 )
@@ -117,12 +117,7 @@ def test_type_combo_overrides_reference_real_biolink_classes():
 )
 def test_generic_types_demotion(input_types, expected):
     """GENERIC_TYPES are dropped when a more specific co-type is present; kept when alone."""
-    if len(input_types) > 1:
-        specific_types = input_types - GENERIC_TYPES
-        result = specific_types if specific_types else input_types
-    else:
-        result = input_types
-    assert result == expected
+    assert apply_generic_demotion(input_types) == expected
 
 
 @pytest.mark.network

--- a/tests/createcompendia/test_leftover_umls.py
+++ b/tests/createcompendia/test_leftover_umls.py
@@ -8,8 +8,9 @@ These are marked ``network`` because they build a Biolink Model Toolkit, which f
 
 import pytest
 
-from src.categories import ACTIVITY, COHORT, PHENOMENON, PHYSICAL_ENTITY
+from src.categories import ACTIVITY, COHORT, DRUG, PHENOMENON, PHYSICAL_ENTITY
 from src.createcompendia.leftover_umls import (
+    GENERIC_TYPES,
     STY_OVERRIDES,
     TYPE_COMBO_OVERRIDES,
     tui_to_biolink_type,
@@ -98,6 +99,30 @@ def test_type_combo_overrides_reference_real_biolink_classes():
         assert toolkit.get_element(biolink_type) is not None, (
             f"{biolink_type} is not a class in Biolink {BIOLINK_VERSION}"
         )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "input_types, expected",
+    [
+        # Generic type alongside a specific type: generic is dropped.
+        ({PHYSICAL_ENTITY, DRUG}, {DRUG}),
+        # Generic type alone: kept as-is (no specific co-type to prefer).
+        ({PHYSICAL_ENTITY}, {PHYSICAL_ENTITY}),
+        # Two non-generic types: demotion does not fire.
+        ({DRUG, PHENOMENON}, {DRUG, PHENOMENON}),
+        # Single non-generic type: unchanged.
+        ({DRUG}, {DRUG}),
+    ],
+)
+def test_generic_types_demotion(input_types, expected):
+    """GENERIC_TYPES are dropped when a more specific co-type is present; kept when alone."""
+    if len(input_types) > 1:
+        specific_types = input_types - GENERIC_TYPES
+        result = specific_types if specific_types else input_types
+    else:
+        result = input_types
+    assert result == expected
 
 
 @pytest.mark.network

--- a/tests/createcompendia/test_leftover_umls.py
+++ b/tests/createcompendia/test_leftover_umls.py
@@ -71,10 +71,16 @@ def test_sty_overrides_have_not_drifted():
         baseline = RECORDED_STY_BASELINE[tui]
         if tui in INTENTIONAL_BIOLINK_PINS:
             # We deliberately pin these to the Biolink value, so "override == live mapping" is
-            # expected, not redundant. Only check that Biolink hasn't drifted from the baseline.
+            # expected, not redundant. Check both that Biolink hasn't drifted from the baseline
+            # and that the override itself still matches the baseline (guards against accidental
+            # changes to STY_OVERRIDES that would silently break the pin).
             assert current == baseline, (
                 f"Biolink STY:{tui} now maps to {current!r}, but the recorded baseline is {baseline!r}. "
                 f"Re-review the intentional pin (currently {override!r}) and update RECORDED_STY_BASELINE."
+            )
+            assert override == baseline, (
+                f"STY_OVERRIDES[{tui!r}] is {override!r} but an intentional pin must match the Biolink "
+                f"baseline {baseline!r}. Restore the override or remove {tui!r} from INTENTIONAL_BIOLINK_PINS."
             )
             continue
         if current == override:

--- a/tests/createcompendia/test_leftover_umls.py
+++ b/tests/createcompendia/test_leftover_umls.py
@@ -13,7 +13,10 @@ from src.createcompendia.leftover_umls import (
     STY_OVERRIDES,
     TYPE_COMBO_OVERRIDES,
     tui_to_biolink_type,
+    writable_output_types,
 )
+from src.node import NodeFactory
+from src.prefixes import UMLS
 from src.util import get_biolink_model_toolkit, get_config
 
 BIOLINK_VERSION = get_config()["biolink_version"]
@@ -35,9 +38,14 @@ RECORDED_STY_BASELINE: dict[str, str | None] = {
     "T090": None,  # https://github.com/NCATSTranslator/Babel/issues/817 -- "Occupation or Discipline": no STY mapping.
     "T091": None,  # https://github.com/NCATSTranslator/Babel/issues/817 -- "Biomedical Occupation or Discipline": no STY mapping.
     "T097": COHORT,  # https://github.com/NCATSTranslator/Babel/issues/817 -- "Professional or Occupational Group": bmt maps to Cohort, overridden to PopulationOfIndividualOrganisms for consistency.
-    "T072": PHYSICAL_ENTITY,  # https://github.com/NCATSTranslator/Babel/issues/840 -- "Physical Object": bmt maps to PhysicalEntity, which has no id_prefixes — rejected.
-    "T073": PHYSICAL_ENTITY,  # https://github.com/NCATSTranslator/Babel/issues/840 -- "Manufactured Object": bmt maps to PhysicalEntity, which has no id_prefixes — rejected.
+    "T072": PHYSICAL_ENTITY,  # https://github.com/NCATSTranslator/Babel/issues/840 -- "Physical Object": kept as PhysicalEntity (writable via extra_prefixes=[UMLS]).
+    "T073": PHYSICAL_ENTITY,  # https://github.com/NCATSTranslator/Babel/issues/840 -- "Manufactured Object": kept as PhysicalEntity (writable via extra_prefixes=[UMLS]).
 }
+
+# STY codes whose override is intentionally pinned to the raw Biolink mapping (rather than correcting
+# it). For these the drift test must NOT treat "override == live Biolink mapping" as redundant: we
+# keep the explicit entry so the type participates in GENERIC_TYPES demotion in leftover_umls.py.
+INTENTIONAL_BIOLINK_PINS: frozenset[str] = frozenset({"T072", "T073"})
 
 
 @pytest.mark.network
@@ -58,6 +66,14 @@ def test_sty_overrides_have_not_drifted():
     for tui, override in STY_OVERRIDES.items():
         current = tui_to_biolink_type(tui, toolkit=toolkit)
         baseline = RECORDED_STY_BASELINE[tui]
+        if tui in INTENTIONAL_BIOLINK_PINS:
+            # We deliberately pin these to the Biolink value, so "override == live mapping" is
+            # expected, not redundant. Only check that Biolink hasn't drifted from the baseline.
+            assert current == baseline, (
+                f"Biolink STY:{tui} now maps to {current!r}, but the recorded baseline is {baseline!r}. "
+                f"Re-review the intentional pin (currently {override!r}) and update RECORDED_STY_BASELINE."
+            )
+            continue
         if current == override:
             pytest.fail(
                 f"Biolink STY:{tui} now maps to {current!r}, which equals the manual override. "
@@ -82,3 +98,19 @@ def test_type_combo_overrides_reference_real_biolink_classes():
         assert toolkit.get_element(biolink_type) is not None, (
             f"{biolink_type} is not a class in Biolink {BIOLINK_VERSION}"
         )
+
+
+@pytest.mark.network
+def test_all_override_target_types_are_writable():
+    """
+    Reproduces the production failure in seconds: every Biolink type the leftover UMLS rule can emit
+    from its manual override tables must be writable by NodeFactory.create_node() when the rule's
+    extra_prefixes=[UMLS] is supplied. Some of these (e.g. biolink:Phenomenon, biolink:PhysicalEntity)
+    have no id_prefixes of their own; before the fix these raised "No Biolink prefixes for ..." deep
+    inside write_compendium() after a ~5h HPC run. create_node() with empty identifiers exercises the
+    same get_prefixes() call and then returns None without touching any labels or files.
+    """
+    factory = NodeFactory(label_dir=None, biolink_version=BIOLINK_VERSION)
+    for output_type in sorted(writable_output_types()):
+        # Must not raise. (Returns None because input_identifiers is empty.)
+        factory.create_node(input_identifiers=[], node_type=output_type, labels={}, extra_prefixes=[UMLS])

--- a/tests/createcompendia/test_leftover_umls.py
+++ b/tests/createcompendia/test_leftover_umls.py
@@ -12,6 +12,7 @@ from src.categories import ACTIVITY, COHORT, DRUG, PHENOMENON, PHYSICAL_ENTITY
 from src.createcompendia.leftover_umls import (
     STY_OVERRIDES,
     TYPE_COMBO_OVERRIDES,
+    DuplicateUmlsTracker,
     apply_generic_demotion,
     summarize_compendium_umls_by_semantic_type,
     tui_to_biolink_type,
@@ -139,9 +140,9 @@ def test_all_override_target_types_are_writable():
 
 @pytest.mark.unit
 def test_summarize_compendium_umls_by_semantic_type():
-    """The per-compendium semantic-type breakdown: unique CURIE counts, single-clique attribution,
-    sample capping, and bucketing by the (injected) most-specific TUI set. Offline -- semantic_key is
-    a stub, so no Biolink/MRSTY access is needed."""
+    """The per-compendium breakdown: unique CURIE counts, single-clique attribution, bucketing by
+    (Biolink type, most-specific TUI set), the filename fallback type, and the per-CURIE occurrence
+    map. Offline -- semantic_key is a stub, so no Biolink/MRSTY access is needed."""
     # Stub semantic_key: a fixed CURIE -> most-specific TUI set mapping.
     tuis_by_curie = {
         "UMLS:C1": frozenset({"T047"}),
@@ -155,33 +156,59 @@ def test_summarize_compendium_umls_by_semantic_type():
 
     clusters = [
         # Single-identifier UMLS-only clique -> counts as a single clique.
-        {"identifiers": [{"i": "UMLS:C1", "l": "c1"}]},
+        {"type": "biolink:Disease", "preferred_name": "C1", "identifiers": [{"i": "UMLS:C1", "l": "c1"}]},
         # C2 sits with a non-UMLS partner -> not a single UMLS clique. C1 reappears (deduped).
-        {"identifiers": [{"i": "UMLS:C1", "l": "c1"}, {"i": "MESH:D2", "l": "m2"}, {"i": "UMLS:C2", "l": "c2"}]},
+        {
+            "type": "biolink:Disease",
+            "identifiers": [{"i": "UMLS:C1", "l": "c1"}, {"i": "MESH:D2", "l": "m2"}, {"i": "UMLS:C2", "l": "c2"}],
+        },
         # Multi-TUI concept, single clique.
-        {"identifiers": [{"i": "UMLS:C3", "l": "c3"}]},
-        # Untyped concept, single clique; label intentionally missing.
+        {"type": "biolink:Disease", "identifiers": [{"i": "UMLS:C3", "l": "c3"}]},
+        # Untyped concept (no "type"): falls back to the supplied filename type. Label missing.
         {"identifiers": [{"i": "UMLS:C4"}]},
     ]
 
-    breakdown, umls_ids = summarize_compendium_umls_by_semantic_type(clusters, semantic_key)
+    breakdown, occ_by_curie = summarize_compendium_umls_by_semantic_type(
+        clusters, semantic_key, fallback_biolink_type="biolink:Disease"
+    )
 
-    assert umls_ids == {"UMLS:C1", "UMLS:C2", "UMLS:C3", "UMLS:C4"}
+    assert set(occ_by_curie.keys()) == {"UMLS:C1", "UMLS:C2", "UMLS:C3", "UMLS:C4"}
+    # Each occurrence is (biolink_type, clique_leader, preferred_name, label). C1 is in two Disease
+    # cliques both led by UMLS:C1, so it has a single distinct (biolink_type, leader) membership.
+    assert {(occ[0], occ[1]) for occ in occ_by_curie["UMLS:C1"]} == {("biolink:Disease", "UMLS:C1")}
+    # C4 picked up the fallback type because its clique had no "type" field.
+    assert occ_by_curie["UMLS:C4"] == {("biolink:Disease", "UMLS:C4", "", "")}
 
-    # {T047}: C1 (single) + C2 (not single) = 2 CURIEs, 1 single.
-    count, single, samples = breakdown[frozenset({"T047"})]
+    # ("biolink:Disease", {T047}): C1 (single) + C2 (not single) = 2 CURIEs, 1 single.
+    count, single, samples = breakdown[("biolink:Disease", frozenset({"T047"}))]
     assert count == 2
     assert single == 1
     assert sorted(samples) == [("UMLS:C1", "c1"), ("UMLS:C2", "c2")]
 
-    # {T047, T191}: just C3, in a single clique.
-    assert breakdown[frozenset({"T047", "T191"})] == [1, 1, [("UMLS:C3", "c3")]]
+    # ("biolink:Disease", {T047, T191}): just C3, in a single clique.
+    assert breakdown[("biolink:Disease", frozenset({"T047", "T191"}))] == [1, 1, [("UMLS:C3", "c3")]]
 
-    # Empty set (untyped): C4, missing label rendered as "".
-    assert breakdown[frozenset()] == [1, 1, [("UMLS:C4", "")]]
+    # Empty set (untyped), fallback Biolink type: C4, missing label rendered as "".
+    assert breakdown[("biolink:Disease", frozenset())] == [1, 1, [("UMLS:C4", "")]]
 
     # Per-compendium total is reproduced by summing curie_count over buckets.
-    assert sum(entry[0] for entry in breakdown.values()) == len(umls_ids)
+    assert sum(entry[0] for entry in breakdown.values()) == len(occ_by_curie)
+
+
+@pytest.mark.unit
+def test_summarize_compendium_umls_splits_by_biolink_type():
+    """A CURIE that appears under two Biolink types is counted once per type (one bucket each)."""
+    clusters = [
+        {"type": "biolink:Drug", "identifiers": [{"i": "UMLS:C1", "l": "c1"}]},
+        {"type": "biolink:ChemicalEntity", "identifiers": [{"i": "UMLS:C1", "l": "c1"}]},
+    ]
+    breakdown, occ_by_curie = summarize_compendium_umls_by_semantic_type(
+        clusters, lambda curie: frozenset({"T047"}), fallback_biolink_type="biolink:ChemicalEntity"
+    )
+    assert breakdown[("biolink:Drug", frozenset({"T047"}))] == [1, 1, [("UMLS:C1", "c1")]]
+    assert breakdown[("biolink:ChemicalEntity", frozenset({"T047"}))] == [1, 1, [("UMLS:C1", "c1")]]
+    # The CURIE records a distinct occurrence under each Biolink type.
+    assert len(occ_by_curie["UMLS:C1"]) == 2
 
 
 @pytest.mark.unit
@@ -190,9 +217,54 @@ def test_summarize_compendium_umls_caps_samples():
     from src.createcompendia.leftover_umls import _SAMPLE_LIMIT
 
     n = _SAMPLE_LIMIT + 4
-    clusters = [{"identifiers": [{"i": f"UMLS:C{i}", "l": f"c{i}"}]} for i in range(n)]
-    breakdown, umls_ids = summarize_compendium_umls_by_semantic_type(clusters, lambda curie: frozenset({"T047"}))
-    count, single, samples = breakdown[frozenset({"T047"})]
+    clusters = [{"type": "biolink:Disease", "identifiers": [{"i": f"UMLS:C{i}", "l": f"c{i}"}]} for i in range(n)]
+    breakdown, occ_by_curie = summarize_compendium_umls_by_semantic_type(
+        clusters, lambda curie: frozenset({"T047"}), fallback_biolink_type="biolink:Disease"
+    )
+    count, single, samples = breakdown[("biolink:Disease", frozenset({"T047"}))]
     assert count == n
     assert single == n
     assert len(samples) == _SAMPLE_LIMIT
+
+
+@pytest.mark.unit
+def test_duplicate_umls_tracker():
+    """DuplicateUmlsTracker flags cross-file and within-file duplicate UMLS CURIEs and nothing else."""
+    tracker = DuplicateUmlsTracker()
+
+    # Seen once -> not a duplicate, but is a member.
+    tracker.record("UMLS:C1", "Disease.txt", "biolink:Disease", "UMLS:C1", "C1", "c1")
+    # Re-seen in the *same* clique (e.g. another MRCONSO row) -> still not a duplicate.
+    tracker.record("UMLS:C1", "Disease.txt", "biolink:Disease", "UMLS:C1", "C1", "c1")
+
+    # Cross-file: same CURIE in two different compendium files.
+    tracker.record("UMLS:C2", "Disease.txt", "biolink:Disease", "MONDO:1", "d", "lbl")
+    tracker.record("UMLS:C2", "ChemicalEntity.txt", "biolink:ChemicalEntity", "CHEBI:1", "c", "lbl")
+
+    # Within-file: same CURIE in two distinct cliques of one file (different leaders).
+    tracker.record("UMLS:C3", "Disease.txt", "biolink:Disease", "MONDO:2", "x", "lbl")
+    tracker.record("UMLS:C3", "Disease.txt", "biolink:Disease", "MONDO:3", "y", "lbl")
+
+    # Both: cross-file *and* within-file.
+    tracker.record("UMLS:C4", "Disease.txt", "biolink:Disease", "MONDO:4", "p", "lbl")
+    tracker.record("UMLS:C4", "Disease.txt", "biolink:Disease", "MONDO:5", "q", "lbl")
+    tracker.record("UMLS:C4", "PhenotypicFeature.txt", "biolink:PhenotypicFeature", "HP:1", "r", "lbl")
+
+    # Membership and count cover every CURIE seen, duplicate or not.
+    assert "UMLS:C1" in tracker
+    assert "UMLS:C9" not in tracker
+    assert len(tracker) == 4
+
+    dups = {curie: scope for curie, _occ, scope in tracker.duplicates()}
+    assert dups == {
+        "UMLS:C2": "cross-file",
+        "UMLS:C3": "within-file",
+        "UMLS:C4": "both",
+    }
+
+    # duplicates() is sorted by CURIE.
+    assert [curie for curie, _occ, _scope in tracker.duplicates()] == ["UMLS:C2", "UMLS:C3", "UMLS:C4"]
+
+    # Occurrences are de-duped by (compendium, leader): C4 has 3 distinct cliques.
+    occ_by_curie = {curie: occ for curie, occ, _scope in tracker.duplicates()}
+    assert len({(o[0], o[2]) for o in occ_by_curie["UMLS:C4"]}) == 3

--- a/tests/test_babel_utils.py
+++ b/tests/test_babel_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from src.babel_utils import parse_rdf_literal
+from src.babel_utils import parse_rdf_literal, reduce_to_most_specific_tree_codes
 
 
 @pytest.mark.unit
@@ -24,3 +24,43 @@ from src.babel_utils import parse_rdf_literal
 )
 def test_parse_rdf_literal(literal, expected):
     assert parse_rdf_literal(literal) == expected
+
+
+# Tree numbers borrowed from real MRSTY STN values (see src/datahandlers/umls.py).
+_UMLS_TREES = {
+    "T116": "A1.4.1.2.1.7",  # Amino Acid, Peptide, or Protein
+    "T121": "A1.4.1.1.1",  # Pharmacologic Substance
+    "T130": "A1.4.1.1.4",  # Indicator, Reagent, or Diagnostic Aid
+    "T109": "A1.4.1.2.1",  # Organic Chemical  (ancestor of T116's A1.4.1.2.1.7)
+    "T123": "A1.4.1.1.3",  # Biologically Active Substance (ancestor of T126)
+    "T126": "A1.4.1.1.3.3",  # Enzyme
+}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "codes,code_to_tree,expected",
+    [
+        # Empty input.
+        (set(), _UMLS_TREES, set()),
+        # Single code is always kept.
+        ({"T116"}, _UMLS_TREES, {"T116"}),
+        # Sibling/cousin TUIs in different subtrees all survive (the real C0000005 case).
+        ({"T116", "T121", "T130"}, _UMLS_TREES, {"T116", "T121", "T130"}),
+        # A proper ancestor is dropped in favor of its descendant: T109 (A1.4.1.2.1) is an
+        # ancestor of T116 (A1.4.1.2.1.7).
+        ({"T109", "T116"}, _UMLS_TREES, {"T116"}),
+        # T123 (A1.4.1.1.3) is an ancestor of T126 (A1.4.1.1.3.3).
+        ({"T123", "T126"}, _UMLS_TREES, {"T126"}),
+        # Ancestor dropped, but an unrelated co-type stays.
+        ({"T109", "T116", "T121"}, _UMLS_TREES, {"T116", "T121"}),
+        # Component-boundary guard: "A1.2" is NOT an ancestor of "A1.20"; both survive.
+        ({"X", "Y"}, {"X": "A1.2", "Y": "A1.20"}, {"X", "Y"}),
+        # True dot-component ancestor "A1.2" of "A1.2.3" is dropped.
+        ({"X", "Y"}, {"X": "A1.2", "Y": "A1.2.3"}, {"Y"}),
+        # A code with no tree number has no ancestor relationship and is always kept.
+        ({"X", "Y"}, {"Y": "A1.2.3"}, {"X", "Y"}),
+    ],
+)
+def test_reduce_to_most_specific_tree_codes(codes, code_to_tree, expected):
+    assert reduce_to_most_specific_tree_codes(codes, code_to_tree) == expected


### PR DESCRIPTION
Improvements to how `leftover_umls` types unclaimed UMLS concepts and reports on them, surfaced by the 1.17 run. Grouped because the leftover_umls changes depend on the `node.py` change in the same branch.

## What's here

**Type handling**
- Handle UMLS semantic types T072/T073, with generic-type demotion and a preflight check (issue #840).
- `node.create_node` can write prefix-less types when `extra_prefixes` is given — the dependency that the generic-type demotion relies on.
- Cleanup of dead `PHYSICAL_ENTITY` entries in `TYPE_COMBO_OVERRIDES`.
- `apply_generic_demotion()` extracted as a named helper (used in both production and tests).
- Fix NAMED_THING fallback: prefer non-empty labels from later MRCONSO rows for the same CUI.

**Coverage reports**
- `compendium-coverage.csv` broken down by semantic type (TUI set), with `tui_set_labels` and `biolink_type` columns.
- `tui-coverage.csv`: same data re-sorted TUI-set-first ("where does semantic type T047 go across Babel?").
- `duplicate-curies.csv`: UMLS CURIEs that landed in more than one clique, with provenance.
- `no-mrsty-curies.csv`: CURIEs with no MRSTY entry, typed as `biolink:NamedThing` as a fallback, with MRCONSO SAB abbreviations for traceability (useful for identifying outdated or superseded CUIs).
- Additional multi-type overrides for semantic type combos seen in the 1.17 data.

**Regression tests and docs**
- Test asserting that `STY_OVERRIDES` pins match the current Biolink baseline (alerts when an override drifts or becomes redundant).
- Unit test for `GENERIC_TYPES` demotion logic.
- Regression test and docs for prefix-less output types.
- `docs/sources/UMLS/Leftover.md` fully documents all report files and the override tables.

**Misc**
- Preflight fix: `writable_output_types()` result captured once; error message for empty combined prefix list clarified.
- `node`: cache empty `id_prefixes`; consolidate prefix validation in `create_node`.
- `if not prefixes` idiom in `node.py`.

## Test plan
- `uv run ruff check && uv run ruff format --check`
- `uv run snakefmt --check --compact-diff .`
- `uv run rumdl check .`
- `uv run pytest -m unit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)