### PR TITLE
drugchemical: record dropped conflation pairs to a retained exclusion report (#754)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,10 +236,21 @@ not for answering "are *these specific* CURIEs joinable."
 You may run `uv run snakemake -c all --rerun-incomplete [rulename]` to run a particular rule.
 When running a download step, it will be easier to run the job in Snakemake, but when running
 a rule that produces intermediate files, it might be easier to download the intermediate files from
-<https://stars.renci.org/var/babel/2025dec11/> (which is the `babel_output` folder from a run on a
-high performance cluster) so you don't need to download all the source files and
-rerun the entire pipeline. You can look at the resource requirements of a rule to decide which
-option would be best.
+a published HPC run (the `babel_outputs` folder from a high performance cluster) so you don't need
+to download all the source files and rerun the entire pipeline. You can look at the resource
+requirements of a rule to decide which option would be best.
+
+There are two publication roots on the RENCI stars server, and the difference matters:
+
+- `https://stars.renci.org/var/babel_outputs/<version>/` is the **full** output set, including
+  every identifier and cross-reference. Use this for debugging. Useful versions:
+  `2024oct24` (currently in Prod) and `2025sep1` (currently in CI). Note that not every version
+  publishes an `intermediate/` tree (e.g. `2024oct24` does not), so concord-level inspection is
+  only possible for versions that do.
+- `https://stars.renci.org/var/babel/<version>/` (e.g. `2025dec11`) contains **only** the subset
+  of identifiers and xrefs that may be shared outside of Translator, so it is missing many
+  identifiers/xrefs. Do **not** use it for debugging unless you are specifically working on that
+  externally-shareable output.
 
 ### Analyzing a SLURM run (`tools/slurm`)
 

--- a/docs/Conflation.md
+++ b/docs/Conflation.md
@@ -4,6 +4,11 @@ Babel is designed to produce cliques of _identical_ identifiers, but our users w
 to combine identifiers that are similar in some other way. Babel generates "conflations" to support
 this.
 
+For debugging "these identifiers used to be conflated and now aren't" regressions in the
+DrugChemical conflation, see [docs/debugging/Conflation.md](debugging/Conflation.md), which also
+documents the per-run exclusion report (`reports/drugchemical/excluded_pairs.tsv.gz`) that records
+why each subject/object pair was dropped.
+
 Babel currently generates two conflations:
 
 1. GeneProtein conflates gene with the protein transcribed from it.

