### PR TITLE
UniChem / chemicals ingest fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,6 +244,13 @@ docstrings, and when to add a pipeline test) that the individual conventions bel
 - **Commits** — if you need to make a large change, break it into multiple commits so it's clearer
   what changes are related.
 
+- **Separate download and extract/validate rules** — always split a Snakemake data-collection step
+  into two rules: a `download_*` rule that only fetches the raw file(s), and a separate rule that
+  validates format or extracts content. This way, if upstream changes its format (e.g. a column
+  rename), only the validation rule fails; Snakemake preserves the downloaded file and the
+  expensive re-download is avoided after a code fix. Format validation belongs in the
+  extraction/filter rule, never in the download rule.
+
 - **Ruff lint** — all Python must pass `uv run ruff check` (run automatically on PRs). Two rules
   that are easy to trip in test code:
   - **E741** — do not use single-letter ambiguous variable names (`l`, `O`, `I`). Use `line`,

--- a/config.yaml
+++ b/config.yaml
@@ -102,12 +102,12 @@ process_ids:      [GO, REACT, RHEA, EC, SMPDB, PANTHER.PATHWAY, UMLS]
 process_concords: [GO, RHEA, UMLS]
 process_outputs:  [Pathway.txt, BiologicalProcess.txt, MolecularActivity.txt]
 
-unichem_datasources: [CHEMBL.COMPOUND, DRUGBANK, GTOPDB, KEGG.COMPOUND, CHEBI, UNII, HMDB, PUBCHEM.COMPOUND, DrugCentral]
+unichem_datasources: [CHEMBL.COMPOUND, DRUGBANK, GTOPDB, CHEBI, UNII, HMDB, PUBCHEM.COMPOUND, DrugCentral]  # KEGG.COMPOUND removed from UniChem — https://github.com/NCATSTranslator/Babel/issues/834
 
-chemical_labels:    [CHEMBL.COMPOUND, GTOPDB, KEGG.COMPOUND, CHEBI, UNII, HMDB, PUBCHEM.COMPOUND, DrugCentral, UMLS, DRUGBANK]
+chemical_labels:    [CHEMBL.COMPOUND, GTOPDB, CHEBI, UNII, HMDB, PUBCHEM.COMPOUND, DrugCentral, UMLS, DRUGBANK]  # KEGG.COMPOUND removed from UniChem — https://github.com/NCATSTranslator/Babel/issues/834
 chemical_synonyms:  [GTOPDB, CHEBI, UNII, HMDB, PUBCHEM.COMPOUND, UMLS, DRUGBANK]
 chemical_concords:  [wikipedia_mesh_chebi, PUBCHEM_MESH, mesh_cas, mesh_unii, PUBCHEM_CAS, GTOPDB, CHEBI, UMLS, DrugCentral, RXNORM]
-chemical_ids:       [CHEMBL.COMPOUND, GTOPDB, KEGG.COMPOUND, CHEBI, UNII, HMDB, PUBCHEM.COMPOUND, DrugCentral, DRUGBANK, MESH, UMLS, RXNORM]
+chemical_ids:       [CHEMBL.COMPOUND, GTOPDB, CHEBI, UNII, HMDB, PUBCHEM.COMPOUND, DrugCentral, DRUGBANK, MESH, UMLS, RXNORM]  # KEGG.COMPOUND removed from UniChem — https://github.com/NCATSTranslator/Babel/issues/834
 chemical_outputs:   [MolecularMixture.txt, SmallMolecule.txt, Polypeptide.txt, ComplexMolecularMixture.txt, ChemicalEntity.txt, ChemicalMixture.txt, Drug.txt]
 
 drugchemicalconflated_synonym_outputs: [DrugChemicalConflated.txt]

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -366,6 +366,7 @@ def pull_via_wget(
     retries: int = 1,
     connect_timeout: int = 60,
     read_timeout: int = 300,
+    verify_gzip: bool = False,
 ):
     """
     Download a file using wget. We call wget from the command line, and use command line options to
@@ -381,6 +382,8 @@ def pull_via_wget(
     :param continue_incomplete: Should wget continue an incomplete download?
     :param recurse: Do we want to download recursively? Should be from Wget_Recursion_Options, such as Wget_Recursion_Options.NO_RECURSION.
     :param retries: The number of retries to attempt.
+    :param verify_gzip: If downloading a Gzip file that isn't being decompressed, verify that the
+        file is valid (by reading it entirely). Has no effect if decompress=True.
     """
 
     # Prepare download URL and location
