### PR TITLE
Validate and harden manual DrugChemical concord handling; fix dead type-filter

### DIFF
--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -240,34 +240,34 @@ def build_rxnorm_relationships(conso, relfile, outfile, metadata_yaml):
             x = line.strip().split("|")
             # UMLS always has the CUI in it, while RXNORM does not.
             if outfile == "UMLS":
-                object = x[0]
-                subject = x[4]
+                object_cui = x[0]
+                subject_cui = x[4]
             else:
-                object = get_cui(x, 2, 0, 1, aui_to_cui, sdui_to_cui)
-                subject = get_cui(x, 6, 4, 5, aui_to_cui, sdui_to_cui)
-            if (subject is not None) and (object is not None):
-                if subject == object:
+                object_cui = get_cui(x, 2, 0, 1, aui_to_cui, sdui_to_cui)
+                subject_cui = get_cui(x, 6, 4, 5, aui_to_cui, sdui_to_cui)
+            if (subject_cui is not None) and (object_cui is not None):
+                if subject_cui == object_cui:
                     continue
                 predicate = x[7]
                 if predicate in single_use_relations:
-                    single_use_relations[predicate][subject].add(object)
+                    single_use_relations[predicate][subject_cui].add(object_cui)
                 elif predicate in one_to_one_relations:
-                    one_to_one_relations[predicate]["subject"][subject].add(object)
-                    one_to_one_relations[predicate]["object"][object].add(subject)
+                    one_to_one_relations[predicate]["subject"][subject_cui].add(object_cui)
+                    one_to_one_relations[predicate]["object"][object_cui].add(subject_cui)
                 else:
-                    outf.write(f"{prefix}:{subject}\t{predicate}\t{prefix}:{object}\n")
+                    outf.write(f"{prefix}:{subject_cui}\t{predicate}\t{prefix}:{object_cui}\n")
         for predicate in single_use_relations:
-            for subject, objects in single_use_relations[predicate].items():
+            for subject_cui, objects in single_use_relations[predicate].items():
                 if len(objects) > 1:
                     continue
-                outf.write(f"{prefix}:{subject}\t{predicate}\t{prefix}:{next(iter(objects))}\n")
+                outf.write(f"{prefix}:{subject_cui}\t{predicate}\t{prefix}:{next(iter(objects))}\n")
         for predicate in one_to_one_relations:
-            for subject, objects in one_to_one_relations[predicate]["subject"].items():
+            for subject_cui, objects in one_to_one_relations[predicate]["subject"].items():
                 if len(objects) > 1:
                     continue
                 if len(one_to_one_relations[predicate]["object"][next(iter(objects))]) > 1:
                     continue