--- a/docs/debugging/Conflation.md
+++ b/docs/debugging/Conflation.md
@@ -1,0 +1,144 @@
+# Debugging DrugChemical conflation regressions
+
+This page captures how to investigate "these identifiers used to be conflated and now aren't"
+problems in the DrugChemical conflation, using Babel issue
+[#754](https://github.com/NCATSTranslator/Babel/issues/754) (Carbidopa) as the worked example. It
+records both the diagnosis approach and the durable instrumentation we added so the next such
+regression is debuggable from retained build artifacts instead of guesswork.
+
+See `docs/Conflation.md` for the conflation output spec, and
+`src/createcompendia/drugchemical.py` for the implementation.
+
+## The motivating problem (#754)
+
+Carbidopa fragmented across Babel versions. Reading the published conflation outputs from
+`https://stars.renci.org/var/babel_outputs/<version>/conflation/DrugChemical.txt` directly:
+
+- **2024oct24** (Prod, correct) — one clique led by `CHEBI:3395`:
+  `["CHEBI:3395", "CHEBI:39585", "PUBCHEM.COMPOUND:146037278", RXCUI:…×27, "UMLS:C1881339"]`.
+- **2025sep1** (CI, regressed) — `CHEBI:3395` and `PUBCHEM.COMPOUND:146037278` are gone,
+  `CHEBI:192511` is new, and the ~27 RXCUIs plus `UMLS:C1881339` survive. (`CHEBI:39585` and
+  `CHEBI:192511` also each appear twice in that line — a separate write/ordering duplication bug
+  worth fixing independently; see the prefix-grouping/expansion in `build_conflation()`.)
+
+Because the RxCUI bridge barely changed but the two *chemical* endpoints dropped out, the regression
+most likely lives at the **compendium** level (CHEBI:3395 / PUBCHEM no longer share a clique with
+the bridge RxCUIs, or got reclassified into a Biolink type a filter rejects), not purely in
+conflation logic. Confirming that requires comparing the *inputs* between the two versions — which
+is exactly what was hard, because we did not retain enough intermediate detail.
+
+## How DrugChemical conflation merges cliques (and where it can drop things)
+
+`build_conflation()` (`src/createcompendia/drugchemical.py`) builds a list of subject/object CURIE
+pairs, normalizes each CURIE to its clique leader, runs `glom()` to merge transitively-connected
+pairs, and writes each merged set as one conflation. The pairs come from four sources:
+
+- The RXNORM and UMLS concords (`intermediate/drugchemical/concords/{RXNORM,UMLS}`): each
+  `RXCUI:a <pred> RXCUI:b` (or `UMLS:…`) pair is kept **only if both endpoints are RxCUIs that
+  belong to a Drug or chemical clique** (looked up via `load_cliques_containing_rxcui()`). If either
+  endpoint is not in such a clique, the pair is dropped. This is the primary RxNorm→CHEBI/PUBCHEM
+  bridge, and historically the drop was silent.
+- The PUBCHEM_RXNORM concord (`RXCUI:a linked PUBCHEM.COMPOUND:b`): the most direct CHEBI/PUBCHEM ↔
+  RxCUI link. Pairs are dropped if an endpoint does not resolve to a clique, has no preferred CURIE,
+  normalizes to a self-pair, or has a Biolink type that is not a `biolink:ChemicalEntity`
+  descendant.
+- The manual concord file (`input_data/manual_concords/drugchemical.tsv`): pairs are dropped if a
+  CURIE is not in any chemical compendium, or both normalize to the same leader.
+- Post-glom: a merged set that collapses to a single identifier after normalization is dropped.
+
+RxCUIs only enter chemical cliques (and thus become usable bridges) via `write_rxnorm_ids()` in
+`src/datahandlers/umls.py`, which types each RxCUI by its RxNorm TTY: `DF` (dose form) is excluded
+entirely; `IN`/`PIN` → ChemicalEntity; `MIN` → MolecularMixture; everything else → Drug. A RxCUI
+typed `Drug` lands in `Drug.txt`, and `biolink:Drug` is **not** a `biolink:ChemicalEntity`
+descendant — so the PubChem-path type filter can sever a `Drug`-typed RxCUI bridge. Also note
+`build_rxnorm_relationships()` drops a relationship whose subject maps to more than one object
+(multi-ingredient drugs), to avoid "everything is everything" over-glomming.
+
+## The durable instrumentation (added for #754)
+
+The core gap was that every one of those drop reasons existed only as a `logger.warning` on STDERR,
+which Snakemake discards once a rule succeeds (`src/util.py` deliberately writes no log files), so a
+past run left no trace of *why* a cross-reference was dropped. We added:
+
+`ConflationExclusionRecorder` (`src/createcompendia/drugchemical.py`) writes one row per dropped
+pair to a gzipped TSV that is now a **declared output** of the `drugchemical_conflation` rule:
+
+```text
+babel_outputs/reports/drugchemical/excluded_pairs.tsv.gz
+```
+
+Columns: `source, reason, subject, object, subject_type, object_type, detail`. Reason codes mirror
+the drop sites listed above: `rxcui_not_in_any_clique`, `no_preferred_curie`, `self_pair`,
+`non_chemical_type`, `manual_concord_not_in_compendium`, `manual_concord_self_pair`,
+`single_identifier_conflation`. A per-`(source, reason)` summary is also logged and folded into
+`babel_outputs/metadata/DrugChemical.yaml` under the `Exclusions` block.
+
+Because it lands under `reports/`, the file is published with every run and retained. Diagnosing a
+future "why was X dropped?" becomes one command:
+
+```bash
+zcat babel_outputs/reports/drugchemical/excluded_pairs.tsv.gz | grep CHEBI:3395
+```
+
+If the dropped CURIE is *not* in the report at all, that itself is informative: the pair was never
+generated upstream (the link is missing from the concord), pointing at the compendium-building /
+RxCUI typing layer rather than the conflation filter.
+
+The recorder is conflation-scoped today but written to be reusable; `geneprotein.py` could adopt it.
+The `build_rxnorm_relationships()` multi-ingredient drop happens during concord building (a
+different rule) and is **not** yet captured — instrumenting it would require that rule to emit its
+own exclusions file. See the TODO list below.
+
+## Diagnosing #754 once the inputs are available (deferred)
+
+The full root-cause diagnosis is deferred until we have richer retained inputs to diff —
+specifically the intermediate concord/identifier Parquet export from
+[PR #704](https://github.com/NCATSTranslator/Babel/pull/704). Once both that export and the new
+exclusion report exist in a run, the procedure is:
+
+1. Confirm the regression in `conflation/DrugChemical.txt` (done; see above).
+2. Check the new `reports/drugchemical/excluded_pairs.tsv.gz`: is `CHEBI:3395` /
+   `PUBCHEM.COMPOUND:146037278` / a bridge RxCUI present with a `reason`? If yes, the reason names
+   the filter to fix. If absent, the link was never generated → step 4.
+3. Use the intermediate-concord Parquet (PR #704) to check whether the raw
+   `RXCUI ↔ PUBCHEM.COMPOUND:146037278` and `RXCUI ↔ RXCUI` edges still exist for the Carbidopa
+   RxCUIs. This is the diff that 2024oct24 could not support, because that version published no
+   `intermediate/` tree.
+4. Inspect the compendia (or the published `duckdb/` Edge table, where available) to see which
+   clique each key CURIE lands in and whether that clique contains the bridge RxCUIs (e.g.
+   `SELECT clique_leader, curie FROM Edge WHERE curie IN ('CHEBI:3395', 'RXCUI:203437', …)`).
+   A SmallMolecule↔MolecularMixture split or a Drug reclassification of a bridge RxCUI is the likely
+   culprit.
+5. Decide conflation-level vs compendium-level, and only then write the fix plus a pinned regression
+   test in `tests/createcompendia/test_drugchemical.py` (a fixture-driven `build_conflation()` run
+   asserting the expected Carbidopa clique membership). If the fix needs a curated edge, add the
+   pair to `input_data/manual_concords/drugchemical.tsv`.
+
+## Reproducing the conflation locally (when needed)
+
+You do not need to rebuild the chemical compendia (a 512G / 6h rule) or download any source files to
+re-run just the conflation. Download these from a full-output version under
+`https://stars.renci.org/var/babel_outputs/<version>/` and place them at the matching local paths:
+
+- `intermediate/drugchemical/concords/{RXNORM,UMLS,PUBCHEM_RXNORM}` and their `metadata-*.yaml`
+- `compendia/Drug.txt` and the other chemical compendia (`config.yaml` `chemical_outputs`)
+- `icRDF.tsv` (top level)
+
+`input_data/manual_concords/drugchemical.tsv` is already in the repo. Then run the
+`drugchemical_conflation` rule. Caveat: the rule loads all chemical compendia into Python dicts and
+has no SLURM `mem=` override (defaults to 64G); on a full build it can exceed that, so use a
+largemem node or trimmed fixture compendia. Note again that `2024oct24` did not publish
+`intermediate/`, so the concords can only be downloaded for versions that did (e.g. `2025sep1`).
+
+A reminder lives in `CLAUDE.md`: use `https://stars.renci.org/var/babel_outputs/` (full identifiers)
+for debugging, **not** `https://stars.renci.org/var/babel/` (externally-shareable subset only).
+
+## TODO / future improvements
+
+- Land PR #704 (intermediate concord/identifier Parquet export) and improve it so the Carbidopa
+  diff above is a single query; see the TODOs filed on that PR.
+- Instrument `build_rxnorm_relationships()`'s multi-ingredient and one-to-one relationship drops
+  with their own exclusion report (separate rule output) so concord-build-time drops are also
+  retained.
+- Fix the duplicate-CURIE write bug (a conflation array should not list `CHEBI:39585` twice).
+- Add the pinned Carbidopa regression test once the root cause and fix are confirmed.

--- a/src/createcompendia/drugchemical.py
+++ b/src/createcompendia/drugchemical.py
@@ -1,4 +1,5 @@
 import csv
+import gzip
 import json
 import logging
 import sys
@@ -318,11 +319,59 @@ def build_pubchem_relationships(infile, outfile, metadata_yaml):
     )
 
 
+class ConflationExclusionRecorder:
+    """Records, to a gzipped TSV, every subject/object pair that ``build_conflation()`` drops, and why.
+
+    Historically the reasons a cross-reference failed to conflate existed only as ``logger.warning``
+    lines on STDERR, which Snakemake discards once a rule succeeds. That made regressions like
+    Babel #754 (the Carbidopa clique fragmenting between runs) impossible to diagnose after the
+    fact. This recorder turns those ephemeral warnings into a declared, published Snakemake output
+    so a future run can answer "why was CHEBI:3395 dropped?" with a single ``zgrep`` against the
+    retained report.
+
+    One row is written per dropped pair. Rows are streamed straight to the gzip file rather than
+    buffered, because the RXN/UMLS concords are large and many pairs may be dropped. ``subject`` and
+    ``object`` are written in whatever form they had at the drop site (raw RxCUI/UMLS CURIE for
+    resolution failures, preferred CURIE for type/self-pair failures). Use as a context manager.
+
+    Columns: source, reason, subject, object, subject_type, object_type, detail.
+    """
+
+    COLUMNS = ["source", "reason", "subject", "object", "subject_type", "object_type", "detail"]
+
+    def __init__(self, outfilename):
+        self.outfilename = outfilename
+        self._outf = gzip.open(outfilename, "wt", newline="")
+        self._writer = csv.writer(self._outf, dialect=csv.excel_tab)
+        self._writer.writerow(self.COLUMNS)
+        # (source, reason) -> count, for a summary log line and the metadata YAML.
+        self.counts = defaultdict(int)
+
+    def record(self, source, reason, subject, obj, subject_type="", object_type="", detail=""):
+        """Record one dropped pair. ``obj`` (not ``object``) avoids shadowing the builtin."""
+        self._writer.writerow([source, reason, subject, obj, subject_type or "", object_type or "", detail])
+        self.counts[(source, reason)] += 1
+
+    def total(self):
+        return sum(self.counts.values())
+
+    def close(self):
+        self._outf.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+        return False
+
+
 def _validate_and_apply_manual_concords(
     manual_concords: list[tuple[str, str]],
     preferred_curie_for_curie: dict[str, str],
     pairs: list[tuple[str, str]],
     manual_concord_filename: str,
+    exclusion_recorder: "ConflationExclusionRecorder | None" = None,
 ) -> int:
     """Validate each manual concord pair against the chemical compendia and append passing pairs to *pairs*.
 
@@ -353,6 +402,19 @@ def _validate_and_apply_manual_concords(
                 f"If so, remove it from {manual_concord_filename}."
             )
         if not subject_ok or not object_ok:
+            if exclusion_recorder is not None:
+                missing = []
+                if not subject_ok:
+                    missing.append(f"subject {subject_curie}")
+                if not object_ok:
+                    missing.append(f"object {object_curie}")
+                exclusion_recorder.record(
+                    source="Manual",
+                    reason="manual_concord_not_in_compendium",
+                    subject=subject_curie,
+                    obj=object_curie,
+                    detail=f"{' and '.join(missing)} not in any chemical compendium",
+                )
             skipped += 1
             continue
         norm_subject = preferred_curie_for_curie[subject_curie]
@@ -362,6 +424,14 @@ def _validate_and_apply_manual_concords(
                 f"Manual concord pair ({subject_curie}, {object_curie}) normalizes to the same preferred CURIE "
                 f"({norm_subject}); skipping self-pair."
             )
+            if exclusion_recorder is not None:
+                exclusion_recorder.record(
+                    source="Manual",
+                    reason="manual_concord_self_pair",
+                    subject=subject_curie,
+                    obj=object_curie,
+                    detail=f"both normalize to {norm_subject}",
+                )
             skipped += 1
             continue
         pairs.append((norm_subject, norm_object))
@@ -381,6 +451,7 @@ def build_conflation(
     outfilename,
     input_metadata_yamls,
     output_metadata_yaml,
+    exclusions_outfilename,
 ):
     """RXN_concord contains relationshps between rxcuis that can be used to conflate
     Now we don't want all of them.  We want the ones that are between drugs and chemicals,
@@ -390,6 +461,11 @@ def build_conflation(
     in the clique."""
 
     config = get_config()
+
+    # Records every subject/object pair we drop, and why, to a declared (and published) output so a
+    # missing cross-reference (e.g. Babel #754) can be diagnosed from a past run. See
+    # docs/debugging/Conflation.md.
+    exclusion_recorder = ConflationExclusionRecorder(exclusions_outfilename)
 
     logger.info("Loading information content values...")
     ic_factory = InformationContentFactory(icrdf_filename)
@@ -449,7 +525,7 @@ def build_conflation(
         chemical_rxcui_to_clique.update(load_cliques_containing_rxcui(chemical_compendium))
 
     pairs = []
-    for concfile in [rxn_concord, umls_concord]:
+    for concfile, source_label in [(rxn_concord, "RXNORM"), (umls_concord, "UMLS")]:
         with open(concfile) as infile:
             for line in infile:
                 x = line.strip().split("\t")
@@ -474,10 +550,29 @@ def build_conflation(
                     subject_curie = chemical_rxcui_to_clique[subject_curie]
                     object_curie = chemical_rxcui_to_clique[object_curie]
                     pairs.append((subject_curie, object_curie))
+                else:
+                    # Neither endpoint is a RxCUI that belongs to a Drug or chemical clique, so this
+                    # relationship cannot bridge two cliques and is dropped. This silent drop is the
+                    # most likely place for a cross-reference (e.g. Babel #754) to vanish when an RxCUI
+                    # stops being a member of the expected clique upstream, which is why we record it.
+                    subject_in_drug = subject_curie in drug_rxcui_to_clique
+                    subject_in_chem = subject_curie in chemical_rxcui_to_clique
+                    object_in_drug = object_curie in drug_rxcui_to_clique
+                    object_in_chem = object_curie in chemical_rxcui_to_clique
+                    exclusion_recorder.record(
+                        source=source_label,
+                        reason="rxcui_not_in_any_clique",
+                        subject=subject_curie,
+                        obj=object_curie,
+                        detail=(
+                            f"subject in_drug={subject_in_drug} in_chem={subject_in_chem}; "
+                            f"object in_drug={object_in_drug} in_chem={object_in_chem}"
+                        ),
+                    )
 
     # Add the manual concords, normalizing CURIEs to their preferred form.
     manual_concords_skipped, manual_concords_applied_curies = _validate_and_apply_manual_concords(
-        manual_concords, preferred_curie_for_curie, pairs, manual_concord_filename
+        manual_concords, preferred_curie_for_curie, pairs, manual_concord_filename, exclusion_recorder
     )
 
     # We've had some issues with non-chemical types getting conflated, so we filter those out here.
@@ -497,6 +592,11 @@ def build_conflation(
             subject_curie = x[0]
             object_curie = x[2]
 
+            # Hold on to the raw (pre-normalization) CURIEs so the exclusion report shows what was
+            # actually in the PubChem concord, not a half-normalized value.
+            raw_subject_curie = subject_curie
+            raw_object_curie = object_curie
+
             if subject_curie in drug_rxcui_to_clique:
                 subject_curie = drug_rxcui_to_clique[subject_curie]
             elif subject_curie in chemical_rxcui_to_clique:
@@ -504,6 +604,13 @@ def build_conflation(
             else:
                 logger.warning(
                     f"Subject in subject-object pair ({subject_curie}, {object_curie}) isn't mapped to a RxCUI, skipping."
+                )
+                exclusion_recorder.record(
+                    source="PUBCHEM_RXNORM",
+                    reason="rxcui_not_in_any_clique",
+                    subject=raw_subject_curie,
+                    obj=raw_object_curie,
+                    detail="subject RxCUI not in any Drug or chemical clique",
                 )
                 continue
                 # raise RuntimeError(f"Unknown identifier in drugchemical conflation as subject: {subject_curie}")
@@ -516,6 +623,13 @@ def build_conflation(
                 logger.warning(
                     f"Object in subject-object pair ({subject_curie}, {object_curie}) isn't mapped to a RxCUI, skipping."
                 )
+                exclusion_recorder.record(
+                    source="PUBCHEM_RXNORM",
+                    reason="rxcui_not_in_any_clique",
+                    subject=raw_subject_curie,
+                    obj=raw_object_curie,
+                    detail="object not in any Drug or chemical clique",
+                )
                 # raise RuntimeError(f"Unknown identifier in drugchemical conflation as object: {object_curie}")
                 continue
 
@@ -524,6 +638,13 @@ def build_conflation(
                 logger.warning(
                     f"Subject in subject-object pair ({subject_curie}, {object_curie}) has no preferred CURIE, skipping."
                 )
+                exclusion_recorder.record(
+                    source="PUBCHEM_RXNORM",
+                    reason="no_preferred_curie",
+                    subject=subject_curie,
+                    obj=object_curie,
+                    detail="subject clique leader not in preferred_curie_for_curie",
+                )
                 continue
             subject_curie = preferred_curie_for_curie[subject_curie]
 
@@ -531,12 +652,26 @@ def build_conflation(
                 logger.warning(
                     f"Object in subject-object pair ({subject_curie}, {object_curie}) has no preferred CURIE, skipping."
                 )
+                exclusion_recorder.record(
+                    source="PUBCHEM_RXNORM",
+                    reason="no_preferred_curie",
+                    subject=subject_curie,
+                    obj=object_curie,
+                    detail="object clique leader not in preferred_curie_for_curie",
+                )
                 continue
             object_curie = preferred_curie_for_curie[object_curie]
 
             if subject_curie == object_curie:
                 logger.warning(
                     f"Subject and object in subject-object pair ({subject_curie}, {object_curie}) normalize to the same identifier ({subject_curie}), skipping."
+                )
+                exclusion_recorder.record(
+                    source="PUBCHEM_RXNORM",
+                    reason="self_pair",
+                    subject=raw_subject_curie,
+                    obj=raw_object_curie,
+                    detail=f"both normalize to {subject_curie}",
                 )
                 continue
 
@@ -547,12 +682,30 @@ def build_conflation(
                 logger.warning(
                     f"Subject in subject-object pair ({subject_curie}, {object_curie}) has type {subject_type}, which is is not a chemical type, skipping."
                 )
+                exclusion_recorder.record(
+                    source="PUBCHEM_RXNORM",
+                    reason="non_chemical_type",
+                    subject=subject_curie,
+                    obj=object_curie,
+                    subject_type=subject_type,
+                    object_type=type_for_preferred_curie.get(object_curie, ""),
+                    detail="subject type is not a biolink:ChemicalEntity descendant",
+                )
                 continue
 
             object_type = type_for_preferred_curie[object_curie]
             if object_type not in biolink_chemical_types:
                 logger.warning(
                     f"Object in subject-object pair ({subject_curie}, {object_curie}) has type {object_type}, which is is not a chemical type, skipping."
+                )
+                exclusion_recorder.record(
+                    source="PUBCHEM_RXNORM",
+                    reason="non_chemical_type",
+                    subject=subject_curie,
+                    obj=object_curie,
+                    subject_type=subject_type,
+                    object_type=object_type,
+                    detail="object type is not a biolink:ChemicalEntity descendant",
                 )
                 continue
 
@@ -668,6 +821,13 @@ def build_conflation(
                 logger.debug(
                     f"Found a DrugChemical conflation with a single identifier, skipping: {normalized_conflation_id_list}."
                 )
+                exclusion_recorder.record(
+                    source="glom",
+                    reason="single_identifier_conflation",
+                    subject=normalized_conflation_id_list[0],
+                    obj="",
+                    detail="clique collapsed to a single identifier after normalization",
+                )
                 continue
 
             # Within each of those groups, we want to sort by:
@@ -738,6 +898,14 @@ def build_conflation(
             outf.write(final_conflation_id_list)
             written.add(fs)
 
+    # Finalize the exclusion report and log a summary of why pairs were dropped.
+    exclusion_recorder.close()
+    logger.info(f"Wrote {exclusion_recorder.total():,} excluded DrugChemical pairs to {exclusions_outfilename}.")
+    exclusion_counts_by_reason = {}
+    for (source, reason), count in sorted(exclusion_recorder.counts.items()):
+        logger.info(f" - {source} / {reason}: {count:,}")
+        exclusion_counts_by_reason[f"{source}/{reason}"] = count
+
     # Write out metadata.yaml
     write_combined_metadata(
         output_metadata_yaml,
@@ -758,7 +926,15 @@ def build_conflation(
                     "predicates": dict(manual_concords_predicate_counts),
                     "prefix_counts": dict(manual_concords_curie_prefix_counts),
                 },
-            }
+            },
+            "Exclusions": {
+                "name": "DrugChemical excluded pairs",
+                "filename": exclusions_outfilename,
+                "counts": {
+                    "count_excluded_pairs": exclusion_recorder.total(),
+                    "count_by_source_and_reason": exclusion_counts_by_reason,
+                },
+            },
         },
     )
 

--- a/src/snakefiles/drugchemical.snakefile
+++ b/src/snakefiles/drugchemical.snakefile
@@ -68,6 +68,7 @@ rule drugchemical_conflation:
     output:
         outfile=config["output_directory"] + "/conflation/DrugChemical.txt",
         metadata_yaml=config["output_directory"] + "/metadata/DrugChemical.yaml",
+        exclusions=config["output_directory"] + "/reports/drugchemical/excluded_pairs.tsv.gz",
     benchmark:
         config["output_directory"] + "/benchmarks/drugchemical_conflation.tsv"
     run:
@@ -82,6 +83,7 @@ rule drugchemical_conflation:
             output.outfile,
             input_metadata_yamls=[input.rxnorm_metadata, input.umls_metadata, input.pubchem_metadata],
             output_metadata_yaml=output.metadata_yaml,
+            exclusions_outfilename=output.exclusions,
         )
 
 

--- a/tests/createcompendia/test_drugchemical.py
+++ b/tests/createcompendia/test_drugchemical.py
@@ -2,14 +2,18 @@
 Unit tests for src/createcompendia/drugchemical.py.
 
 These exercise _validate_and_apply_manual_concords, which validates manual
-concord pairs against the chemical compendia and normalises their CURIEs.
+concord pairs against the chemical compendia and normalises their CURIEs, and
+ConflationExclusionRecorder, which records every dropped subject/object pair to a
+gzipped TSV so a missing cross-reference can be diagnosed from a past run.
 """
 
+import csv
+import gzip
 import logging
 
 import pytest
 
-from src.createcompendia.drugchemical import _validate_and_apply_manual_concords
+from src.createcompendia.drugchemical import ConflationExclusionRecorder, _validate_and_apply_manual_concords
 
 CONCORD_FILE = "input_data/manual_concords/drugchemical.tsv"
 
@@ -101,3 +105,66 @@ def test_aliases_normalizing_to_same_curie_are_skipped(caplog):
     assert pairs == []
     assert applied_curies == set()
     assert "CHEMBL:123" in caplog.text
+
+
+def _read_exclusions(path):
+    """Read a gzipped exclusion-report TSV back into a list of dict rows."""
+    with gzip.open(path, "rt", newline="") as inf:
+        return list(csv.DictReader(inf, dialect=csv.excel_tab))
+
+
+@pytest.mark.unit
+def test_exclusion_recorder_writes_header_rows_and_counts(tmp_path):
+    """The recorder writes a header, one row per dropped pair, and tracks per-(source, reason) counts."""
+    outfile = tmp_path / "excluded_pairs.tsv.gz"
+    with ConflationExclusionRecorder(outfile) as recorder:
+        recorder.record(source="RXNORM", reason="rxcui_not_in_any_clique", subject="RXCUI:1", obj="RXCUI:2")
+        recorder.record(source="RXNORM", reason="rxcui_not_in_any_clique", subject="RXCUI:3", obj="RXCUI:4")
+        recorder.record(
+            source="PUBCHEM_RXNORM",
+            reason="non_chemical_type",
+            subject="CHEBI:5",
+            obj="PUBCHEM.COMPOUND:6",
+            subject_type="biolink:Gene",
+            detail="subject type is not a biolink:ChemicalEntity descendant",
+        )
+        assert recorder.total() == 3
+
+    rows = _read_exclusions(outfile)
+    assert len(rows) == 3
+    assert set(rows[0].keys()) == set(ConflationExclusionRecorder.COLUMNS)
+    assert rows[0]["source"] == "RXNORM"
+    assert rows[0]["subject"] == "RXCUI:1"
+    assert rows[2]["subject_type"] == "biolink:Gene"
+    assert rows[2]["object"] == "PUBCHEM.COMPOUND:6"
+    assert recorder.counts[("RXNORM", "rxcui_not_in_any_clique")] == 2
+    assert recorder.counts[("PUBCHEM_RXNORM", "non_chemical_type")] == 1
+
+
+@pytest.mark.unit
+def test_validate_records_missing_curie_exclusion(tmp_path):
+    """When a manual concord CURIE is absent from the compendia, a row is recorded with the missing CURIE."""
+    outfile = tmp_path / "excluded_pairs.tsv.gz"
+    pairs: list[tuple[str, str]] = []
+    with ConflationExclusionRecorder(outfile) as recorder:
+        _validate_and_apply_manual_concords([("MISSING:001", "CHEBI:456")], PREFERRED, pairs, CONCORD_FILE, recorder)
+    rows = _read_exclusions(outfile)
+    assert len(rows) == 1
+    assert rows[0]["reason"] == "manual_concord_not_in_compendium"
+    assert "MISSING:001" in rows[0]["detail"]
+
+
+@pytest.mark.unit
+def test_validate_records_self_pair_exclusion(tmp_path):
+    """A manual concord whose CURIEs collapse to the same leader is recorded as a self-pair."""
+    outfile = tmp_path / "excluded_pairs.tsv.gz"
+    pairs: list[tuple[str, str]] = []
+    with ConflationExclusionRecorder(outfile) as recorder:
+        # CHEMBL:123 and DRUGBANK:DB001 both normalize to CHEMBL:123.
+        _validate_and_apply_manual_concords(
+            [("CHEMBL:123", "DRUGBANK:DB001")], PREFERRED, pairs, CONCORD_FILE, recorder
+        )
+    rows = _read_exclusions(outfile)
+    assert len(rows) == 1
+    assert rows[0]["reason"] == "manual_concord_self_pair"
+    assert rows[0]["subject"] == "CHEMBL:123"


### PR DESCRIPTION
## What this does

Makes DrugChemical conflation regressions diagnosable from retained build artifacts, motivated by
#754 (the Carbidopa clique fragmenting between the 2024oct24 and 2025sep1 runs).

Previously, every reason `build_conflation()` dropped a subject/object pair existed only as a
`logger.warning` on STDERR, which Snakemake discards once the rule succeeds. So a past run left no
trace of *why* a cross-reference was dropped, and (because 2024oct24 published no `intermediate/`
tree) there was no way to diff inputs after the fact.

### Changes

- **`ConflationExclusionRecorder`** (`src/createcompendia/drugchemical.py`) streams one row per
  dropped pair — `source, reason, subject, object, subject_type, object_type, detail` — to a gzipped
  TSV that is now a **declared output** of the `drugchemical_conflation` rule:
  `babel_outputs/reports/drugchemical/excluded_pairs.tsv.gz`. Lands under `reports/`, so it is
  published and retained every run. Diagnosing "why was CHEBI:3395 dropped?" becomes one `zgrep`.
- Instrumented **every** drop site: the previously-**silent** RXNORM/UMLS `else` branch (the most
  likely place a bridge vanishes), all six PubChem-path filters, both manual-concord rejections, and
  the post-glom single-identifier collapse. A per-`(source, reason)` summary is logged and folded
  into `metadata/DrugChemical.yaml` under an `Exclusions` block.
- **Tests**: offline unit tests for the recorder round-trip and the two manual-concord exclusion
  paths.
- **Docs**: new `docs/debugging/Conflation.md` (full diagnosis procedure, including the deferred
  root-cause steps that depend on #704's intermediate Parquet export), cross-linked from
  `docs/Conflation.md`. Corrected the stars.renci.org guidance in `CLAUDE.md` to use
  `/var/babel_outputs/` (full identifiers) for debugging, not `/var/babel/` (shareable subset).

## Scope / not in this PR

This is the "do-now" instrumentation only. The actual #754 root-cause fix is **deferred** until the
intermediate-concord Parquet export (#704) lands, so the new exclusion report can be diffed against
the raw upstream edges; the procedure is documented in `docs/debugging/Conflation.md`. Related TODOs
were filed on #704. Also noted there: a separate duplicate-CURIE write bug observed in the 2025sep1
output, and instrumenting `build_rxnorm_relationships()`'s concord-build-time drops.

## Testing

`uv run pytest tests/createcompendia/test_drugchemical.py -q` (9 passed). ruff, snakefmt, and rumdl
all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