@@ -458,6 +461,18 @@ def pull_via_wget(
         if os.path.isfile(dl_file_name):
             file_size = os.path.getsize(dl_file_name)
             logger.info(f"Downloaded {dl_file_name} from {url}, file size {file_size} bytes.")
+            if verify_gzip:
+                if file_size < 1024:
+                    raise RuntimeError(
+                        f"Downloaded Gzip file {dl_file_name} is too small ({file_size} bytes) to be valid."
+                    )
+                try:
+                    with gzip.open(dl_file_name, "rb") as f:
+                        for _ in iter(lambda: f.read(1024 * 1024), b""):
+                            pass
+                    logger.info(f"Verified {dl_file_name} as a valid Gzip file.")
+                except Exception as e:
+                    raise RuntimeError(f"Downloaded Gzip file {dl_file_name} failed verification: {e}") from e
         elif os.path.isdir(dl_file_name):
             # Count the number of files in directory dl_file_name
             dir_size = sum(

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -399,6 +399,8 @@ def pull_via_wget(
     else:
         dl_file_name = os.path.join(download_dir, in_file_name)
 
+    os.makedirs(os.path.dirname(os.path.abspath(dl_file_name)), exist_ok=True)
+
     # Prepare wget options.
     wget_command_line = [
         "wget",
@@ -467,13 +469,12 @@ def pull_via_wget(
                     raise RuntimeError(
                         f"Downloaded Gzip file {dl_file_name} is too small ({file_size} bytes) to be valid."
                     )
-                try:
-                    with gzip.open(dl_file_name, "rb") as f:
-                        for _ in iter(lambda: f.read(1024 * 1024), b""):
-                            pass
-                    logger.info(f"Verified {dl_file_name} as a valid Gzip file.")
-                except Exception as e:
-                    raise RuntimeError(f"Downloaded Gzip file {dl_file_name} failed verification: {e}") from e
+                result = subprocess.run(["gzip", "-t", dl_file_name], capture_output=True, text=True)
+                if result.returncode != 0:
+                    raise RuntimeError(
+                        f"Downloaded Gzip file {dl_file_name} failed verification: {result.stderr.strip()}"
+                    )
+                logger.info(f"Verified {dl_file_name} as a valid Gzip file.")
         elif os.path.isdir(dl_file_name):
             # Count the number of files in directory dl_file_name
             dir_size = sum(

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -367,6 +367,7 @@ def pull_via_wget(
     retries: int = 1,
     connect_timeout: int = 60,
     read_timeout: int = 300,
+    verify_gzip: bool = False,
 ):
     """
     Download a file using wget. We call wget from the command line, and use command line options to
@@ -382,6 +383,8 @@ def pull_via_wget(
     :param continue_incomplete: Should wget continue an incomplete download?
     :param recurse: Do we want to download recursively? Should be from Wget_Recursion_Options, such as Wget_Recursion_Options.NO_RECURSION.
     :param retries: The number of retries to attempt.
+    :param verify_gzip: If downloading a Gzip file that isn't being decompressed, verify that the
+        file is valid (by reading it entirely). Has no effect if decompress=True.
     """
 
     # Prepare download URL and location
@@ -459,6 +462,18 @@ def pull_via_wget(
         if os.path.isfile(dl_file_name):
             file_size = os.path.getsize(dl_file_name)
             logger.info(f"Downloaded {dl_file_name} from {url}, file size {file_size} bytes.")
+            if verify_gzip:
+                if file_size < 1024:
+                    raise RuntimeError(
+                        f"Downloaded Gzip file {dl_file_name} is too small ({file_size} bytes) to be valid."
+                    )
+                try:
+                    with gzip.open(dl_file_name, "rb") as f:
+                        for _ in iter(lambda: f.read(1024 * 1024), b""):
+                            pass
+                    logger.info(f"Verified {dl_file_name} as a valid Gzip file.")
+                except Exception as e:
+                    raise RuntimeError(f"Downloaded Gzip file {dl_file_name} failed verification: {e}") from e
         elif os.path.isdir(dl_file_name):
             # Count the number of files in directory dl_file_name
             dir_size = sum(

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -431,6 +431,7 @@ def write_unichem_concords(structfile, reffile, outdir):
     inchikeys = read_inchikeys(structfile)
     concfiles = {}
     row_counts = {}
+    double_prefix_warned = set()  # sources where we already logged the strip-warning
     for num, name in unichem_data_sources.items():
         concname = f"{outdir}/UNICHEM_{name}"
         print(concname)
@@ -441,11 +442,38 @@ def write_unichem_concords(structfile, reffile, outdir):
         assert header_line == UNICHEM_REFERENCE_TSV_HEADER, f"Incorrect header line in {reffile}: {header_line}"
         for line in inf:
             x = line.rstrip().split("\t")
-            outf = concfiles[x[1]]
+            src_id = x[1]
+            compound_id = x[2]
+            expected_prefix = unichem_data_sources[src_id]
+            outf = concfiles[src_id]
             assert x[3] == "1"  # Only '1' (current) assignments should be in this file
             # (see https://chembl.gitbook.io/unichem/definitions/what-is-an-assignment).
-            outf.write(f"{unichem_data_sources[x[1]]}:{x[2]}\toio:equivalent\t{inchikeys[x[0]]}\n")
-            row_counts[x[1]] += 1
+
+            # Guard against UniChem embedding the prefix inside the compound ID.
+            # e.g. CHEBI source stores "CHEBI:12345" instead of bare "12345".
+            if ":" in compound_id:
+                embedded_prefix, bare_id = compound_id.split(":", 1)
+                if embedded_prefix == expected_prefix:
+                    # Double prefix — strip the embedded one and warn once per source.
+                    if src_id not in double_prefix_warned:
+                        logger.warning(
+                            f"UniChem source {src_id} ({expected_prefix}): compound ID already contains "
+                            f"the prefix (e.g. {compound_id!r}). Stripping embedded prefix. "
+                            f"Consider reporting this to UniChem."
+                        )
+                        double_prefix_warned.add(src_id)
+                    compound_id = bare_id
+                else:
+                    raise ValueError(
+                        f"UniChem source {src_id} ({expected_prefix}): compound ID {compound_id!r} "
+                        f"contains an unexpected embedded prefix {embedded_prefix!r}. "
+                        f"Expected either a bare ID or one prefixed with {expected_prefix!r}. "
+                        f"Update unichem_data_sources in src/datahandlers/unichem.py if this source "
+                        f"has changed its identifier scheme."
+                    )
+
+            outf.write(f"{expected_prefix}:{compound_id}\toio:equivalent\t{inchikeys[x[0]]}\n")
+            row_counts[src_id] += 1
     for outf in concfiles.values():
         outf.close()
 

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -485,10 +485,14 @@ def combine_unichem(concordances, output):
                 # Get the prefix from the first row to determine if we need to remove overused xrefs
                 prefixes_in_file.add(Text.get_prefix(x[0]))
 
-        # Was there more than one prefix in the first column?
-        if len(prefixes_in_file) != 1:
+        # Was there exactly one prefix in the first column?
+        if len(prefixes_in_file) == 0:
             raise RuntimeError(
-                f"More than one prefix found in {infile}: {prefixes_in_file}. All UNICHEM files should have only one prefix."
+                f"No prefixes found in {infile} (file may be empty or have no valid CURIE in column 1). All UNICHEM files should have exactly one prefix."
+            )
+        if len(prefixes_in_file) > 1:
+            raise RuntimeError(
+                f"Multiple prefixes found in {infile}: {prefixes_in_file}. All UNICHEM files should have exactly one prefix."
             )
         prefix_to_check = prefixes_in_file.pop()
 

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -27,7 +27,7 @@ from src.categories import (
     POLYPEPTIDE,
     SMALL_MOLECULE,
 )
-from src.datahandlers.unichem import UNICHEM_REFERENCE_TSV_HEADER
+from src.datahandlers.unichem import UNICHEM_REFERENCE_TSV_HEADER, UNICHEM_STRUCT_TSV_HEADER
 from src.datahandlers.unichem import data_sources as unichem_data_sources
 from src.metadata.provenance import write_combined_metadata, write_concord_metadata
 from src.prefixes import (
@@ -496,9 +496,7 @@ def read_inchikeys(struct_file):
     inchikeys = {}
     with gzip.open(struct_file, "rt") as inf:
         header_line = inf.readline()
-        assert header_line == "UCI\tSTANDARDINCHI\tSTANDARDINCHIKEY\n", (
-            f"Unexpected header line in {struct_file}: {header_line}"
-        )
+        assert header_line == UNICHEM_STRUCT_TSV_HEADER, f"Unexpected header line in {struct_file}: {header_line}"
         for sline in inf:
             line = sline.rstrip().split("\t")
             if len(line) == 0:

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -430,10 +430,12 @@ def write_gtopdb_ids(infile, outfile):
 def write_unichem_concords(structfile, reffile, outdir):
     inchikeys = read_inchikeys(structfile)
     concfiles = {}
+    row_counts = {}
     for num, name in unichem_data_sources.items():
         concname = f"{outdir}/UNICHEM_{name}"
         print(concname)
         concfiles[num] = open(concname, "w")
+        row_counts[num] = 0
     with open(reffile) as inf:
         header_line = inf.readline()
         assert header_line == UNICHEM_REFERENCE_TSV_HEADER, f"Incorrect header line in {reffile}: {header_line}"
@@ -443,8 +445,20 @@ def write_unichem_concords(structfile, reffile, outdir):
             assert x[3] == "1"  # Only '1' (current) assignments should be in this file
             # (see https://chembl.gitbook.io/unichem/definitions/what-is-an-assignment).
             outf.write(f"{unichem_data_sources[x[1]]}:{x[2]}\toio:equivalent\t{inchikeys[x[0]]}\n")
+            row_counts[x[1]] += 1
     for outf in concfiles.values():
         outf.close()
+
+    empty_sources = [(num, unichem_data_sources[num]) for num, count in row_counts.items() if count == 0]
+    if empty_sources:
+        descriptions = ", ".join(f"{name!r} (source ID {num!r})" for num, name in empty_sources)
+        raise RuntimeError(
+            f"UniChem reference file produced no entries for the following sources: {descriptions}. "
+            f"These sources may have been removed or renumbered in the current UniChem release. "
+            f"To fix: remove them from unichem_data_sources in src/datahandlers/unichem.py and "
+            f"from unichem_datasources (and chemical_labels/chemical_ids if present) in config.yaml, "
+            f"then rerun this step."
+        )
 
 
 def read_inchikeys(struct_file):

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -27,6 +27,7 @@ from src.categories import (
     POLYPEPTIDE,
     SMALL_MOLECULE,
 )
+from src.datahandlers.unichem import UNICHEM_REFERENCE_TSV_HEADER
 from src.datahandlers.unichem import data_sources as unichem_data_sources
 from src.metadata.provenance import write_combined_metadata, write_concord_metadata
 from src.prefixes import (
@@ -317,11 +318,7 @@ def write_drugbank_ids(infile, outfile):
     written = set()
     with open(infile) as inf, open(outfile, "w") as outf:
         header_line = inf.readline()
-        # UniChem uses "ASSIGMENT" (missing one N) in its reference file header.
-        assert header_line in (
-            "UCI\tSRC_ID\tSRC_COMPOUND_ID\tASSIGNMENT\n",
-            "UCI\tSRC_ID\tSRC_COMPOUND_ID\tASSIGMENT\n",
-        ), f"Incorrect header line in {infile}: {header_line}"
+        assert header_line == UNICHEM_REFERENCE_TSV_HEADER, f"Incorrect header line in {infile}: {header_line}"
         for line in inf:
             x = line.rstrip().split("\t")
             if x[1] == drugbank_id:
@@ -439,9 +436,7 @@ def write_unichem_concords(structfile, reffile, outdir):
         concfiles[num] = open(concname, "w")
     with open(reffile) as inf:
         header_line = inf.readline()
-        assert header_line == "UCI\tSRC_ID\tSRC_COMPOUND_ID\tASSIGNMENT\n", (
-            f"Incorrect header line in {reffile}: {header_line}"
-        )
+        assert header_line == UNICHEM_REFERENCE_TSV_HEADER, f"Incorrect header line in {reffile}: {header_line}"
         for line in inf:
             x = line.rstrip().split("\t")
             outf = concfiles[x[1]]

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -318,9 +318,10 @@ def write_drugbank_ids(infile, outfile):
     with open(infile) as inf, open(outfile, "w") as outf:
         header_line = inf.readline()
         # UniChem uses "ASSIGMENT" (missing one N) in its reference file header.
-        assert header_line in ("UCI\tSRC_ID\tSRC_COMPOUND_ID\tASSIGNMENT\n", "UCI\tSRC_ID\tSRC_COMPOUND_ID\tASSIGMENT\n"), (
-            f"Incorrect header line in {infile}: {header_line}"
-        )
+        assert header_line in (
+            "UCI\tSRC_ID\tSRC_COMPOUND_ID\tASSIGNMENT\n",
+            "UCI\tSRC_ID\tSRC_COMPOUND_ID\tASSIGMENT\n",
+        ), f"Incorrect header line in {infile}: {header_line}"
         for line in inf:
             x = line.rstrip().split("\t")
             if x[1] == drugbank_id:

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -447,8 +447,11 @@ def write_unichem_concords(structfile, reffile, outdir):
                 compound_id = x[2]
                 expected_prefix = unichem_data_sources[src_id]
                 outf = concfiles[src_id]
-                assert x[3] == "1"  # Only '1' (current) assignments should be in this file
-                # (see https://chembl.gitbook.io/unichem/definitions/what-is-an-assignment).
+                assert x[3] == "1", (  # Only '1' (current) assignments should be in this file
+                    f"Expected assignment '1' (current) but got {x[3]!r} for src_id={src_id!r}, "
+                    f"compound_id={compound_id!r}; filter_unichem should have excluded non-current rows "
+                    f"(see https://chembl.gitbook.io/unichem/definitions/what-is-an-assignment)"
+                )
 
                 # Guard against UniChem embedding the prefix inside the compound ID.
                 # e.g. CHEBI source stores "CHEBI:12345" instead of bare "12345".

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -437,45 +437,47 @@ def write_unichem_concords(structfile, reffile, outdir):
         print(concname)
         concfiles[num] = open(concname, "w")
         row_counts[num] = 0
-    with open(reffile) as inf:
-        header_line = inf.readline()
-        assert header_line == UNICHEM_REFERENCE_TSV_HEADER, f"Incorrect header line in {reffile}: {header_line}"
-        for line in inf:
-            x = line.rstrip().split("\t")
-            src_id = x[1]
-            compound_id = x[2]
-            expected_prefix = unichem_data_sources[src_id]
-            outf = concfiles[src_id]
-            assert x[3] == "1"  # Only '1' (current) assignments should be in this file
-            # (see https://chembl.gitbook.io/unichem/definitions/what-is-an-assignment).
+    try:
+        with open(reffile) as inf:
+            header_line = inf.readline()
+            assert header_line == UNICHEM_REFERENCE_TSV_HEADER, f"Incorrect header line in {reffile}: {header_line}"
+            for line in inf:
+                x = line.rstrip().split("\t")
+                src_id = x[1]
+                compound_id = x[2]
+                expected_prefix = unichem_data_sources[src_id]
+                outf = concfiles[src_id]
+                assert x[3] == "1"  # Only '1' (current) assignments should be in this file
+                # (see https://chembl.gitbook.io/unichem/definitions/what-is-an-assignment).
 
-            # Guard against UniChem embedding the prefix inside the compound ID.
-            # e.g. CHEBI source stores "CHEBI:12345" instead of bare "12345".
-            if ":" in compound_id:
-                embedded_prefix, bare_id = compound_id.split(":", 1)
-                if embedded_prefix == expected_prefix:
-                    # Double prefix — strip the embedded one and warn once per source.
-                    if src_id not in double_prefix_warned:
-                        logger.warning(
-                            f"UniChem source {src_id} ({expected_prefix}): compound ID already contains "
-                            f"the prefix (e.g. {compound_id!r}). Stripping embedded prefix. "
-                            f"Consider reporting this to UniChem."
+                # Guard against UniChem embedding the prefix inside the compound ID.
+                # e.g. CHEBI source stores "CHEBI:12345" instead of bare "12345".
+                if ":" in compound_id:
+                    embedded_prefix, bare_id = compound_id.split(":", 1)
+                    if embedded_prefix == expected_prefix:
+                        # Double prefix — strip the embedded one and warn once per source.
+                        if src_id not in double_prefix_warned:
+                            logger.warning(
+                                f"UniChem source {src_id} ({expected_prefix}): compound ID already contains "
+                                f"the prefix (e.g. {compound_id!r}). Stripping embedded prefix. "
+                                f"Consider reporting this to UniChem."
+                            )
+                            double_prefix_warned.add(src_id)
+                        compound_id = bare_id
+                    else:
+                        raise ValueError(
+                            f"UniChem source {src_id} ({expected_prefix}): compound ID {compound_id!r} "
+                            f"contains an unexpected embedded prefix {embedded_prefix!r}. "
+                            f"Expected either a bare ID or one prefixed with {expected_prefix!r}. "
+                            f"Update unichem_data_sources in src/datahandlers/unichem.py if this source "
+                            f"has changed its identifier scheme."
                         )
-                        double_prefix_warned.add(src_id)
-                    compound_id = bare_id
-                else:
-                    raise ValueError(
-                        f"UniChem source {src_id} ({expected_prefix}): compound ID {compound_id!r} "
-                        f"contains an unexpected embedded prefix {embedded_prefix!r}. "
-                        f"Expected either a bare ID or one prefixed with {expected_prefix!r}. "
-                        f"Update unichem_data_sources in src/datahandlers/unichem.py if this source "
-                        f"has changed its identifier scheme."
-                    )
 
-            outf.write(f"{expected_prefix}:{compound_id}\toio:equivalent\t{inchikeys[x[0]]}\n")
-            row_counts[src_id] += 1
-    for outf in concfiles.values():
-        outf.close()
+                outf.write(f"{expected_prefix}:{compound_id}\toio:equivalent\t{inchikeys[x[0]]}\n")
+                row_counts[src_id] += 1
+    finally:
+        for outf in concfiles.values():
+            outf.close()
 
     empty_sources = [(num, unichem_data_sources[num]) for num, count in row_counts.items() if count == 0]
     if empty_sources:

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -317,7 +317,8 @@ def write_drugbank_ids(infile, outfile):
     written = set()
     with open(infile) as inf, open(outfile, "w") as outf:
         header_line = inf.readline()
-        assert header_line == "UCI\tSRC_ID\tSRC_COMPOUND_ID\tASSIGNMENT\n", (
+        # UniChem uses "ASSIGMENT" (missing one N) in its reference file header.
+        assert header_line in ("UCI\tSRC_ID\tSRC_COMPOUND_ID\tASSIGNMENT\n", "UCI\tSRC_ID\tSRC_COMPOUND_ID\tASSIGMENT\n"), (
             f"Incorrect header line in {infile}: {header_line}"
         )
         for line in inf:

--- a/src/datahandlers/unichem.py
+++ b/src/datahandlers/unichem.py
@@ -21,8 +21,8 @@ data_sources: dict = {
 REFERENCE_HEADER = "UCI\tSRC_ID\tSRC_COMPOUND_ID\tASSIGMENT\n"
 
 
-def download_unichem():
-    """Download raw UniChem files. Format validation happens in filter_unichem."""
+def download_unichem_structure():
+    """Download UniChem structure file. Format validation happens in filter_unichem."""
     pull_via_wget(
         "http://ftp.ebi.ac.uk/pub/databases/chembl/UniChem/data/table_dumps/",
         "structure.tsv.gz",
@@ -30,6 +30,10 @@ def download_unichem():
         subpath="UNICHEM",
         verify_gzip=True,
     )
+
+
+def download_unichem_reference():
+    """Download UniChem reference file. Format validation happens in filter_unichem."""
     pull_via_wget(
         "http://ftp.ebi.ac.uk/pub/databases/chembl/UniChem/data/table_dumps/",
         "reference.tsv.gz",
@@ -56,7 +60,7 @@ def filter_unichem(ref_file, ref_filtered):
         if header_line != REFERENCE_HEADER:
             raise ValueError(
                 f"UniChem reference file {ref_file} has an unexpected header — "
-                f"re-run download_unichem to re-download.\n"
+                f"re-run download_unichem_reference to re-download.\n"
                 f"  Expected : {REFERENCE_HEADER!r}\n"
                 f"  Got      : {header_line!r}"
             )

--- a/src/datahandlers/unichem.py
+++ b/src/datahandlers/unichem.py
@@ -16,7 +16,7 @@ data_sources: dict = {
     "34": DRUGCENTRAL,
 }
 
-_UNICHEM_FTP_BASE = "http://ftp.ebi.ac.uk/pub/databases/chembl/UniChem/data/table_dumps/"
+_UNICHEM_HTTP_BASE = "http://ftp.ebi.ac.uk/pub/databases/chembl/UniChem/data/table_dumps/"
 
 # Expected headers for UniChem table dumps — validated at filter/parse time.
 # Note: upstream uses "ASSIGMENT" (missing 'N') in the reference file — this matches the upstream typo exactly.
@@ -25,13 +25,15 @@ UNICHEM_STRUCT_TSV_HEADER = "UCI\tSTANDARDINCHI\tSTANDARDINCHIKEY\n"
 
 
 def download_unichem_structure():
-    """Download UniChem structure file. Format validation happens in filter_unichem."""
-    pull_via_wget(_UNICHEM_FTP_BASE, "structure.tsv.gz", decompress=False, subpath="UNICHEM", verify_gzip=True)
+    """Download UniChem structure file. Gzip integrity is verified at download time; column-format
+    validation happens in read_inchikeys() (called from write_unichem_concords)."""
+    pull_via_wget(_UNICHEM_HTTP_BASE, "structure.tsv.gz", decompress=False, subpath="UNICHEM", verify_gzip=True)
 
 
 def download_unichem_reference():
-    """Download UniChem reference file. Format validation happens in filter_unichem."""
-    pull_via_wget(_UNICHEM_FTP_BASE, "reference.tsv.gz", decompress=False, subpath="UNICHEM", verify_gzip=True)
+    """Download UniChem reference file. Gzip integrity is verified at download time; header and
+    column-format validation happens in filter_unichem()."""
+    pull_via_wget(_UNICHEM_HTTP_BASE, "reference.tsv.gz", decompress=False, subpath="UNICHEM", verify_gzip=True)
 
 
 def filter_unichem(ref_file, ref_filtered):

--- a/src/datahandlers/unichem.py
+++ b/src/datahandlers/unichem.py
@@ -18,7 +18,7 @@ data_sources: dict = {
 
 # Expected header of reference.tsv.gz — validated by filter_unichem() at filter time.
 # Note: upstream uses "ASSIGMENT" (missing 'N') — this matches the upstream typo exactly.
-REFERENCE_HEADER = "UCI\tSRC_ID\tSRC_COMPOUND_ID\tASSIGMENT\n"
+UNICHEM_REFERENCE_TSV_HEADER = "UCI\tSRC_ID\tSRC_COMPOUND_ID\tASSIGMENT\n"
 
 
 def download_unichem_structure():
@@ -57,11 +57,11 @@ def filter_unichem(ref_file, ref_filtered):
         except EOFError as e:
             raise RuntimeError(f"UniChem reference file {ref_file} is truncated (could not read header): {e}") from e
 
-        if header_line != REFERENCE_HEADER:
+        if header_line != UNICHEM_REFERENCE_TSV_HEADER:
             raise ValueError(
                 f"UniChem reference file {ref_file} has an unexpected header — "
-                f"re-run download_unichem_reference to re-download.\n"
-                f"  Expected : {REFERENCE_HEADER!r}\n"
+                f"examine the file and update UNICHEM_REFERENCE_TSV_HEADER in src/datahandlers/unichem.py if the format has changed.\n"
+                f"  Expected : {UNICHEM_REFERENCE_TSV_HEADER!r}\n"
                 f"  Got      : {header_line!r}"
             )
         out.write(header_line)

--- a/src/datahandlers/unichem.py
+++ b/src/datahandlers/unichem.py
@@ -1,14 +1,14 @@
 import gzip
 
 from src.babel_utils import pull_via_wget
-from src.prefixes import CHEBI, CHEMBLCOMPOUND, DRUGBANK, DRUGCENTRAL, GTOPDB, HMDB, KEGGCOMPOUND, PUBCHEMCOMPOUND, UNII
+from src.prefixes import CHEBI, CHEMBLCOMPOUND, DRUGBANK, DRUGCENTRAL, GTOPDB, HMDB, PUBCHEMCOMPOUND, UNII
 
 # global for this file
 data_sources: dict = {
     "1": CHEMBLCOMPOUND,
     "2": DRUGBANK,
     "4": GTOPDB,
-    "6": KEGGCOMPOUND,
+    # "6": KEGGCOMPOUND,  # Removed from UniChem — https://github.com/NCATSTranslator/Babel/issues/834
     "7": CHEBI,
     "14": UNII,
     "18": HMDB,

--- a/src/datahandlers/unichem.py
+++ b/src/datahandlers/unichem.py
@@ -16,36 +16,27 @@ data_sources: dict = {
     "34": DRUGCENTRAL,
 }
 
-# Expected header of reference.tsv.gz — validated by filter_unichem() at filter time.
-# Note: upstream uses "ASSIGMENT" (missing 'N') — this matches the upstream typo exactly.
+_UNICHEM_FTP_BASE = "http://ftp.ebi.ac.uk/pub/databases/chembl/UniChem/data/table_dumps/"
+
+# Expected headers for UniChem table dumps — validated at filter/parse time.
+# Note: upstream uses "ASSIGMENT" (missing 'N') in the reference file — this matches the upstream typo exactly.
 UNICHEM_REFERENCE_TSV_HEADER = "UCI\tSRC_ID\tSRC_COMPOUND_ID\tASSIGMENT\n"
+UNICHEM_STRUCT_TSV_HEADER = "UCI\tSTANDARDINCHI\tSTANDARDINCHIKEY\n"
 
 
 def download_unichem_structure():
     """Download UniChem structure file. Format validation happens in filter_unichem."""
-    pull_via_wget(
-        "http://ftp.ebi.ac.uk/pub/databases/chembl/UniChem/data/table_dumps/",
-        "structure.tsv.gz",
-        decompress=False,
-        subpath="UNICHEM",
-        verify_gzip=True,
-    )
+    pull_via_wget(_UNICHEM_FTP_BASE, "structure.tsv.gz", decompress=False, subpath="UNICHEM", verify_gzip=True)
 
 
 def download_unichem_reference():
     """Download UniChem reference file. Format validation happens in filter_unichem."""
-    pull_via_wget(
-        "http://ftp.ebi.ac.uk/pub/databases/chembl/UniChem/data/table_dumps/",
-        "reference.tsv.gz",
-        decompress=False,
-        subpath="UNICHEM",
-        verify_gzip=True,
-    )
+    pull_via_wget(_UNICHEM_FTP_BASE, "reference.tsv.gz", decompress=False, subpath="UNICHEM", verify_gzip=True)
 
 
 def filter_unichem(ref_file, ref_filtered):
     """Filter UniChem reference file to those sources we're interested in."""
-    srclist = [str(k) for k in data_sources.keys()]
+    srcs = set(data_sources)
     try:
         rf_handle = gzip.open(ref_file, "rt")
     except (OSError, gzip.BadGzipFile) as e:
@@ -73,7 +64,7 @@ def filter_unichem(ref_file, ref_filtered):
                     f"UniChem reference file {ref_file} line {line_num}: "
                     f"expected ≥4 tab-separated columns, got {len(x)}: {line!r}"
                 )
-            if x[1] in srclist and x[3] == "1":
+            if x[1] in srcs and x[3] == "1":
                 # Only use rows with assignment == 1 (current), not 0 (obsolete)
                 # As per https://chembl.gitbook.io/unichem/definitions/what-is-an-assignment
                 out.write(line)

--- a/src/datahandlers/unichem.py
+++ b/src/datahandlers/unichem.py
@@ -1,6 +1,6 @@
 import gzip
 
-from src.babel_utils import pull_via_urllib
+from src.babel_utils import pull_via_wget
 from src.prefixes import CHEBI, CHEMBLCOMPOUND, DRUGBANK, DRUGCENTRAL, GTOPDB, HMDB, KEGGCOMPOUND, PUBCHEMCOMPOUND, UNII
 
 # global for this file
@@ -23,14 +23,14 @@ REFERENCE_HEADER = "UCI\tSRC_ID\tSRC_COMPOUND_ID\tASSIGMENT\n"
 
 def download_unichem():
     """Download raw UniChem files. Format validation happens in filter_unichem."""
-    pull_via_urllib(
+    pull_via_wget(
         "http://ftp.ebi.ac.uk/pub/databases/chembl/UniChem/data/table_dumps/",
         "structure.tsv.gz",
         decompress=False,
         subpath="UNICHEM",
         verify_gzip=True,
     )
-    pull_via_urllib(
+    pull_via_wget(
         "http://ftp.ebi.ac.uk/pub/databases/chembl/UniChem/data/table_dumps/",
         "reference.tsv.gz",
         decompress=False,

--- a/src/datahandlers/unichem.py
+++ b/src/datahandlers/unichem.py
@@ -16,13 +16,13 @@ data_sources: dict = {
     "34": DRUGCENTRAL,
 }
 
-# Expected header of reference.tsv.gz — shared by pull_unichem() (validated at
-# download time) and filter_unichem() (validated again at filter time).
-REFERENCE_HEADER = "UCI\tSRC_ID\tSRC_COMPOUND_ID\tASSIGNMENT\n"
+# Expected header of reference.tsv.gz — validated by filter_unichem() at filter time.
+# Note: upstream uses "ASSIGMENT" (missing 'N') — this matches the upstream typo exactly.
+REFERENCE_HEADER = "UCI\tSRC_ID\tSRC_COMPOUND_ID\tASSIGMENT\n"
 
 
-def pull_unichem():
-    """Download UniChem files."""
+def download_unichem():
+    """Download raw UniChem files. Format validation happens in filter_unichem."""
     pull_via_urllib(
         "http://ftp.ebi.ac.uk/pub/databases/chembl/UniChem/data/table_dumps/",
         "structure.tsv.gz",
@@ -30,25 +30,13 @@ def pull_unichem():
         subpath="UNICHEM",
         verify_gzip=True,
     )
-    ref_path = pull_via_urllib(
+    pull_via_urllib(
         "http://ftp.ebi.ac.uk/pub/databases/chembl/UniChem/data/table_dumps/",
         "reference.tsv.gz",
         decompress=False,
         subpath="UNICHEM",
         verify_gzip=True,
     )
-
-    # Validate the header immediately after downloading so that get_unichem fails
-    # (and Snakemake deletes its outputs) rather than letting filter_unichem fail
-    # later on a file whose format has silently changed upstream.
-    with gzip.open(ref_path, "rt") as f:
-        header = f.readline()
-    if header != REFERENCE_HEADER:
-        raise RuntimeError(
-            f"UniChem reference.tsv.gz has an unexpected header — the upstream format may have changed.\n"
-            f"  Expected : {REFERENCE_HEADER!r}\n"
-            f"  Got      : {header!r}"
-        )
 
 
 def filter_unichem(ref_file, ref_filtered):
@@ -68,7 +56,7 @@ def filter_unichem(ref_file, ref_filtered):
         if header_line != REFERENCE_HEADER:
             raise ValueError(
                 f"UniChem reference file {ref_file} has an unexpected header — "
-                f"re-run get_unichem to re-download.\n"
+                f"re-run download_unichem to re-download.\n"
                 f"  Expected : {REFERENCE_HEADER!r}\n"
                 f"  Got      : {header_line!r}"
             )

--- a/src/datahandlers/unichem.py
+++ b/src/datahandlers/unichem.py
@@ -16,6 +16,10 @@ data_sources: dict = {
     "34": DRUGCENTRAL,
 }
 
+# Expected header of reference.tsv.gz — shared by pull_unichem() (validated at
+# download time) and filter_unichem() (validated again at filter time).
+REFERENCE_HEADER = "UCI\tSRC_ID\tSRC_COMPOUND_ID\tASSIGNMENT\n"
+
 
 def pull_unichem():
     """Download UniChem files."""
@@ -26,7 +30,7 @@ def pull_unichem():
         subpath="UNICHEM",
         verify_gzip=True,
     )
-    pull_via_urllib(
+    ref_path = pull_via_urllib(
         "http://ftp.ebi.ac.uk/pub/databases/chembl/UniChem/data/table_dumps/",
         "reference.tsv.gz",
         decompress=False,
@@ -34,19 +38,50 @@ def pull_unichem():
         verify_gzip=True,
     )
 
+    # Validate the header immediately after downloading so that get_unichem fails
+    # (and Snakemake deletes its outputs) rather than letting filter_unichem fail
+    # later on a file whose format has silently changed upstream.
+    with gzip.open(ref_path, "rt") as f:
+        header = f.readline()
+    if header != REFERENCE_HEADER:
+        raise RuntimeError(
+            f"UniChem reference.tsv.gz has an unexpected header — the upstream format may have changed.\n"
+            f"  Expected : {REFERENCE_HEADER!r}\n"
+            f"  Got      : {header!r}"
+        )
+
 
 def filter_unichem(ref_file, ref_filtered):
     """Filter UniChem reference file to those sources we're interested in."""
     srclist = [str(k) for k in data_sources.keys()]
-    with gzip.open(ref_file, "rt") as rf, open(ref_filtered, "w") as ref_filtered:
-        header_line = rf.readline()
-        assert header_line == "UCI\tSRC_ID\tSRC_COMPOUND_ID\tASSIGNMENT\n", (
-            f"Incorrect header line in {ref_file}: {header_line}"
-        )
-        ref_filtered.write(header_line)
-        for line in rf:
+    try:
+        rf_handle = gzip.open(ref_file, "rt")
+    except (OSError, gzip.BadGzipFile) as e:
+        raise RuntimeError(f"Cannot open UniChem reference file {ref_file}: {e}") from e
+
+    with rf_handle, open(ref_filtered, "w") as out:
+        try:
+            header_line = rf_handle.readline()
+        except EOFError as e:
+            raise RuntimeError(f"UniChem reference file {ref_file} is truncated (could not read header): {e}") from e
+
+        if header_line != REFERENCE_HEADER:
+            raise ValueError(
+                f"UniChem reference file {ref_file} has an unexpected header — "
+                f"re-run get_unichem to re-download.\n"
+                f"  Expected : {REFERENCE_HEADER!r}\n"
+                f"  Got      : {header_line!r}"
+            )
+        out.write(header_line)
+
+        for line_num, line in enumerate(rf_handle, start=2):
             x = line.rstrip().split("\t")
+            if len(x) < 4:
+                raise ValueError(
+                    f"UniChem reference file {ref_file} line {line_num}: "
+                    f"expected ≥4 tab-separated columns, got {len(x)}: {line!r}"
+                )
             if x[1] in srclist and x[3] == "1":
                 # Only use rows with assignment == 1 (current), not 0 (obsolete)
                 # As per https://chembl.gitbook.io/unichem/definitions/what-is-an-assignment
-                ref_filtered.writelines([line])
+                out.write(line)

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -756,20 +756,34 @@ rule get_panther_pathway_labels:
 ### Unichem
 
 
-rule download_unichem:
+rule download_unichem_structure:
     output:
         config["download_directory"] + "/UNICHEM/structure.tsv.gz",
-        config["download_directory"] + "/UNICHEM/reference.tsv.gz",
     benchmark:
-        config["output_directory"] + "/benchmarks/download_unichem.tsv"
+        config["output_directory"] + "/benchmarks/download_unichem_structure.tsv"
     retries: 3
     resources:
         mem="8G",
         disk="50G",
         cpus_per_task=1,
-        runtime=120,
+        runtime=240,
     run:
-        unichem.download_unichem()
+        unichem.download_unichem_structure()
+
+
+rule download_unichem_reference:
+    output:
+        config["download_directory"] + "/UNICHEM/reference.tsv.gz",
+    benchmark:
+        config["output_directory"] + "/benchmarks/download_unichem_reference.tsv"
+    retries: 3
+    resources:
+        mem="8G",
+        disk="8G",
+        cpus_per_task=1,
+        runtime=60,
+    run:
+        unichem.download_unichem_reference()
 
 
 rule filter_unichem:

--- a/src/snakefiles/datacollect.snakefile
+++ b/src/snakefiles/datacollect.snakefile
@@ -756,18 +756,20 @@ rule get_panther_pathway_labels:
 ### Unichem
 
 
-rule get_unichem:
+rule download_unichem:
     output:
         config["download_directory"] + "/UNICHEM/structure.tsv.gz",
         config["download_directory"] + "/UNICHEM/reference.tsv.gz",
     benchmark:
-        config["output_directory"] + "/benchmarks/get_unichem.tsv"
+        config["output_directory"] + "/benchmarks/download_unichem.tsv"
     retries: 3
     resources:
         mem="8G",
+        disk="50G",
         cpus_per_task=1,
+        runtime=120,
     run:
-        unichem.pull_unichem()
+        unichem.download_unichem()
 
 
 rule filter_unichem:

--- a/tests/createcompendia/test_chemicals.py
+++ b/tests/createcompendia/test_chemicals.py
@@ -68,3 +68,17 @@ def test_write_unichem_concords_raises_on_unexpected_embedded_prefix(tmp_path):
 
     with pytest.raises(ValueError, match="unexpected embedded prefix"):
         write_unichem_concords(str(struct), str(ref), str(tmp_path))
+
+
+@pytest.mark.unit
+def test_write_unichem_concords_raises_when_source_produces_no_entries(tmp_path):
+    """Any configured source that contributes zero rows should raise RuntimeError."""
+    struct = tmp_path / "structure.tsv.gz"
+    ref = tmp_path / "reference.tsv"
+    _write_struct(struct)
+    # Feed rows for every source except CHEBI — CHEBI should trigger the empty-source guard.
+    rows = [("1", src_id, "100") for src_id in unichem_data_sources if src_id != CHEBI_SRC_ID]
+    _write_ref(ref, rows)
+
+    with pytest.raises(RuntimeError, match="no entries for the following sources"):
+        write_unichem_concords(str(struct), str(ref), str(tmp_path))

--- a/tests/createcompendia/test_chemicals.py
+++ b/tests/createcompendia/test_chemicals.py
@@ -1,0 +1,72 @@
+"""Unit tests for src.createcompendia.chemicals.
+
+Currently focused on write_unichem_concords()'s handling of UniChem compound IDs
+that already embed their source prefix (e.g. the CHEBI source stores
+"CHEBI:12345" rather than a bare "12345"), which previously produced invalid
+"CHEBI:CHEBI:12345" CURIEs across the chemical compendia.
+"""
+
+import gzip
+
+import pytest
+
+from src.createcompendia.chemicals import write_unichem_concords
+from src.datahandlers.unichem import UNICHEM_REFERENCE_TSV_HEADER
+from src.datahandlers.unichem import data_sources as unichem_data_sources
+from src.prefixes import CHEBI
+
+STRUCT_HEADER = "UCI\tSTANDARDINCHI\tSTANDARDINCHIKEY\n"
+
+# UniChem source id for CHEBI (see data_sources in src/datahandlers/unichem.py).
+CHEBI_SRC_ID = "7"
+
+
+def _bare_rows_for_other_sources():
+    """One bare-ID row per non-CHEBI source.
+
+    write_unichem_concords() raises if any configured source produces no entries,
+    so a focused test still has to feed every source at least one row.
+    """
+    return [("1", src_id, "100") for src_id in unichem_data_sources if src_id != CHEBI_SRC_ID]
+
+
+def _write_struct(path):
+    """Write a minimal gzipped UniChem structure file with one UCI→InChIKey row."""
+    with gzip.open(path, "wt") as out:
+        out.write(STRUCT_HEADER)
+        out.write("1\tInChI=1S/H2O/h1H2\tXLYOFNOQVPJJNP-UHFFFAOYSA-N\n")
+
+
+def _write_ref(path, rows):
+    """Write a UniChem reference file; rows are (uci, src_id, compound_id) tuples (assignment is always '1')."""
+    with open(path, "w") as out:
+        out.write(UNICHEM_REFERENCE_TSV_HEADER)
+        for uci, src_id, compound_id in rows:
+            out.write(f"{uci}\t{src_id}\t{compound_id}\t1\n")
+
+
+@pytest.mark.unit
+def test_write_unichem_concords_strips_embedded_chebi_prefix(tmp_path):
+    """A CHEBI compound ID stored as 'CHEBI:12345' must yield CHEBI:12345, not CHEBI:CHEBI:12345."""
+    struct = tmp_path / "structure.tsv.gz"
+    ref = tmp_path / "reference.tsv"
+    _write_struct(struct)
+    _write_ref(ref, [("1", CHEBI_SRC_ID, "CHEBI:12345"), *_bare_rows_for_other_sources()])
+
+    write_unichem_concords(str(struct), str(ref), str(tmp_path))
+
+    content = (tmp_path / f"UNICHEM_{CHEBI}").read_text()
+    assert "CHEBI:12345\t" in content
+    assert "CHEBI:CHEBI" not in content
+
+
+@pytest.mark.unit
+def test_write_unichem_concords_raises_on_unexpected_embedded_prefix(tmp_path):
+    """A CHEBI row carrying a foreign embedded prefix is a format change worth a loud failure."""
+    struct = tmp_path / "structure.tsv.gz"
+    ref = tmp_path / "reference.tsv"
+    _write_struct(struct)
+    _write_ref(ref, [("1", CHEBI_SRC_ID, "FOO:9")])
+
+    with pytest.raises(ValueError, match="unexpected embedded prefix"):
+        write_unichem_concords(str(struct), str(ref), str(tmp_path))

--- a/tests/createcompendia/test_chemicals.py
+++ b/tests/createcompendia/test_chemicals.py
@@ -11,14 +11,12 @@ import gzip
 import pytest
 
 from src.createcompendia.chemicals import write_unichem_concords
-from src.datahandlers.unichem import UNICHEM_REFERENCE_TSV_HEADER
+from src.datahandlers.unichem import UNICHEM_REFERENCE_TSV_HEADER, UNICHEM_STRUCT_TSV_HEADER
 from src.datahandlers.unichem import data_sources as unichem_data_sources
 from src.prefixes import CHEBI
 
-STRUCT_HEADER = "UCI\tSTANDARDINCHI\tSTANDARDINCHIKEY\n"
-
-# UniChem source id for CHEBI (see data_sources in src/datahandlers/unichem.py).
-CHEBI_SRC_ID = "7"
+# Derive CHEBI's UniChem source ID from the authoritative dict rather than hardcoding it.
+CHEBI_SRC_ID = next(k for k, v in unichem_data_sources.items() if v == CHEBI)
 
 
 def _bare_rows_for_other_sources():
@@ -33,7 +31,7 @@ def _bare_rows_for_other_sources():
 def _write_struct(path):
     """Write a minimal gzipped UniChem structure file with one UCI→InChIKey row."""
     with gzip.open(path, "wt") as out:
-        out.write(STRUCT_HEADER)
+        out.write(UNICHEM_STRUCT_TSV_HEADER)
         out.write("1\tInChI=1S/H2O/h1H2\tXLYOFNOQVPJJNP-UHFFFAOYSA-N\n")
 
 

--- a/tests/datahandlers/test_unichem.py
+++ b/tests/datahandlers/test_unichem.py
@@ -40,9 +40,7 @@ def test_unichem_url_accessible_with_user_agent(filename):
     assert len(raw) > 0, f"UniChem {filename} returned an empty body"
 
     # Confirm the bytes are a valid gzip stream (magic bytes 0x1f 0x8b).
-    assert raw[:2] == b"\x1f\x8b", (
-        f"UniChem {filename} does not appear to be a gzip file (got {raw[:2]!r})"
-    )
+    assert raw[:2] == b"\x1f\x8b", f"UniChem {filename} does not appear to be a gzip file (got {raw[:2]!r})"
 
     # Try to decompress the partial chunk to catch obviously truncated/corrupt files.
     try:

--- a/tests/datahandlers/test_unichem.py
+++ b/tests/datahandlers/test_unichem.py
@@ -72,13 +72,15 @@ def test_unichem_reference_header_matches_expected():
 
     assert raw[:2] == b"\x1f\x8b", "reference.tsv.gz does not look like a gzip file"
 
+    header = ""
     try:
         with gzip.open(io.BytesIO(raw), "rt") as gz:
             header = gz.readline()
     except EOFError:
-        # Partial gzip stream at end of chunk is expected; we already got the header
-        # by this point since readline() returned before raising.
-        pass
+        # A partial gzip stream at the end of the chunk is expected. readline() may have
+        # already populated `header` before the stream ended; if it didn't, fail loudly.
+        if not header:
+            pytest.fail("reference.tsv.gz: gzip stream ended before a complete header line could be read")
     except Exception as exc:
         pytest.fail(f"Could not decompress initial chunk of reference.tsv.gz: {exc}")
 

--- a/tests/datahandlers/test_unichem.py
+++ b/tests/datahandlers/test_unichem.py
@@ -14,7 +14,7 @@ import urllib.request
 import pytest
 
 from src.babel_utils import get_user_agent
-from src.datahandlers.unichem import REFERENCE_HEADER
+from src.datahandlers.unichem import UNICHEM_REFERENCE_TSV_HEADER
 
 pytestmark = [pytest.mark.network]
 
@@ -58,7 +58,7 @@ def test_unichem_url_accessible_with_user_agent(filename):
 
 @pytest.mark.slow
 def test_unichem_reference_header_matches_expected():
-    """The first line of reference.tsv.gz must match REFERENCE_HEADER exactly.
+    """The first line of reference.tsv.gz must match UNICHEM_REFERENCE_TSV_HEADER exactly.
 
     This test downloads a small initial chunk of the file (~256 KB) and decompresses
     it to read the header.  It guards against upstream format changes like the
@@ -84,9 +84,9 @@ def test_unichem_reference_header_matches_expected():
     except Exception as exc:
         pytest.fail(f"Could not decompress initial chunk of reference.tsv.gz: {exc}")
 
-    assert header == REFERENCE_HEADER, (
-        f"UniChem reference.tsv.gz header has changed — update REFERENCE_HEADER in "
+    assert header == UNICHEM_REFERENCE_TSV_HEADER, (
+        f"UniChem reference.tsv.gz header has changed — update UNICHEM_REFERENCE_TSV_HEADER in "
         f"src/datahandlers/unichem.py.\n"
-        f"  Expected : {REFERENCE_HEADER!r}\n"
+        f"  Expected : {UNICHEM_REFERENCE_TSV_HEADER!r}\n"
         f"  Got      : {header!r}"
     )

--- a/tests/datahandlers/test_unichem.py
+++ b/tests/datahandlers/test_unichem.py
@@ -71,13 +71,15 @@ def test_unichem_reference_header_matches_expected():
 
     assert raw[:2] == b"\x1f\x8b", "reference.tsv.gz does not look like a gzip file"
 
+    header = ""
     try:
         with gzip.open(io.BytesIO(raw), "rt") as gz:
             header = gz.readline()
     except EOFError:
-        # Partial gzip stream at end of chunk is expected; we already got the header
-        # by this point since readline() returned before raising.
-        pass
+        # A partial gzip stream at the end of the chunk is expected. readline() may have
+        # already populated `header` before the stream ended; if it didn't, fail loudly.
+        if not header:
+            pytest.fail("reference.tsv.gz: gzip stream ended before a complete header line could be read")
     except Exception as exc:
         pytest.fail(f"Could not decompress initial chunk of reference.tsv.gz: {exc}")
 

--- a/tests/datahandlers/test_unichem.py
+++ b/tests/datahandlers/test_unichem.py
@@ -1,16 +1,20 @@
 """Network tests for the UniChem download.
 
 These verify that the UniChem FTP mirror URLs are reachable with the User-Agent
-Babel sends and that each file is a valid gzip archive.
+Babel sends, that each file is a valid gzip archive, and that the reference file
+header matches the constant in unichem.py.
 Run with: uv run pytest --network tests/datahandlers/test_unichem.py
 """
 
+import gzip
+import io
 import urllib.error
 import urllib.request
 
 import pytest
 
 from src.babel_utils import get_user_agent
+from src.datahandlers.unichem import REFERENCE_HEADER
 
 pytestmark = [pytest.mark.network]
 
@@ -50,3 +54,39 @@ def test_unichem_url_accessible_with_user_agent(filename):
         d.decompress(raw)
     except zlib.error as exc:
         pytest.fail(f"UniChem {filename} first 64 KB failed gzip decompression: {exc}")
+
+
+@pytest.mark.slow
+def test_unichem_reference_header_matches_expected():
+    """The first line of reference.tsv.gz must match REFERENCE_HEADER exactly.
+
+    This test downloads a small initial chunk of the file (~256 KB) and decompresses
+    it to read the header.  It guards against upstream format changes like the
+    2026-06 rename of 'ASSIGNMENT' → 'ASSIGMENT'.
+    """
+    url = UNICHEM_BASE + "reference.tsv.gz"
+    req = urllib.request.Request(url, headers={"User-Agent": get_user_agent()})
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            raw = resp.read(262144)  # 256 KB — header is always in the first block
+    except urllib.error.HTTPError as e:
+        pytest.fail(f"UniChem reference.tsv.gz returned HTTP {e.code}: {e}")
+
+    assert raw[:2] == b"\x1f\x8b", "reference.tsv.gz does not look like a gzip file"
+
+    try:
+        with gzip.open(io.BytesIO(raw), "rt") as gz:
+            header = gz.readline()
+    except EOFError:
+        # Partial gzip stream at end of chunk is expected; we already got the header
+        # by this point since readline() returned before raising.
+        pass
+    except Exception as exc:
+        pytest.fail(f"Could not decompress initial chunk of reference.tsv.gz: {exc}")
+
+    assert header == REFERENCE_HEADER, (
+        f"UniChem reference.tsv.gz header has changed — update REFERENCE_HEADER in "
+        f"src/datahandlers/unichem.py.\n"
+        f"  Expected : {REFERENCE_HEADER!r}\n"
+        f"  Got      : {header!r}"
+    )

--- a/tests/datahandlers/test_unichem.py
+++ b/tests/datahandlers/test_unichem.py
@@ -15,7 +15,7 @@ import zlib
 import pytest
 
 from src.babel_utils import get_user_agent
-from src.datahandlers.unichem import REFERENCE_HEADER
+from src.datahandlers.unichem import UNICHEM_REFERENCE_TSV_HEADER
 
 pytestmark = [pytest.mark.network]
 
@@ -55,7 +55,7 @@ def test_unichem_url_accessible_with_user_agent(filename):
 
 @pytest.mark.slow
 def test_unichem_reference_header_matches_expected():
-    """The first line of reference.tsv.gz must match REFERENCE_HEADER exactly.
+    """The first line of reference.tsv.gz must match UNICHEM_REFERENCE_TSV_HEADER exactly.
 
     This test downloads a small initial chunk of the file (~256 KB) and decompresses
     it to read the header.  It guards against upstream format changes like the
@@ -81,9 +81,9 @@ def test_unichem_reference_header_matches_expected():
     except Exception as exc:
         pytest.fail(f"Could not decompress initial chunk of reference.tsv.gz: {exc}")
 
-    assert header == REFERENCE_HEADER, (
-        f"UniChem reference.tsv.gz header has changed — update REFERENCE_HEADER in "
+    assert header == UNICHEM_REFERENCE_TSV_HEADER, (
+        f"UniChem reference.tsv.gz header has changed — update UNICHEM_REFERENCE_TSV_HEADER in "
         f"src/datahandlers/unichem.py.\n"
-        f"  Expected : {REFERENCE_HEADER!r}\n"
+        f"  Expected : {UNICHEM_REFERENCE_TSV_HEADER!r}\n"
         f"  Got      : {header!r}"
     )

--- a/tests/datahandlers/test_unichem.py
+++ b/tests/datahandlers/test_unichem.py
@@ -1,6 +1,6 @@
 """Network tests for the UniChem download.
 
-These verify that the UniChem FTP mirror URLs are reachable with the User-Agent
+These verify that the UniChem HTTP mirror URLs are reachable with the User-Agent
 Babel sends, that each file is a valid gzip archive, and that the reference file
 header matches the constant in unichem.py.
 Run with: uv run pytest --network tests/datahandlers/test_unichem.py

--- a/tests/datahandlers/test_unichem.py
+++ b/tests/datahandlers/test_unichem.py
@@ -1,10 +1,13 @@
 """Network tests for the UniChem download.
 
 These verify that the UniChem HTTP mirror URLs are reachable with the User-Agent
-Babel sends and that each file is a valid gzip archive.
+Babel sends, that each file is a valid gzip archive, and that the reference file
+header matches the constant in unichem.py.
 Run with: uv run pytest --network tests/datahandlers/test_unichem.py
 """
 
+import gzip
+import io
 import urllib.error
 import urllib.request
 import zlib
@@ -12,6 +15,7 @@ import zlib
 import pytest
 
 from src.babel_utils import get_user_agent
+from src.datahandlers.unichem import REFERENCE_HEADER
 
 pytestmark = [pytest.mark.network]
 
@@ -47,3 +51,39 @@ def test_unichem_url_accessible_with_user_agent(filename):
         d.decompress(raw)
     except zlib.error as exc:
         pytest.fail(f"UniChem {filename} first 64 KB failed gzip decompression: {exc}")
+
+
+@pytest.mark.slow
+def test_unichem_reference_header_matches_expected():
+    """The first line of reference.tsv.gz must match REFERENCE_HEADER exactly.
+
+    This test downloads a small initial chunk of the file (~256 KB) and decompresses
+    it to read the header.  It guards against upstream format changes like the
+    2026-06 rename of 'ASSIGNMENT' → 'ASSIGMENT'.
+    """
+    url = UNICHEM_BASE + "reference.tsv.gz"
+    req = urllib.request.Request(url, headers={"User-Agent": get_user_agent()})
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            raw = resp.read(262144)  # 256 KB — header is always in the first block
+    except urllib.error.HTTPError as e:
+        pytest.fail(f"UniChem reference.tsv.gz returned HTTP {e.code}: {e}")
+
+    assert raw[:2] == b"\x1f\x8b", "reference.tsv.gz does not look like a gzip file"
+
+    try:
+        with gzip.open(io.BytesIO(raw), "rt") as gz:
+            header = gz.readline()
+    except EOFError:
+        # Partial gzip stream at end of chunk is expected; we already got the header
+        # by this point since readline() returned before raising.
+        pass
+    except Exception as exc:
+        pytest.fail(f"Could not decompress initial chunk of reference.tsv.gz: {exc}")
+
+    assert header == REFERENCE_HEADER, (
+        f"UniChem reference.tsv.gz header has changed — update REFERENCE_HEADER in "
+        f"src/datahandlers/unichem.py.\n"
+        f"  Expected : {REFERENCE_HEADER!r}\n"
+        f"  Got      : {header!r}"
+    )


### PR DESCRIPTION
This PR fixes:

**Output fix**
- Strip the embedded `CHEBI:` prefix from UniChem compound IDs so they stop producing malformed `CHEBI:CHEBI:...` CURIEs (with a regression test).

**Source removal**
- Remove KEGG.COMPOUND (UniChem source 6), which was dropped upstream (#834).

**Header handling**
- Accept UniChem's misspelled `ASSIGMENT` header (missing the second 'N'); centralize the reference-TSV and struct-TSV header strings as exported constants (`UNICHEM_REFERENCE_TSV_HEADER`, `UNICHEM_STRUCT_TSV_HEADER`) so all assertions share one source of truth.

**Rule split and download robustness**
- Split `get_unichem` into separate `download_unichem_structure` / `download_unichem_reference` / `filter_unichem` rules (per the repo convention added in CLAUDE.md), enabling parallel downloads and preserving the cached file when only the format check fails.
- Switch to `pull_via_wget` for resumable downloads with gzip integrity verification.
- Add `os.makedirs` to `pull_via_wget` so callers outside Snakemake don't fail when the subpath directory hasn't been created yet (mirrors `pull_via_urllib` behaviour).
- Replace the Python gzip read loop in `verify_gzip` with `subprocess gzip -t` — faster (native code), cleaner stderr on failure.

**Error handling**
- Distinguish empty-file vs multi-prefix errors in `combine_unichem`; raise `RuntimeError` with a targeted message for each case.
- Raise early when any configured UniChem source produces no entries in the reference file, with a message explaining how to fix it.

**Naming / docstring / assert cleanups**
- Rename `_UNICHEM_FTP_BASE` → `_UNICHEM_HTTP_BASE` (the URL is HTTP, not FTP).
- Fix `download_unichem_structure()` / `download_unichem_reference()` docstrings to correctly state where gzip and format validation each happen.
- Add a descriptive message to the bare `assert x[3] == "1"` in `write_unichem_concords`.

Per CLAUDE.md, the CHEBI-prefix and KEGG.COMPOUND changes were checked for cross-compendium identifier movement.

## Test plan
- `uv run ruff check && uv run ruff format --check`
- `uv run snakefmt --check --compact-diff .`
- `uv run rumdl check .`
- `uv run pytest -m unit`  (incl. `test_chemicals.py`: CHEBI-prefix stripping, unexpected-prefix rejection, empty-source guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)