### PR TITLE
fixed issue #827 with DRUGBANK:DB10626 preferred name

### DIFF
--- a/input_data/label_overrides.yaml
+++ b/input_data/label_overrides.yaml
@@ -1,0 +1,22 @@
+# Manual CURIE-specific label corrections.
+#
+# Use this file when an upstream source emits a primary label that is too broad,
+# misleading, or otherwise unsuitable for Babel output, and the correction should
+# apply only to that exact CURIE.
+#
+# Required fields:
+#   replacement_label: the label Babel should use for this CURIE.
+#   reason: why the manual correction exists.
+#
+# Optional fields:
+#   expected_source_label: the exact upstream label expected before replacement.
+#                          If the source label changes, Babel raises an error so
+#                          the override can be re-reviewed. If the source label
+#                          already equals replacement_label, Babel keeps it and
+#                          logs that the override is redundant.
+
+label_overrides:
+  "DRUGBANK:DB10626":
+    replacement_label: "Trout allergenic extract"
+    expected_source_label: "Trout"
+    reason: "DrugBank's generic name is too broad for this allergenic extract; RxNorm/UMLS use the specific extract label."

--- a/src/label_overrides.py
+++ b/src/label_overrides.py
@@ -1,0 +1,113 @@
+"""Manual CURIE-specific label corrections for upstream source labels."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+from src.util import get_config, get_logger
+
+logger = get_logger(__name__)
+
+_instance: Optional["LabelOverrideFactory"] = None
+
+
+@dataclass(frozen=True)
+class LabelOverride:
+    """A replacement label for one CURIE, with an expected source-label drift check."""
+
+    replacement_label: str
+    expected_source_label: str | None
+    reason: str
+
+
+class LabelOverrideFactory:
+    """Load and apply manual label overrides from ``input_data/label_overrides.yaml``."""
+
+    def __init__(self, override_file: Path):
+        self.override_file = override_file
+        self.overrides: dict[str, LabelOverride] = {}
+        self._load(override_file)
+
+    def _load(self, path: Path) -> None:
+        if not path.exists():
+            logger.info(f"LabelOverrideFactory: override file not found at {path}; no labels will be overridden.")
+            return
+
+        with open(path) as f:
+            data = yaml.safe_load(f) or {}
+
+        raw_overrides = data.get("label_overrides", {})
+        if not isinstance(raw_overrides, dict):
+            raise ValueError(f"label_overrides must be a CURIE-keyed mapping in {path}")
+
+        for curie, raw in raw_overrides.items():
+            if not isinstance(raw, dict):
+                raise ValueError(f"Label override for {curie} in {path} must be a mapping")
+            replacement_label = raw.get("replacement_label")
+            if not replacement_label:
+                raise ValueError(f"Label override for {curie} in {path} must include replacement_label")
+            self.overrides[curie] = LabelOverride(
+                replacement_label=replacement_label,
+                expected_source_label=raw.get("expected_source_label"),
+                reason=raw.get("reason", "(no reason given)"),
+            )
+
+        logger.info(f"LabelOverrideFactory: loaded {len(self.overrides)} label override(s) from {path}")
+
+    def apply(self, curie: str, label: str) -> str:
+        """Return the corrected label for ``curie`` when an override exists.
+
+        If ``expected_source_label`` is configured and the observed label no longer
+        matches it, fail loudly unless the observed label already equals the replacement.
+        This keeps stale manual overrides from silently masking upstream changes.
+        """
+
+        if not label or curie not in self.overrides:
+            return label
+
+        override = self.overrides[curie]
+        source = _source_from_curie(curie)
+        if label == override.replacement_label:
+            logger.warning(
+                f"Label override for {curie} in {self.override_file} is redundant: {source} already emits "
+                f"{override.replacement_label!r}. Reason: {override.reason}"
+            )
+            return label
+
+        if override.expected_source_label is not None and label != override.expected_source_label:
+            raise RuntimeError(
+                f"Label override for {curie} in {self.override_file} expected source label "
+                f"{override.expected_source_label!r}, but {source} emitted {label!r}. Re-review this override. "
+                f"Reason: {override.reason}"
+            )
+
+        logger.warning(
+            f"Overriding label for {curie} from {label!r} to {override.replacement_label!r} in {source}. "
+            f"Reason: {override.reason}"
+        )
+        return override.replacement_label
+
+
+def _source_from_curie(curie: str) -> str:
+    """Return the CURIE prefix for override diagnostics."""
+
+    return curie.split(":", 1)[0] if ":" in curie else "unknown source"
+
+
+def _get_label_override_factory() -> LabelOverrideFactory:
+    """Return the process-wide label override factory."""
+
+    global _instance
+    if _instance is None:
+        config = get_config()
+        override_file = Path(config.get("input_directory", "input_data")) / "label_overrides.yaml"
+        _instance = LabelOverrideFactory(override_file)
+    return _instance
+
+
+def apply_label_override(curie: str, label: str) -> str:
+    """Apply any configured manual label override for ``curie``."""
+
+    return _get_label_override_factory().apply(curie, label)

--- a/src/node.py
+++ b/src/node.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 
 import curies
 
+from src.label_overrides import apply_label_override
 from src.LabeledID import LabeledID
 from src.predicates import HAS_EXACT_SYNONYM
 from src.prefixes import PUBCHEMCOMPOUND
@@ -78,10 +79,13 @@ class SynonymFactory:
                 for line in inf:
                     x = line.strip().split("\t", maxsplit=1)
                     if len(x) == 1:
-                        lbs[x[0]].add((HAS_EXACT_SYNONYM, ""))
+                        curie = x[0]
+                        lbs[curie].add((HAS_EXACT_SYNONYM, ""))
                     elif len(x) == 2:
-                        lbs[x[0]].add((HAS_EXACT_SYNONYM, x[1]))
-                        if x[1]:
+                        curie = x[0]
+                        label = apply_label_override(curie, x[1])
+                        lbs[curie].add((HAS_EXACT_SYNONYM, label))
+                        if label:
                             count_labels += 1
         synfname = os.path.join(self.synonym_dir, prefix, "synonyms")
         if os.path.exists(synfname):
@@ -534,10 +538,11 @@ class NodeFactory:
             with open(labelfname) as inf:
                 for line in inf:
                     x = line.strip().split("\t", maxsplit=1)
+                    curie = x[0]
                     if len(x) == 1:
-                        lbs[x[0]] = ""
+                        lbs[curie] = ""
                     else:
-                        lbs[x[0]] = x[1]
+                        lbs[curie] = apply_label_override(curie, x[1])
         self.extra_labels[prefix] = lbs
 
     def apply_labels(self, input_identifiers, labels, node_types=None):
@@ -556,12 +561,12 @@ class NodeFactory:
                     for line in labelf:
                         x = line.strip().split("\t")
                         curie = x[0]
-                        new_label = x[1]
+                        new_label = apply_label_override(curie, x[1])
                         if curie in self.common_labels:
                             # We have multiple labels! For simplicity's sake, let's choose the longest one.
                             if len(new_label) <= len(self.common_labels[curie]):
                                 continue
-                        self.common_labels[x[0]] = x[1]
+                        self.common_labels[curie] = new_label
                         count_common_file_labels += 1
                 logger.info(
                     f"Loaded {count_common_file_labels:,} common labels from {common_labels_path}: {get_memory_usage_summary()}"
@@ -577,7 +582,7 @@ class NodeFactory:
             if isinstance(iid, LabeledID):
                 raise ValueError(f"LabeledID don't belong here ({iid}), pass in labels separately.")
             if iid in labels:
-                label = labels[iid]
+                label = apply_label_override(iid, labels[iid])
                 if synonym_filter.should_suppress(label, source=f"explicit labels for {iid}", node_types=node_types):
                     label = ""
                 labeled_list.append(LabeledID(identifier=iid, label=label))

--- a/tests/node/test_node_factory.py
+++ b/tests/node/test_node_factory.py
@@ -1,5 +1,6 @@
 import pytest
 
+import src.node as node_module
 import src.prefixes as pref
 from src import categories
 from src.LabeledID import LabeledID
@@ -313,3 +314,48 @@ def test_load_extra_labels_tab_in_label(tmp_path):
     fac.common_labels = {}
     fac.load_extra_labels("CHEMBL.COMPOUND")
     assert fac.extra_labels["CHEMBL.COMPOUND"]["CHEMBL.COMPOUND:CHEMBL3"] == "Water\tbottle"
+
+
+@pytest.mark.unit
+def test_load_extra_labels_applies_label_override(tmp_path):
+    """CURIE-specific label overrides are applied when source label files are loaded."""
+    label_dir = tmp_path / "DRUGBANK"
+    label_dir.mkdir()
+    (label_dir / "labels").write_text("DRUGBANK:DB10626\tTrout\n")
+    fac = NodeFactory(str(tmp_path), BIOLINK_VERSION)
+    fac.common_labels = {}
+    fac.load_extra_labels("DRUGBANK")
+    assert fac.extra_labels["DRUGBANK"]["DRUGBANK:DB10626"] == "Trout allergenic extract"
+
+
+@pytest.mark.unit
+def test_common_labels_apply_label_override(tmp_path, monkeypatch):
+    """Common labels use CURIE-specific label overrides before fallback labeling."""
+    common_dir = tmp_path / "common"
+    common_dir.mkdir()
+    (common_dir / "labels").write_text("DRUGBANK:DB10626\tTrout\n")
+    config = dict(get_config())
+    config["download_directory"] = str(tmp_path)
+    config["common"] = {"labels": ["labels"], "synonyms": [], "descriptions": []}
+
+    monkeypatch.setattr(node_module, "get_config", lambda: config)
+    fac = NodeFactory(str(tmp_path / "labels"), BIOLINK_VERSION)
+
+    labels = fac.apply_labels(["DRUGBANK:DB10626"], {})
+
+    assert labels == [LabeledID("DRUGBANK:DB10626", "Trout allergenic extract")]
+
+
+@pytest.mark.unit
+def test_label_override_feeds_preferred_name_selection(tmp_path):
+    """DRUGBANK:DB10626 is corrected before preferred-name selection sees the node."""
+    label_dir = tmp_path / "DRUGBANK"
+    label_dir.mkdir()
+    (label_dir / "labels").write_text("DRUGBANK:DB10626\tTrout\n")
+    fac = NodeFactory(str(tmp_path), BIOLINK_VERSION)
+    fac.common_labels = {}
+
+    node = fac.create_node(["DRUGBANK:DB10626", "UMLS:C2725895"], categories.CHEMICAL_ENTITY)
+
+    assert node["identifiers"][0]["identifier"] == "DRUGBANK:DB10626"
+    assert node["identifiers"][0]["label"] == "Trout allergenic extract"

--- a/tests/node/test_synonym_factory.py
+++ b/tests/node/test_synonym_factory.py
@@ -25,3 +25,19 @@ def test_load_synonyms_single_column(tmp_path):
 
     assert (HAS_EXACT_SYNONYM, "Water") in sf.synonyms["CHEMBL.COMPOUND"]["CHEMBL.COMPOUND:CHEMBL1"]
     assert (HAS_EXACT_SYNONYM, "") in sf.synonyms["CHEMBL.COMPOUND"]["CHEMBL.COMPOUND:CHEMBL2"]
+
+
+@pytest.mark.unit
+def test_load_synonyms_applies_label_override(tmp_path):
+    """Labels exposed as exact synonyms use the same CURIE-specific overrides."""
+    label_dir = tmp_path / "DRUGBANK"
+    label_dir.mkdir()
+    (label_dir / "labels").write_text("DRUGBANK:DB10626\tTrout\n")
+    sf = object.__new__(SynonymFactory)
+    sf.synonym_dir = tmp_path
+    sf.synonyms = {}
+    sf.common_synonyms = defaultdict(set)
+
+    sf.load_synonyms("DRUGBANK")
+
+    assert (HAS_EXACT_SYNONYM, "Trout allergenic extract") in sf.synonyms["DRUGBANK"]["DRUGBANK:DB10626"]

--- a/tests/test_label_overrides.py
+++ b/tests/test_label_overrides.py
@@ -1,0 +1,84 @@
+"""Unit tests for CURIE-specific label overrides."""
+
+import logging
+
+import pytest
+import yaml
+
+from src.label_overrides import LabelOverrideFactory
+
+
+def make_override_factory(tmp_path, overrides):
+    """Write a minimal label_overrides.yaml and return a LabelOverrideFactory for it."""
+    yaml_file = tmp_path / "label_overrides.yaml"
+    yaml_file.write_text(yaml.dump({"label_overrides": overrides}))
+    return LabelOverrideFactory(yaml_file)
+
+
+@pytest.mark.unit
+def test_label_override_replaces_expected_source_label(tmp_path):
+    factory = make_override_factory(
+        tmp_path,
+        {
+            "DRUGBANK:DB10626": {
+                "replacement_label": "Trout allergenic extract",
+                "expected_source_label": "Trout",
+                "reason": "Too broad",
+            }
+        },
+    )
+
+    assert factory.apply("DRUGBANK:DB10626", "Trout") == "Trout allergenic extract"
+
+
+@pytest.mark.unit
+def test_label_override_ignores_other_curies(tmp_path):
+    factory = make_override_factory(
+        tmp_path,
+        {
+            "DRUGBANK:DB10626": {
+                "replacement_label": "Trout allergenic extract",
+                "expected_source_label": "Trout",
+                "reason": "Too broad",
+            }
+        },
+    )
+
+    assert factory.apply("DRUGBANK:DB99999", "Trout") == "Trout"
+
+
+@pytest.mark.unit
+def test_label_override_allows_redundant_upstream_fix(tmp_path, caplog):
+    factory = make_override_factory(
+        tmp_path,
+        {
+            "DRUGBANK:DB10626": {
+                "replacement_label": "Trout allergenic extract",
+                "expected_source_label": "Trout",
+                "reason": "Too broad",
+            }
+        },
+    )
+
+    with caplog.at_level(logging.WARNING, logger="src.label_overrides"):
+        label = factory.apply("DRUGBANK:DB10626", "Trout allergenic extract")
+
+    assert label == "Trout allergenic extract"
+    assert any("redundant" in record.message for record in caplog.records)
+
+
+@pytest.mark.unit
+def test_label_override_fails_on_unexpected_source_label(tmp_path):
+    factory = make_override_factory(
+        tmp_path,
+        {
+            "DRUGBANK:DB10626": {
+                "replacement_label": "Trout allergenic extract",
+                "expected_source_label": "Trout",
+                "reason": "Too broad",
+            }
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="expected source label"):
+        factory.apply("DRUGBANK:DB10626", "Rainbow trout")


### PR DESCRIPTION
@gaurav This issue is triggered by upstream DRUGBANK source having a broad Trout as the preferred label for this curie. Even though both UMLS C2725895 and [rxcui:882582](https://rxnav.nlm.nih.gov/REST/rxcui/882482/properties.json) have the correct preferred label, DRUGBANK preferred label is chosen due to the preferred_name_boost_prefixes configuration for biolink:ChemicalEntity in config.yaml file that includes DRUGBANK in the list. Since this is just one example where boosted DRUGBANK label does not give us the correct preferred name, I fixed this issue by adding a configurable label_overrides.yaml which will be loaded to correct upstream DRUGBANK preferred label for this curie to the correct label. Let me know if there is a better approach to fix this issue, though.