-                outf.write(f"{prefix}:{subject}\t{predicate}\t{prefix}:{next(iter(objects))}\n")
+                outf.write(f"{prefix}:{subject_cui}\t{predicate}\t{prefix}:{next(iter(objects))}\n")
 
     write_concord_metadata(
         metadata_yaml,
@@ -334,25 +334,25 @@ def _validate_and_apply_manual_concords(
     Returns the number of skipped pairs.
     """
     skipped = 0
-    for subject, obj in manual_concords:
-        subject_ok = subject in preferred_curie_for_curie
-        object_ok = obj in preferred_curie_for_curie
+    for subject_curie, object_curie in manual_concords:
+        subject_ok = subject_curie in preferred_curie_for_curie
+        object_ok = object_curie in preferred_curie_for_curie
         if not subject_ok:
             logger.warning(
-                f"Manual concord subject {subject} (paired with {obj}) is not in any chemical compendium — "
+                f"Manual concord subject {subject_curie} (paired with {object_curie}) is not in any chemical compendium — "
                 f"it may have been reclassified (e.g. as a protein). "
                 f"If so, remove it from {manual_concord_filename}."
             )
         if not object_ok:
             logger.warning(
-                f"Manual concord object {obj} (paired with {subject}) is not in any chemical compendium — "
+                f"Manual concord object {object_curie} (paired with {subject_curie}) is not in any chemical compendium — "
                 f"it may have been reclassified (e.g. as a protein). "
                 f"If so, remove it from {manual_concord_filename}."
             )
         if not subject_ok or not object_ok:
             skipped += 1
             continue
-        pairs.append((preferred_curie_for_curie[subject], preferred_curie_for_curie[obj]))
+        pairs.append((preferred_curie_for_curie[subject_curie], preferred_curie_for_curie[object_curie]))
     return skipped
 
 
@@ -439,27 +439,27 @@ def build_conflation(
         with open(concfile) as infile:
             for line in infile:
                 x = line.strip().split("\t")
-                subject = x[0]
-                object = x[2]
+                subject_curie = x[0]
+                object_curie = x[2]
 
                 # While we do this, we will also normalize all chemicals to their preferred clique IDs.
-                if subject in drug_rxcui_to_clique and object in chemical_rxcui_to_clique:
-                    subject = drug_rxcui_to_clique[subject]
-                    object = chemical_rxcui_to_clique[object]
-                    pairs.append((subject, object))
-                elif subject in chemical_rxcui_to_clique and object in drug_rxcui_to_clique:
-                    subject = chemical_rxcui_to_clique[subject]
-                    object = drug_rxcui_to_clique[object]
-                    pairs.append((subject, object))
+                if subject_curie in drug_rxcui_to_clique and object_curie in chemical_rxcui_to_clique:
+                    subject_curie = drug_rxcui_to_clique[subject_curie]
+                    object_curie = chemical_rxcui_to_clique[object_curie]
+                    pairs.append((subject_curie, object_curie))
+                elif subject_curie in chemical_rxcui_to_clique and object_curie in drug_rxcui_to_clique:
+                    subject_curie = chemical_rxcui_to_clique[subject_curie]
+                    object_curie = drug_rxcui_to_clique[object_curie]
+                    pairs.append((subject_curie, object_curie))
                 # OK, this is possible, and it's OK, as long as we get real clique leaders
-                elif subject in drug_rxcui_to_clique and object in drug_rxcui_to_clique:
-                    subject = drug_rxcui_to_clique[subject]
-                    object = drug_rxcui_to_clique[object]
-                    pairs.append((subject, object))
-                elif subject in chemical_rxcui_to_clique and object in chemical_rxcui_to_clique:
-                    subject = chemical_rxcui_to_clique[subject]
-                    object = chemical_rxcui_to_clique[object]
-                    pairs.append((subject, object))
+                elif subject_curie in drug_rxcui_to_clique and object_curie in drug_rxcui_to_clique:
+                    subject_curie = drug_rxcui_to_clique[subject_curie]
+                    object_curie = drug_rxcui_to_clique[object_curie]
+                    pairs.append((subject_curie, object_curie))
+                elif subject_curie in chemical_rxcui_to_clique and object_curie in chemical_rxcui_to_clique:
+                    subject_curie = chemical_rxcui_to_clique[subject_curie]
+                    object_curie = chemical_rxcui_to_clique[object_curie]
+                    pairs.append((subject_curie, object_curie))
 
     # Add the manual concords, normalizing CURIEs to their preferred form.
     manual_concords_skipped = _validate_and_apply_manual_concords(
@@ -480,66 +480,68 @@ def build_conflation(
     with open(pubchem_rxn_concord) as infile:
         for line in infile:
             x = line.strip().split("\t")
-            subject = x[0]
-            object = x[2]
+            subject_curie = x[0]
+            object_curie = x[2]
 
-            if subject in drug_rxcui_to_clique:
-                subject = drug_rxcui_to_clique[subject]
-            elif subject in chemical_rxcui_to_clique:
-                subject = chemical_rxcui_to_clique[subject]
+            if subject_curie in drug_rxcui_to_clique:
+                subject_curie = drug_rxcui_to_clique[subject_curie]
+            elif subject_curie in chemical_rxcui_to_clique:
+                subject_curie = chemical_rxcui_to_clique[subject_curie]
             else:
                 logger.warning(
-                    f"Subject in subject-object pair ({subject}, {object}) isn't mapped to a RxCUI, skipping."
+                    f"Subject in subject-object pair ({subject_curie}, {object_curie}) isn't mapped to a RxCUI, skipping."
                 )
                 continue
-                # raise RuntimeError(f"Unknown identifier in drugchemical conflation as subject: {subject}")
+                # raise RuntimeError(f"Unknown identifier in drugchemical conflation as subject: {subject_curie}")
 
-            if object in drug_rxcui_to_clique:
-                object = drug_rxcui_to_clique[object]
-            elif object in chemical_rxcui_to_clique:
-                object = chemical_rxcui_to_clique[object]
+            if object_curie in drug_rxcui_to_clique:
+                object_curie = drug_rxcui_to_clique[object_curie]
+            elif object_curie in chemical_rxcui_to_clique:
+                object_curie = chemical_rxcui_to_clique[object_curie]
             else:
                 logger.warning(
-                    f"Object in subject-object pair ({subject}, {object}) isn't mapped to a RxCUI, continuing."
+                    f"Object in subject-object pair ({subject_curie}, {object_curie}) isn't mapped to a RxCUI, continuing."
                 )
-                # raise RuntimeError(f"Unknown identifier in drugchemical conflation as object: {object}")
+                # raise RuntimeError(f"Unknown identifier in drugchemical conflation as object: {object_curie}")
 
             # Normalize both the subject and object, otherwise skip them.
-            if subject not in preferred_curie_for_curie:
+            if subject_curie not in preferred_curie_for_curie:
                 logger.warning(
-                    f"Subject in subject-object pair ({subject}, {object}) has no preferred CURIE, skipping."
+                    f"Subject in subject-object pair ({subject_curie}, {object_curie}) has no preferred CURIE, skipping."
                 )
                 continue
-            subject = preferred_curie_for_curie[subject]
+            subject_curie = preferred_curie_for_curie[subject_curie]
 
-            if object not in preferred_curie_for_curie:
-                logger.warning(f"Object in subject-object pair ({subject}, {object}) has no preferred CURIE, skipping.")
-                continue
-            object = preferred_curie_for_curie[object]
-
-            if subject == object:
+            if object_curie not in preferred_curie_for_curie:
                 logger.warning(
-                    f"Subject and object in subject-object pair ({subject}, {object}) normalize to the same identifier ({subject}), skipping."
+                    f"Object in subject-object pair ({subject_curie}, {object_curie}) has no preferred CURIE, skipping."
+                )
+                continue
+            object_curie = preferred_curie_for_curie[object_curie]
+
+            if subject_curie == object_curie:
+                logger.warning(
+                    f"Subject and object in subject-object pair ({subject_curie}, {object_curie}) normalize to the same identifier ({subject_curie}), skipping."
                 )
                 continue
 
             # Either the subject or the object might not be a chemical -- for example, MESH:C415772 shows up here,
             # but it's a gene, not a chemical.
-            subject_type = type_for_preferred_curie[subject]
+            subject_type = type_for_preferred_curie[subject_curie]
             if CHEMICAL_ENTITY not in biolink_chemical_types:
                 logger.warning(
-                    f"Subject in subject-object pair ({subject}, {object}) has type {subject_type}, which is is not a chemical type, skipping."
+                    f"Subject in subject-object pair ({subject_curie}, {object_curie}) has type {subject_type}, which is is not a chemical type, skipping."
                 )
                 continue
 
-            object_type = type_for_preferred_curie[object]
+            object_type = type_for_preferred_curie[object_curie]
             if CHEMICAL_ENTITY not in biolink_chemical_types:
                 logger.warning(
-                    f"Object in subject-object pair ({subject}, {object}) has type {object_type}, which is is not a chemical type, skipping."
+                    f"Object in subject-object pair ({subject_curie}, {object_curie}) has type {object_type}, which is is not a chemical type, skipping."
                 )
                 continue
 
-            pairs.append((subject, object))
+            pairs.append((subject_curie, object_curie))
 
     # Glommin' time
     logger.info(f"glom: {get_memory_usage_summary()}")

--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -318,6 +318,44 @@ def build_pubchem_relationships(infile, outfile, metadata_yaml):
     )
 
 
+def _validate_and_apply_manual_concords(
+    manual_concords: list[tuple[str, str]],
+    preferred_curie_for_curie: dict[str, str],
+    pairs: list[tuple[str, str]],
+    manual_concord_filename: str,
+) -> int:
+    """Validate each manual concord pair against the chemical compendia and append passing pairs to *pairs*.
+
+    Both CURIEs in a pair must appear in *preferred_curie_for_curie*; if either is absent a warning is
+    emitted for that CURIE, the whole pair is skipped, and the skip count returned by this function is
+    incremented. When both are absent, a warning is emitted for each before the pair is skipped.
+    Passing CURIEs are normalised to their preferred form before being appended.
+
+    Returns the number of skipped pairs.
+    """
+    skipped = 0
+    for subject, obj in manual_concords:
+        subject_ok = subject in preferred_curie_for_curie
+        object_ok = obj in preferred_curie_for_curie
+        if not subject_ok:
+            logger.warning(
+                f"Manual concord subject {subject} (paired with {obj}) is not in any chemical compendium — "
+                f"it may have been reclassified (e.g. as a protein). "
+                f"If so, remove it from {manual_concord_filename}."
+            )
+        if not object_ok:
+            logger.warning(
+                f"Manual concord object {obj} (paired with {subject}) is not in any chemical compendium — "
+                f"it may have been reclassified (e.g. as a protein). "
+                f"If so, remove it from {manual_concord_filename}."
+            )
+        if not subject_ok or not object_ok:
+            skipped += 1
+            continue
+        pairs.append((preferred_curie_for_curie[subject], preferred_curie_for_curie[obj]))
+    return skipped
+
+
 def build_conflation(
     manual_concord_filename,
     rxn_concord,
@@ -424,25 +462,9 @@ def build_conflation(
                     pairs.append((subject, object))
 
     # Add the manual concords, normalizing CURIEs to their preferred form.
-    manual_concords_skipped = 0
-    for subject, object in manual_concords:
-        if subject not in preferred_curie_for_curie:
-            logger.warning(
-                f"Manual concord subject {subject} (paired with {object}) is not in any chemical compendium — "
-                f"it may have been reclassified (e.g. as a protein). "
-                f"If so, remove it from {manual_concord_filename}."
-            )
-            manual_concords_skipped += 1
-            continue
-        if object not in preferred_curie_for_curie:
-            logger.warning(
-                f"Manual concord object {object} (paired with {subject}) is not in any chemical compendium — "
-                f"it may have been reclassified (e.g. as a protein). "
-                f"If so, remove it from {manual_concord_filename}."
-            )
-            manual_concords_skipped += 1
-            continue
-        pairs.append((preferred_curie_for_curie[subject], preferred_curie_for_curie[object]))
+    manual_concords_skipped = _validate_and_apply_manual_concords(
+        manual_concords, preferred_curie_for_curie, pairs, manual_concord_filename
+    )
 
     # We've had some issues with non-chemical types getting conflated, so we filter those out here.
     biolink_model_toolkit = get_biolink_model_toolkit(config["biolink_version"])
@@ -595,8 +617,9 @@ def build_conflation(
                 if iid not in preferred_curie_for_curie:
                     raise RuntimeError(
                         f"Conflation clique member {iid} (in clique {conflation_id_list}) is not in any chemical "
-                        f"compendium. This usually means a manual concord references a CURIE that isn't in any "
-                        f"compendium — check {manual_concord_filename} for entries containing {iid}."
+                        f"compendium. This is an internal logic error: all CURIEs entering glom() should have been "
+                        f"validated against the compendia beforehand. Check the RXN/UMLS concord processing paths "
+                        f"above, as manual concord entries are already validated by _validate_and_apply_manual_concords."
                     )
                 preferred_curie = preferred_curie_for_curie[iid]
                 if preferred_curie != iid:

--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -632,7 +632,8 @@ def build_conflation(
                         f"Conflation clique member {iid} (in clique {conflation_id_list}) is not in any chemical "
                         f"compendium. This is an internal logic error: all CURIEs entering glom() should have been "
                         f"validated against the compendia beforehand. Check the RXN/UMLS concord processing paths "
-                        f"above, as manual concord entries are already validated by _validate_and_apply_manual_concords."
+                        f"above, as manual concord entries from {manual_concord_filename} are already validated by "
+                        f"_validate_and_apply_manual_concords."
                     )
                 preferred_curie = preferred_curie_for_curie[iid]
                 if preferred_curie != iid:

--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -424,20 +424,23 @@ def build_conflation(
                     pairs.append((subject, object))
 
     # Add the manual concords, normalizing CURIEs to their preferred form.
+    manual_concords_skipped = 0
     for subject, object in manual_concords:
         if subject not in preferred_curie_for_curie:
             logger.warning(
                 f"Manual concord subject {subject} (paired with {object}) is not in any chemical compendium — "
                 f"it may have been reclassified (e.g. as a protein). "
-                f"If so, remove it from input_data/manual_concords/drugchemical.tsv."
+                f"If so, remove it from {manual_concord_filename}."
             )
+            manual_concords_skipped += 1
             continue
         if object not in preferred_curie_for_curie:
             logger.warning(
                 f"Manual concord object {object} (paired with {subject}) is not in any chemical compendium — "
                 f"it may have been reclassified (e.g. as a protein). "
-                f"If so, remove it from input_data/manual_concords/drugchemical.tsv."
+                f"If so, remove it from {manual_concord_filename}."
             )
+            manual_concords_skipped += 1
             continue
         pairs.append((preferred_curie_for_curie[subject], preferred_curie_for_curie[object]))
 
@@ -593,7 +596,7 @@ def build_conflation(
                     raise RuntimeError(
                         f"Conflation clique member {iid} (in clique {conflation_id_list}) is not in any chemical "
                         f"compendium. This usually means a manual concord references a CURIE that isn't in any "
-                        f"compendium — check input_data/manual_concords/drugchemical.tsv for entries containing {iid}."
+                        f"compendium — check {manual_concord_filename} for entries containing {iid}."
                     )
                 preferred_curie = preferred_curie_for_curie[iid]
                 if preferred_curie != iid:
@@ -707,6 +710,8 @@ def build_conflation(
                 "filename": manual_concord_filename,
                 "counts": {
                     "count_concords": len(manual_concords),
+                    "count_concords_skipped": manual_concords_skipped,
+                    "count_concords_applied": len(manual_concords) - manual_concords_skipped,
                     "count_distinct_curies": len(manual_concords_curies),
                     "predicates": dict(manual_concords_predicate_counts),
                     "prefix_counts": dict(manual_concords_curie_prefix_counts),

--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -353,14 +353,16 @@ def build_conflation(
             # We're only interested in two fields, so you can add additional files ('comment', 'notes', etc.) as needed.
             if "subject" not in row or "object" not in row:
                 raise RuntimeError(f"Missing subject or object fields in {manual_concord_filename}: {row}")
-            if row["subject"].strip() == "" or row["object"].strip() == "":
+            subject_curie = row["subject"].strip()
+            object_curie = row["object"].strip()
+            if subject_curie == "" or object_curie == "":
                 raise RuntimeError(f"Empty subject or object fields in {manual_concord_filename}: {row}")
-            manual_concords.append((row["subject"], row["object"]))
+            manual_concords.append((subject_curie, object_curie))
             manual_concords_predicate_counts[row["predicate"]] += 1
-            manual_concords_curies.add(row["subject"])
-            manual_concords_curies.add(row["object"])
+            manual_concords_curies.add(subject_curie)
+            manual_concords_curies.add(object_curie)
 
-            sorted_curies = sorted([row["subject"], row["object"]])
+            sorted_curies = sorted([subject_curie, object_curie])
             prefix_count_label = row["predicate"] + "(" + (" ,".join(sorted_curies)) + ")"
             manual_concords_curie_prefix_counts[prefix_count_label] += 1
     logger.info(f"{len(manual_concords)} manual concords loaded.")

--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -486,7 +486,7 @@ def build_conflation(
             mixin=True,
         )
     )
-    logging.info(f"Filtering RxCUI pairs to those in these Biolink chemical types: {sorted(biolink_chemical_types)}")
+    logger.info(f"Filtering RxCUI pairs to those in these Biolink chemical types: {sorted(biolink_chemical_types)}")
     with open(pubchem_rxn_concord) as infile:
         for line in infile:
             x = line.strip().split("\t")
@@ -510,9 +510,10 @@ def build_conflation(
                 object_curie = chemical_rxcui_to_clique[object_curie]
             else:
                 logger.warning(
-                    f"Object in subject-object pair ({subject_curie}, {object_curie}) isn't mapped to a RxCUI, continuing."
+                    f"Object in subject-object pair ({subject_curie}, {object_curie}) isn't mapped to a RxCUI, skipping."
                 )
                 # raise RuntimeError(f"Unknown identifier in drugchemical conflation as object: {object_curie}")
+                continue
 
             # Normalize both the subject and object, otherwise skip them.
             if subject_curie not in preferred_curie_for_curie:
@@ -585,7 +586,7 @@ def build_conflation(
     for i, prefix in enumerate(conflation_prefix_order):
         conflation_prefix_sort_order[prefix] = i
 
-    logging.info(f"Using prefix sort order: {json.dumps(conflation_prefix_sort_order, indent=2)}")
+    logger.info(f"Using prefix sort order: {json.dumps(conflation_prefix_sort_order, indent=2)}")
 
     # Write out all the resulting cliques.
     written = set()

--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -528,14 +528,14 @@ def build_conflation(
             # Either the subject or the object might not be a chemical -- for example, MESH:C415772 shows up here,
             # but it's a gene, not a chemical.
             subject_type = type_for_preferred_curie[subject_curie]
-            if CHEMICAL_ENTITY not in biolink_chemical_types:
+            if subject_type not in biolink_chemical_types:
                 logger.warning(
                     f"Subject in subject-object pair ({subject_curie}, {object_curie}) has type {subject_type}, which is is not a chemical type, skipping."
                 )
                 continue
 
             object_type = type_for_preferred_curie[object_curie]
-            if CHEMICAL_ENTITY not in biolink_chemical_types:
+            if object_type not in biolink_chemical_types:
                 logger.warning(
                     f"Object in subject-object pair ({subject_curie}, {object_curie}) has type {object_type}, which is is not a chemical type, skipping."
                 )

--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -329,7 +329,8 @@ def _validate_and_apply_manual_concords(
     Both CURIEs in a pair must appear in *preferred_curie_for_curie*; if either is absent a warning is
     emitted for that CURIE, the whole pair is skipped, and the skip count returned by this function is
     incremented. When both are absent, a warning is emitted for each before the pair is skipped.
-    Passing CURIEs are normalised to their preferred form before being appended.
+    Passing CURIEs are normalised to their preferred form before being appended. If both CURIEs normalise
+    to the same preferred CURIE, a warning is emitted and the self-pair is skipped.
 
     Returns the number of skipped pairs.
     """
@@ -352,7 +353,16 @@ def _validate_and_apply_manual_concords(
         if not subject_ok or not object_ok:
             skipped += 1
             continue
-        pairs.append((preferred_curie_for_curie[subject_curie], preferred_curie_for_curie[object_curie]))
+        norm_subject = preferred_curie_for_curie[subject_curie]
+        norm_object = preferred_curie_for_curie[object_curie]
+        if norm_subject == norm_object:
+            logger.warning(
+                f"Manual concord pair ({subject_curie}, {object_curie}) normalizes to the same preferred CURIE "
+                f"({norm_subject}); skipping self-pair."
+            )
+            skipped += 1
+            continue
+        pairs.append((norm_subject, norm_object))
     return skipped
 
 

--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -425,12 +425,16 @@ def build_conflation(
     for subject, object in manual_concords:
         if subject not in preferred_curie_for_curie:
             logger.warning(
-                f"Manual concord subject {subject} (paired with {object}) is not in any chemical compendium, skipping."
+                f"Manual concord subject {subject} (paired with {object}) is not in any chemical compendium — "
+                f"it may have been reclassified (e.g. as a protein). "
+                f"If so, remove it from input_data/manual_concords/drugchemical.tsv."
             )
             continue
         if object not in preferred_curie_for_curie:
             logger.warning(
-                f"Manual concord object {object} (paired with {subject}) is not in any chemical compendium, skipping."
+                f"Manual concord object {object} (paired with {subject}) is not in any chemical compendium — "
+                f"it may have been reclassified (e.g. as a protein). "
+                f"If so, remove it from input_data/manual_concords/drugchemical.tsv."
             )
             continue
         pairs.append((preferred_curie_for_curie[subject], preferred_curie_for_curie[object]))

--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -332,9 +332,11 @@ def _validate_and_apply_manual_concords(
     Passing CURIEs are normalised to their preferred form before being appended. If both CURIEs normalise
     to the same preferred CURIE, a warning is emitted and the self-pair is skipped.
 
-    Returns the number of skipped pairs.
+    Returns (skipped, applied_curies) where skipped is the number of skipped pairs and applied_curies
+    is the set of preferred CURIEs that were actually added to pairs.
     """
     skipped = 0
+    applied_curies: set[str] = set()
     for subject_curie, object_curie in manual_concords:
         subject_ok = subject_curie in preferred_curie_for_curie
         object_ok = object_curie in preferred_curie_for_curie
@@ -363,7 +365,9 @@ def _validate_and_apply_manual_concords(
             skipped += 1
             continue
         pairs.append((norm_subject, norm_object))
-    return skipped
+        applied_curies.add(norm_subject)
+        applied_curies.add(norm_object)
+    return skipped, applied_curies
 
 
 def build_conflation(
@@ -472,7 +476,7 @@ def build_conflation(
                     pairs.append((subject_curie, object_curie))
 
     # Add the manual concords, normalizing CURIEs to their preferred form.
-    manual_concords_skipped = _validate_and_apply_manual_concords(
+    manual_concords_skipped, manual_concords_applied_curies = _validate_and_apply_manual_concords(
         manual_concords, preferred_curie_for_curie, pairs, manual_concord_filename
     )
 
@@ -750,6 +754,7 @@ def build_conflation(
                     "count_concords_skipped": manual_concords_skipped,
                     "count_concords_applied": len(manual_concords) - manual_concords_skipped,
                     "count_distinct_curies": len(manual_concords_curies),
+                    "count_distinct_curies_applied": len(manual_concords_applied_curies),
                     "predicates": dict(manual_concords_predicate_counts),
                     "prefix_counts": dict(manual_concords_curie_prefix_counts),
                 },

--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -421,8 +421,19 @@ def build_conflation(
                     object = chemical_rxcui_to_clique[object]
                     pairs.append((subject, object))
 
-    # Add the manual concords.
-    pairs.extend(manual_concords)
+    # Add the manual concords, normalizing CURIEs to their preferred form.
+    for subject, object in manual_concords:
+        if subject not in preferred_curie_for_curie:
+            logger.warning(
+                f"Manual concord subject {subject} (paired with {object}) is not in any chemical compendium, skipping."
+            )
+            continue
+        if object not in preferred_curie_for_curie:
+            logger.warning(
+                f"Manual concord object {object} (paired with {subject}) is not in any chemical compendium, skipping."
+            )
+            continue
+        pairs.append((preferred_curie_for_curie[subject], preferred_curie_for_curie[object]))
 
     # We've had some issues with non-chemical types getting conflated, so we filter those out here.
     biolink_model_toolkit = get_biolink_model_toolkit(config["biolink_version"])
@@ -572,6 +583,12 @@ def build_conflation(
             normalized_conflation_id_list = list()
             for iid in conflation_id_list:
                 # Normalization shouldn't be needed here, because they're all clique leaders, but just in case.
+                if iid not in preferred_curie_for_curie:
+                    raise RuntimeError(
+                        f"Conflation clique member {iid} (in clique {conflation_id_list}) is not in any chemical "
+                        f"compendium. This usually means a manual concord references a CURIE that isn't in any "
+                        f"compendium — check input_data/manual_concords/drugchemical.tsv for entries containing {iid}."
+                    )
                 preferred_curie = preferred_curie_for_curie[iid]
                 if preferred_curie != iid:
                     logger.warning(

--- a/tests/createcompendia/test_drugchemical.py
+++ b/tests/createcompendia/test_drugchemical.py
@@ -25,7 +25,9 @@ PREFERRED = {
 def test_valid_pair_is_normalised_and_appended():
     """A pair where both CURIEs are in the compendia is normalised and appended to pairs."""
     pairs: list[tuple[str, str]] = []
-    skipped, applied_curies = _validate_and_apply_manual_concords([("DRUGBANK:DB001", "CHEBI:456")], PREFERRED, pairs, CONCORD_FILE)
+    skipped, applied_curies = _validate_and_apply_manual_concords(
+        [("DRUGBANK:DB001", "CHEBI:456")], PREFERRED, pairs, CONCORD_FILE
+    )
     assert skipped == 0
     assert pairs == [("CHEMBL:123", "CHEBI:456")]
     assert applied_curies == {"CHEMBL:123", "CHEBI:456"}
@@ -48,7 +50,9 @@ def test_missing_object_is_skipped_with_warning(caplog):
     """A pair whose object is absent from the compendia is skipped; the object CURIE appears in the warning."""
     pairs: list[tuple[str, str]] = []
     with caplog.at_level(logging.WARNING, logger="src.createcompendia.drugchemical"):
-        skipped, _ = _validate_and_apply_manual_concords([("CHEMBL:123", "MISSING:002")], PREFERRED, pairs, CONCORD_FILE)
+        skipped, _ = _validate_and_apply_manual_concords(
+            [("CHEMBL:123", "MISSING:002")], PREFERRED, pairs, CONCORD_FILE
+        )
     assert skipped == 1
     assert pairs == []
     assert "MISSING:002" in caplog.text
@@ -60,7 +64,9 @@ def test_both_missing_warns_for_each_and_counts_once(caplog):
     """When both CURIEs in a pair are absent, a warning is emitted for each but the pair is counted as one skip."""
     pairs: list[tuple[str, str]] = []
     with caplog.at_level(logging.WARNING, logger="src.createcompendia.drugchemical"):
-        skipped, _ = _validate_and_apply_manual_concords([("MISSING:001", "MISSING:002")], PREFERRED, pairs, CONCORD_FILE)
+        skipped, _ = _validate_and_apply_manual_concords(
+            [("MISSING:001", "MISSING:002")], PREFERRED, pairs, CONCORD_FILE
+        )
     assert skipped == 1
     assert pairs == []
     assert "MISSING:001" in caplog.text
@@ -88,7 +94,9 @@ def test_aliases_normalizing_to_same_curie_are_skipped(caplog):
     pairs: list[tuple[str, str]] = []
     # CHEMBL:123 and DRUGBANK:DB001 both map to CHEMBL:123 in PREFERRED.
     with caplog.at_level(logging.WARNING, logger="src.createcompendia.drugchemical"):
-        skipped, applied_curies = _validate_and_apply_manual_concords([("CHEMBL:123", "DRUGBANK:DB001")], PREFERRED, pairs, CONCORD_FILE)
+        skipped, applied_curies = _validate_and_apply_manual_concords(
+            [("CHEMBL:123", "DRUGBANK:DB001")], PREFERRED, pairs, CONCORD_FILE
+        )
     assert skipped == 1
     assert pairs == []
     assert applied_curies == set()

--- a/tests/createcompendia/test_drugchemical.py
+++ b/tests/createcompendia/test_drugchemical.py
@@ -25,9 +25,10 @@ PREFERRED = {
 def test_valid_pair_is_normalised_and_appended():
     """A pair where both CURIEs are in the compendia is normalised and appended to pairs."""
     pairs: list[tuple[str, str]] = []
-    skipped = _validate_and_apply_manual_concords([("DRUGBANK:DB001", "CHEBI:456")], PREFERRED, pairs, CONCORD_FILE)
+    skipped, applied_curies = _validate_and_apply_manual_concords([("DRUGBANK:DB001", "CHEBI:456")], PREFERRED, pairs, CONCORD_FILE)
     assert skipped == 0
     assert pairs == [("CHEMBL:123", "CHEBI:456")]
+    assert applied_curies == {"CHEMBL:123", "CHEBI:456"}
 
 
 @pytest.mark.unit
@@ -35,7 +36,7 @@ def test_missing_subject_is_skipped_with_warning(caplog):
     """A pair whose subject is absent from the compendia is skipped; the subject CURIE appears in the warning."""
     pairs: list[tuple[str, str]] = []
     with caplog.at_level(logging.WARNING, logger="src.createcompendia.drugchemical"):
-        skipped = _validate_and_apply_manual_concords([("MISSING:001", "CHEBI:456")], PREFERRED, pairs, CONCORD_FILE)
+        skipped, _ = _validate_and_apply_manual_concords([("MISSING:001", "CHEBI:456")], PREFERRED, pairs, CONCORD_FILE)
     assert skipped == 1
     assert pairs == []
     assert "MISSING:001" in caplog.text
@@ -47,7 +48,7 @@ def test_missing_object_is_skipped_with_warning(caplog):
     """A pair whose object is absent from the compendia is skipped; the object CURIE appears in the warning."""
     pairs: list[tuple[str, str]] = []
     with caplog.at_level(logging.WARNING, logger="src.createcompendia.drugchemical"):
-        skipped = _validate_and_apply_manual_concords([("CHEMBL:123", "MISSING:002")], PREFERRED, pairs, CONCORD_FILE)
+        skipped, _ = _validate_and_apply_manual_concords([("CHEMBL:123", "MISSING:002")], PREFERRED, pairs, CONCORD_FILE)
     assert skipped == 1
     assert pairs == []
     assert "MISSING:002" in caplog.text
@@ -59,7 +60,7 @@ def test_both_missing_warns_for_each_and_counts_once(caplog):
     """When both CURIEs in a pair are absent, a warning is emitted for each but the pair is counted as one skip."""
     pairs: list[tuple[str, str]] = []
     with caplog.at_level(logging.WARNING, logger="src.createcompendia.drugchemical"):
-        skipped = _validate_and_apply_manual_concords([("MISSING:001", "MISSING:002")], PREFERRED, pairs, CONCORD_FILE)
+        skipped, _ = _validate_and_apply_manual_concords([("MISSING:001", "MISSING:002")], PREFERRED, pairs, CONCORD_FILE)
     assert skipped == 1
     assert pairs == []
     assert "MISSING:001" in caplog.text
@@ -76,7 +77,7 @@ def test_mixed_pairs_counts_correctly(caplog):
         ("CHEMBL:123", "MISSING:002"),  # bad object
     ]
     with caplog.at_level(logging.WARNING, logger="src.createcompendia.drugchemical"):
-        skipped = _validate_and_apply_manual_concords(concords, PREFERRED, pairs, CONCORD_FILE)
+        skipped, _ = _validate_and_apply_manual_concords(concords, PREFERRED, pairs, CONCORD_FILE)
     assert skipped == 2
     assert pairs == [("CHEMBL:123", "CHEBI:456")]
 
@@ -87,7 +88,8 @@ def test_aliases_normalizing_to_same_curie_are_skipped(caplog):
     pairs: list[tuple[str, str]] = []
     # CHEMBL:123 and DRUGBANK:DB001 both map to CHEMBL:123 in PREFERRED.
     with caplog.at_level(logging.WARNING, logger="src.createcompendia.drugchemical"):
-        skipped = _validate_and_apply_manual_concords([("CHEMBL:123", "DRUGBANK:DB001")], PREFERRED, pairs, CONCORD_FILE)
+        skipped, applied_curies = _validate_and_apply_manual_concords([("CHEMBL:123", "DRUGBANK:DB001")], PREFERRED, pairs, CONCORD_FILE)
     assert skipped == 1
     assert pairs == []
+    assert applied_curies == set()
     assert "CHEMBL:123" in caplog.text

--- a/tests/createcompendia/test_drugchemical.py
+++ b/tests/createcompendia/test_drugchemical.py
@@ -79,3 +79,15 @@ def test_mixed_pairs_counts_correctly(caplog):
         skipped = _validate_and_apply_manual_concords(concords, PREFERRED, pairs, CONCORD_FILE)
     assert skipped == 2
     assert pairs == [("CHEMBL:123", "CHEBI:456")]
+
+
+@pytest.mark.unit
+def test_aliases_normalizing_to_same_curie_are_skipped(caplog):
+    """A pair whose two CURIEs both map to the same preferred CURIE is skipped as a self-pair."""
+    pairs: list[tuple[str, str]] = []
+    # CHEMBL:123 and DRUGBANK:DB001 both map to CHEMBL:123 in PREFERRED.
+    with caplog.at_level(logging.WARNING, logger="src.createcompendia.drugchemical"):
+        skipped = _validate_and_apply_manual_concords([("CHEMBL:123", "DRUGBANK:DB001")], PREFERRED, pairs, CONCORD_FILE)
+    assert skipped == 1
+    assert pairs == []
+    assert "CHEMBL:123" in caplog.text

--- a/tests/createcompendia/test_drugchemical.py
+++ b/tests/createcompendia/test_drugchemical.py
@@ -1,0 +1,81 @@
+"""
+Unit tests for src/createcompendia/drugchemical.py.
+
+These exercise _validate_and_apply_manual_concords, which validates manual
+concord pairs against the chemical compendia and normalises their CURIEs.
+"""
+
+import logging
+
+import pytest
+
+from src.createcompendia.drugchemical import _validate_and_apply_manual_concords
+
+CONCORD_FILE = "input_data/manual_concords/drugchemical.tsv"
+
+# A small preferred-CURIE map: each CURIE maps to its clique leader.
+PREFERRED = {
+    "CHEMBL:123": "CHEMBL:123",
+    "DRUGBANK:DB001": "CHEMBL:123",  # alias → same leader as CHEMBL:123
+    "CHEBI:456": "CHEBI:456",
+}
+
+
+@pytest.mark.unit
+def test_valid_pair_is_normalised_and_appended():
+    """A pair where both CURIEs are in the compendia is normalised and appended to pairs."""
+    pairs: list[tuple[str, str]] = []
+    skipped = _validate_and_apply_manual_concords([("DRUGBANK:DB001", "CHEBI:456")], PREFERRED, pairs, CONCORD_FILE)
+    assert skipped == 0
+    assert pairs == [("CHEMBL:123", "CHEBI:456")]
+
+
+@pytest.mark.unit
+def test_missing_subject_is_skipped_with_warning(caplog):
+    """A pair whose subject is absent from the compendia is skipped; the subject CURIE appears in the warning."""
+    pairs: list[tuple[str, str]] = []
+    with caplog.at_level(logging.WARNING, logger="src.createcompendia.drugchemical"):
+        skipped = _validate_and_apply_manual_concords([("MISSING:001", "CHEBI:456")], PREFERRED, pairs, CONCORD_FILE)
+    assert skipped == 1
+    assert pairs == []
+    assert "MISSING:001" in caplog.text
+    assert CONCORD_FILE in caplog.text
+
+
+@pytest.mark.unit
+def test_missing_object_is_skipped_with_warning(caplog):
+    """A pair whose object is absent from the compendia is skipped; the object CURIE appears in the warning."""
+    pairs: list[tuple[str, str]] = []
+    with caplog.at_level(logging.WARNING, logger="src.createcompendia.drugchemical"):
+        skipped = _validate_and_apply_manual_concords([("CHEMBL:123", "MISSING:002")], PREFERRED, pairs, CONCORD_FILE)
+    assert skipped == 1
+    assert pairs == []
+    assert "MISSING:002" in caplog.text
+    assert CONCORD_FILE in caplog.text
+
+
+@pytest.mark.unit
+def test_both_missing_warns_for_each_and_counts_once(caplog):
+    """When both CURIEs in a pair are absent, a warning is emitted for each but the pair is counted as one skip."""
+    pairs: list[tuple[str, str]] = []
+    with caplog.at_level(logging.WARNING, logger="src.createcompendia.drugchemical"):
+        skipped = _validate_and_apply_manual_concords([("MISSING:001", "MISSING:002")], PREFERRED, pairs, CONCORD_FILE)
+    assert skipped == 1
+    assert pairs == []
+    assert "MISSING:001" in caplog.text
+    assert "MISSING:002" in caplog.text
+
+
+@pytest.mark.unit
+def test_mixed_pairs_counts_correctly(caplog):
+    """Skipped pairs do not prevent valid pairs from being appended; counts are independent."""
+    pairs: list[tuple[str, str]] = []
+    concords = [
+        ("CHEMBL:123", "CHEBI:456"),  # valid
+        ("MISSING:001", "CHEBI:456"),  # bad subject
+        ("CHEMBL:123", "MISSING:002"),  # bad object
+    ]
+    with caplog.at_level(logging.WARNING, logger="src.createcompendia.drugchemical"):
+        skipped = _validate_and_apply_manual_concords(concords, PREFERRED, pairs, CONCORD_FILE)
+    assert skipped == 2
+    assert pairs == [("CHEMBL:123", "CHEBI:456")]


### PR DESCRIPTION
Validates the manual DrugChemical concords against the chemical compendia before they are glommed, so a CURIE that was reclassified out of the chemical compendia is caught with an actionable warning (suggesting its removal) instead of silently distorting a clique.

Additional hardening and cleanup applied during review:

- **Whitespace stripping** — the manual concord loader checked `.strip()` for emptiness but stored unstripped values; a space-padded CURIE would silently fail the compendium lookup.
- **Both-bad-CURIE warning** — the original early-exit skipped the second CURIE check when the first was bad; a pair with two missing CURIEs now emits a warning for each before being skipped.
- **`manual_concord_filename` in messages** — all diagnostic messages (two warnings, one `RuntimeError`) previously hardcoded the TSV path; they now use the function argument so the path is correct in all call contexts.
- **Skip counter in metadata** — the provenance YAML now records `count_concords_skipped`, `count_concords_applied`, and `count_distinct_curies_applied` alongside the loaded totals, so the metadata accurately reflects how many pairs and CURIEs were actually used.
- **Extracted `_validate_and_apply_manual_concords`** — the validation loop is pulled into a module-level helper, making it independently testable and keeping `build_conflation` focused on orchestration.
- **Self-pair guard** — if two CURIEs in a manual concord normalise to the same preferred CURIE, the pair is now warned and skipped (consistent with the pubchem concord path).
- **Unit tests** — six `@pytest.mark.unit` tests cover valid normalisation, missing subject, missing object, both missing (two warnings / one skip), mixed batches, and aliases that normalise to the same CURIE.
- **`subject`/`object` rename** — local variables named `object` (shadowing a Python builtin) and the inconsistently named `obj` are renamed to `subject_curie`/`object_curie` (or `subject_cui`/`object_cui` in `build_rxnorm_relationships` where the values are raw CUIs). Dict key strings (`row["subject"]`, etc.) are unchanged.
- **Dead type-filter fix** — the pubchem concord path checked `CHEMICAL_ENTITY not in biolink_chemical_types` (a constant, always False with `reflexive=True`) instead of `subject_type`/`object_type`; non-chemical types were never filtered as intended.
- **Missing `continue` fix** — in the pubchem concord path, the "object not mapped to RxCUI" branch lacked a `continue`, causing a confusing second warning before the pair was finally skipped.
- **`logging.info` → `logger.info`** — two calls in `build_conflation` used the bare root logger instead of the module-level logger.

## Test plan
- `uv run ruff check && uv run ruff format --check`
- `uv run snakefmt --check --compact-diff .`
- `uv run rumdl check .`
- `uv run pytest -m unit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)