### PR TITLE
Add bounded retry/backoff to TripleStore SPARQL execution

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -28,6 +28,15 @@ tmp_directory: babel_downloads/tmp
 # HTTP settings.
 http: {}
 
+# SPARQL query settings.
+sparql:
+  # How many times to attempt a SPARQL query before giving up. The first attempt counts,
+  # so max_retries=3 means one initial try plus two retries.
+  max_retries: 3
+  # Base delay in seconds between retries. Actual delay grows exponentially with each attempt
+  # (attempt 1 → 1s, attempt 2 → 2s, attempt 3 → 4s, …).
+  retry_base_delay_seconds: 1
+
 # Maps Python compendium names (as used in src/createcompendia/ and tests) to the
 # directory names that Snakemake uses under intermediate_directory.
 # Compendia not listed here use their own name as the directory name.

--- a/config.yaml
+++ b/config.yaml
@@ -30,11 +30,11 @@ http: {}
 
 # SPARQL query settings.
 sparql:
-  # How many times to attempt a SPARQL query before giving up. The first attempt counts,
-  # so max_retries=3 means one initial try plus two retries.
-  max_retries: 3
-  # Base delay in seconds between retries. Actual delay grows exponentially with each attempt
-  # (attempt 1 → 1s, attempt 2 → 2s, attempt 3 → 4s, …).
+  # Total number of attempts (initial try + retries) before giving up; must be >= 1.
+  # Example: max_attempts=3 → one initial try, then up to two retries.
+  max_attempts: 3
+  # Base delay in seconds between attempts; must be >= 0. Actual delay grows exponentially
+  # (attempt 1 → 1 s, attempt 2 → 2 s, attempt 3 → 4 s, …). Accepts fractional values.
   retry_base_delay_seconds: 1
 
 # Maps Python compendium names (as used in src/createcompendia/ and tests) to the

--- a/src/triplestore.py
+++ b/src/triplestore.py
@@ -8,9 +8,9 @@ from urllib.error import HTTPError
 from SPARQLWrapper import JSON, POST, POSTDIRECTLY, SPARQLWrapper2
 
 from src.babel_utils import get_user_agent
-from src.util import LoggingUtil, get_config
+from src.util import LoggingUtil, get_config, get_logger
 
-logger = LoggingUtil.init_logging(__name__, logging.WARNING)
+logger = get_logger(__name__)
 
 
 class TripleStore:

--- a/src/triplestore.py
+++ b/src/triplestore.py
@@ -1,13 +1,16 @@
 import logging
 import os
+from json import JSONDecodeError
 from string import Template
+from time import sleep
+from urllib.error import HTTPError, URLError
 
 from SPARQLWrapper import JSON, POST, POSTDIRECTLY, SPARQLWrapper2
 
 from src.babel_utils import get_user_agent
-from src.util import LoggingUtil
+from src.util import LoggingUtil, get_config
 
-logger = LoggingUtil.init_logging(__name__, logging.ERROR)
+logger = LoggingUtil.init_logging(__name__, logging.WARNING)
 
 
 class TripleStore:
@@ -29,18 +32,61 @@ class TripleStore:
             query = stream.read()
         return query
 
-    def execute_query(self, query, post=False):
+    def execute_query(self, query, post=False, max_retries=None, retry_base_delay_seconds=None):
         """Execute a SPARQL query.
 
         :param query: A SPARQL query.
+        :param post: If True, send the query via HTTP POST.
+        :param max_retries: Maximum number of attempts before giving up (default from config).
+        :param retry_base_delay_seconds: Base delay in seconds for exponential back-off (default from config).
         :return: Returns a JSON formatted object.
         """
+        sparql_cfg = get_config().get("sparql", {})
+        if max_retries is None:
+            max_retries = sparql_cfg.get("max_retries", 3)
+        if retry_base_delay_seconds is None:
+            retry_base_delay_seconds = sparql_cfg.get("retry_base_delay_seconds", 1)
+
         if post:
             self.service.setRequestMethod(POSTDIRECTLY)
             self.service.setMethod(POST)
         self.service.setQuery(query)
         self.service.setReturnFormat(JSON)
-        return self.service.query().convert()
+        return self.dispatch_with_retries(max_retries, retry_base_delay_seconds)
+
+    def dispatch_with_retries(self, max_retries: int, retry_base_delay_seconds: int):
+        """Dispatch the query already loaded on self.service, retrying on transient failures."""
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                return self.service.query().convert()
+            except HTTPError as e:
+                if e.code < 500 or attempt >= max_retries:
+                    raise
+                self.wait_before_retry(attempt, max_retries, retry_base_delay_seconds, "SPARQL HTTP %d", e.code)
+            except (JSONDecodeError, TimeoutError, URLError, OSError) as e:
+                if attempt >= max_retries:
+                    raise
+                self.wait_before_retry(
+                    attempt,
+                    max_retries,
+                    retry_base_delay_seconds,
+                    "Transient SPARQL query failure (%s)",
+                    e.__class__.__name__,
+                )
+
+    def wait_before_retry(self, attempt: int, max_retries: int, retry_base_delay_seconds: int, msg: str, *args) -> None:
+        """Log a warning and sleep with exponential back-off before the next attempt."""
+        wait_seconds = retry_base_delay_seconds * (2 ** (attempt - 1))
+        logger.warning(
+            msg + " on attempt %d/%d; retrying in %ss",
+            *args,
+            attempt,
+            max_retries,
+            wait_seconds,
+        )
+        sleep(wait_seconds)
 
     def query(self, query_text, outputs, flat=False, post=False):
         """Execute a fully formed query and return results."""

--- a/src/triplestore.py
+++ b/src/triplestore.py
@@ -3,7 +3,7 @@ import os
 from json import JSONDecodeError
 from string import Template
 from time import sleep
-from urllib.error import HTTPError, URLError
+from urllib.error import HTTPError
 
 from SPARQLWrapper import JSON, POST, POSTDIRECTLY, SPARQLWrapper2
 
@@ -32,29 +32,38 @@ class TripleStore:
             query = stream.read()
         return query
 
-    def execute_query(self, query, post=False, max_retries=None, retry_base_delay_seconds=None):
+    def execute_query(self, query, post=False, max_attempts=None, retry_base_delay_seconds=None):
         """Execute a SPARQL query.
 
         :param query: A SPARQL query.
         :param post: If True, send the query via HTTP POST.
-        :param max_retries: Maximum number of attempts before giving up (default from config).
+        :param max_attempts: Total number of attempts (initial + retries) before giving up (default from config).
         :param retry_base_delay_seconds: Base delay in seconds for exponential back-off (default from config).
         :return: Returns a JSON formatted object.
         """
         sparql_cfg = get_config().get("sparql", {})
-        if max_retries is None:
-            max_retries = sparql_cfg.get("max_retries", 3)
+        if max_attempts is None:
+            max_attempts = sparql_cfg.get("max_attempts", 3)
         if retry_base_delay_seconds is None:
             retry_base_delay_seconds = sparql_cfg.get("retry_base_delay_seconds", 1)
+
+        if max_attempts < 1:
+            raise ValueError(f"max_attempts must be >= 1, got {max_attempts}")
+        if retry_base_delay_seconds < 0:
+            raise ValueError(f"retry_base_delay_seconds must be >= 0, got {retry_base_delay_seconds}")
 
         if post:
             self.service.setRequestMethod(POSTDIRECTLY)
             self.service.setMethod(POST)
         self.service.setQuery(query)
         self.service.setReturnFormat(JSON)
-        return self.dispatch_with_retries(max_retries, retry_base_delay_seconds)
+        return self._dispatch_with_retries(max_attempts, retry_base_delay_seconds)
 
-    def dispatch_with_retries(self, max_retries: int, retry_base_delay_seconds: int):
+    # HTTP status codes that indicate a transient server-side condition worth retrying.
+    # 429 (rate limiting) and 5xx (server errors) are transient; 4xx client errors are not.
+    _RETRYABLE_HTTP_CODES = frozenset({429, 500, 502, 503, 504})
+
+    def _dispatch_with_retries(self, max_attempts: int, retry_base_delay_seconds: float):
         """Dispatch the query already loaded on self.service, retrying on transient failures."""
         attempt = 0
         while True:
@@ -62,28 +71,30 @@ class TripleStore:
             try:
                 return self.service.query().convert()
             except HTTPError as e:
-                if e.code < 500 or attempt >= max_retries:
+                if e.code not in self._RETRYABLE_HTTP_CODES or attempt >= max_attempts:
                     raise
-                self.wait_before_retry(attempt, max_retries, retry_base_delay_seconds, "SPARQL HTTP %d", e.code)
-            except (JSONDecodeError, TimeoutError, URLError, OSError) as e:
-                if attempt >= max_retries:
+                self._wait_before_retry(attempt, max_attempts, retry_base_delay_seconds, "SPARQL HTTP %d", e.code)
+            except (JSONDecodeError, OSError) as e:
+                if attempt >= max_attempts:
                     raise
-                self.wait_before_retry(
+                self._wait_before_retry(
                     attempt,
-                    max_retries,
+                    max_attempts,
                     retry_base_delay_seconds,
                     "Transient SPARQL query failure (%s)",
                     e.__class__.__name__,
                 )
 
-    def wait_before_retry(self, attempt: int, max_retries: int, retry_base_delay_seconds: int, msg: str, *args) -> None:
+    def _wait_before_retry(
+        self, attempt: int, max_attempts: int, retry_base_delay_seconds: float, msg: str, *args
+    ) -> None:
         """Log a warning and sleep with exponential back-off before the next attempt."""
         wait_seconds = retry_base_delay_seconds * (2 ** (attempt - 1))
         logger.warning(
             msg + " on attempt %d/%d; retrying in %ss",
             *args,
             attempt,
-            max_retries,
+            max_attempts,
             wait_seconds,
         )
         sleep(wait_seconds)

--- a/src/triplestore.py
+++ b/src/triplestore.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from json import JSONDecodeError
 from string import Template
@@ -8,7 +7,7 @@ from urllib.error import HTTPError
 from SPARQLWrapper import JSON, POST, POSTDIRECTLY, SPARQLWrapper2
 
 from src.babel_utils import get_user_agent
-from src.util import LoggingUtil, get_config, get_logger
+from src.util import get_config, get_logger
 
 logger = get_logger(__name__)
 

--- a/tests/test_triplestore.py
+++ b/tests/test_triplestore.py
@@ -74,6 +74,21 @@ def test_execute_query_retries_on_http_503(monkeypatch):
 
 
 @pytest.mark.unit
+def test_execute_query_retries_on_http_429(monkeypatch):
+    """HTTP 429 (rate limiting) is a transient error and should be retried."""
+    ts = _mock_triplestore(
+        monkeypatch,
+        [
+            HTTPError("https://example.invalid", 429, "Too Many Requests", hdrs=None, fp=None),
+            {"ok": True},
+        ],
+    )
+
+    result = ts.execute_query("SELECT * WHERE {?s ?p ?o}")
+    assert result == {"ok": True}
+
+
+@pytest.mark.unit
 def test_execute_query_does_not_retry_http_400(monkeypatch):
     ts = _mock_triplestore(
         monkeypatch,
@@ -84,3 +99,34 @@ def test_execute_query_does_not_retry_http_400(monkeypatch):
 
     with pytest.raises(HTTPError):
         ts.execute_query("SELECT * WHERE {?s ?p ?o}")
+
+
+@pytest.mark.unit
+def test_execute_query_raises_after_all_attempts_exhausted(monkeypatch):
+    """After max_attempts failures the original exception propagates."""
+    ts = _mock_triplestore(
+        monkeypatch,
+        [
+            HTTPError("https://example.invalid", 503, "Service Unavailable", hdrs=None, fp=None),
+            HTTPError("https://example.invalid", 503, "Service Unavailable", hdrs=None, fp=None),
+            HTTPError("https://example.invalid", 503, "Service Unavailable", hdrs=None, fp=None),
+        ],
+    )
+
+    with pytest.raises(HTTPError) as exc_info:
+        ts.execute_query("SELECT * WHERE {?s ?p ?o}", max_attempts=3)
+    assert exc_info.value.code == 503
+
+
+@pytest.mark.unit
+def test_execute_query_rejects_invalid_max_attempts(monkeypatch):
+    ts = _mock_triplestore(monkeypatch, [])
+    with pytest.raises(ValueError, match="max_attempts"):
+        ts.execute_query("SELECT * WHERE {?s ?p ?o}", max_attempts=0)
+
+
+@pytest.mark.unit
+def test_execute_query_rejects_negative_delay(monkeypatch):
+    ts = _mock_triplestore(monkeypatch, [])
+    with pytest.raises(ValueError, match="retry_base_delay_seconds"):
+        ts.execute_query("SELECT * WHERE {?s ?p ?o}", retry_base_delay_seconds=-1)

--- a/tests/test_triplestore.py
+++ b/tests/test_triplestore.py
@@ -16,8 +16,13 @@ _FakeService — replaces ts.service with a queue of _FakeQueryResult values.
 
 _mock_triplestore() wires both fakes into a TripleStore and patches out
 `sleep` so retry delays are instant in tests.
+
+Network tests (marked `network`, skipped by default) run the same retry logic
+against the real Ubergraph endpoint, exercising the full SPARQLWrapper stack.
+Pass --network or --all to pytest to enable them.
 """
 
+from contextlib import contextmanager
 from json import JSONDecodeError
 from urllib.error import HTTPError
 
@@ -202,3 +207,59 @@ def test_execute_query_rejects_negative_delay(monkeypatch):
     ts = _mock_triplestore(monkeypatch, [])
     with pytest.raises(ValueError, match="retry_base_delay_seconds"):
         ts.execute_query("SELECT * WHERE {?s ?p ?o}", retry_base_delay_seconds=-1)
+
+
+# ---------------------------------------------------------------------------
+# Network tests — skipped by default, enabled with --network or --all
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _sparql_errors_are_xfail():
+    """Mark the enclosing test xfail if the SPARQL server returns any error.
+
+    Distinguishes server-side problems (xfail — expected in a degraded
+    environment) from assertion failures on valid-but-wrong data (real failures).
+    """
+    try:
+        yield
+    except Exception as exc:
+        pytest.xfail(f"SPARQL query failed (server-side issue): {exc}")
+
+
+@pytest.mark.network
+def test_execute_query_network_basic(ubergraph):
+    """A trivial SELECT against the real Ubergraph endpoint returns a non-empty result.
+
+    This exercises the full SPARQLWrapper stack (HTTP, JSON parsing, retry
+    machinery) against a live server, confirming that the happy path works
+    end-to-end.  Uses `SELECT (1 AS ?x) WHERE {}` — a standard SPARQL probe
+    that every conformant endpoint must answer.
+    """
+    with _sparql_errors_are_xfail():
+        result = ubergraph.triplestore.execute_query("SELECT (1 AS ?x) WHERE {}")
+    assert result is not None
+
+
+@pytest.mark.network
+def test_execute_query_network_long_running(ubergraph):
+    """A moderately expensive query completes without triggering spurious retries.
+
+    Fetches the first 10 000 owl:equivalentClass triples from Ubergraph — enough
+    to exercise the streaming/JSON-parse path and take a second or two, without
+    being so large that it strains the server on every CI run.  If the server
+    takes longer than usual and returns a transient error, the retry logic
+    should recover and the test should still pass (or xfail on a persistent
+    server error).
+    """
+    query = """
+    SELECT ?s ?o WHERE {
+        ?s <http://www.w3.org/2002/07/owl#equivalentClass> ?o .
+    }
+    LIMIT 10000
+    """
+    with _sparql_errors_are_xfail():
+        result = ubergraph.triplestore.execute_query(query)
+    assert result is not None
+    # SPARQLWrapper returns a dict with a "results" / "bindings" structure
+    assert "results" in result or hasattr(result, "bindings")

--- a/tests/test_triplestore.py
+++ b/tests/test_triplestore.py
@@ -1,0 +1,86 @@
+from json import JSONDecodeError
+from urllib.error import HTTPError
+
+import pytest
+
+from src.triplestore import TripleStore
+
+
+class _FakeQueryResult:
+    def __init__(self, value):
+        self._value = value
+
+    def convert(self):
+        if isinstance(self._value, Exception):
+            raise self._value
+        return self._value
+
+
+class _FakeService:
+    def __init__(self, values):
+        self._values = list(values)
+
+    def setRequestMethod(self, _):
+        return None
+
+    def setMethod(self, _):
+        return None
+
+    def setQuery(self, _):
+        return None
+
+    def setReturnFormat(self, _):
+        return None
+
+    def query(self):
+        if not self._values:
+            raise RuntimeError("No values remaining in fake service")
+        return _FakeQueryResult(self._values.pop(0))
+
+
+def _mock_triplestore(monkeypatch, responses):
+    ts = TripleStore("https://example.invalid/sparql")
+    ts.service = _FakeService(responses)
+    monkeypatch.setattr("src.triplestore.sleep", lambda _: None)
+    return ts
+
+
+@pytest.mark.unit
+def test_execute_query_retries_on_json_decode_error(monkeypatch):
+    ts = _mock_triplestore(
+        monkeypatch,
+        [
+            JSONDecodeError("bad json", "{}", 1),
+            {"ok": True},
+        ],
+    )
+
+    result = ts.execute_query("SELECT * WHERE {?s ?p ?o}")
+    assert result == {"ok": True}
+
+
+@pytest.mark.unit
+def test_execute_query_retries_on_http_503(monkeypatch):
+    ts = _mock_triplestore(
+        monkeypatch,
+        [
+            HTTPError("https://example.invalid", 503, "Service Unavailable", hdrs=None, fp=None),
+            {"ok": True},
+        ],
+    )
+
+    result = ts.execute_query("SELECT * WHERE {?s ?p ?o}")
+    assert result == {"ok": True}
+
+
+@pytest.mark.unit
+def test_execute_query_does_not_retry_http_400(monkeypatch):
+    ts = _mock_triplestore(
+        monkeypatch,
+        [
+            HTTPError("https://example.invalid", 400, "Bad Request", hdrs=None, fp=None),
+        ],
+    )
+
+    with pytest.raises(HTTPError):
+        ts.execute_query("SELECT * WHERE {?s ?p ?o}")

--- a/tests/test_triplestore.py
+++ b/tests/test_triplestore.py
@@ -1,3 +1,23 @@
+"""Tests for TripleStore.execute_query() retry and error-handling logic.
+
+The retry path is tested without a live SPARQL server using two thin fakes:
+
+_FakeQueryResult — wraps a single return value for one call to .convert().
+    If the value is an Exception instance, .convert() raises it; otherwise it
+    returns the value.  This mirrors SPARQLWrapper2's QueryResult contract,
+    where .convert() is what actually parses the HTTP response and can raise
+    JSONDecodeError or HTTPError if the body is malformed or the status was bad.
+
+_FakeService — replaces ts.service with a queue of _FakeQueryResult values.
+    Each call to .query() pops the next entry; if the queue is empty it raises
+    RuntimeError so a test that forgot to supply enough responses fails loudly.
+    The no-op setRequestMethod / setMethod / setQuery / setReturnFormat stubs
+    absorb the configuration calls that execute_query() makes before dispatch.
+
+_mock_triplestore() wires both fakes into a TripleStore and patches out
+`sleep` so retry delays are instant in tests.
+"""
+
 from json import JSONDecodeError
 from urllib.error import HTTPError
 
@@ -7,6 +27,14 @@ from src.triplestore import TripleStore
 
 
 class _FakeQueryResult:
+    """Single query result consumed by one .convert() call.
+
+    Stores either a plain return value or an exception.  If an exception is
+    stored, .convert() raises it, simulating a failed HTTP round-trip (e.g.
+    JSONDecodeError when the server returns malformed JSON, or HTTPError when
+    SPARQLWrapper surfaces an HTTP error status).
+    """
+
     def __init__(self, value):
         self._value = value
 
@@ -17,6 +45,19 @@ class _FakeQueryResult:
 
 
 class _FakeService:
+    """Replacement for SPARQLWrapper2 that replays a pre-loaded response queue.
+
+    Construct with an iterable of values (plain objects or Exception instances)
+    that will be returned by successive .query() calls.  Each call pops the
+    first entry and wraps it in _FakeQueryResult.  Attempting to call .query()
+    on an empty queue raises RuntimeError, which surfaces in tests as a clear
+    "you didn't supply enough responses" failure rather than a silent wrong answer.
+
+    The set*() methods are no-ops that absorb the configuration calls
+    execute_query() makes before dispatching (setRequestMethod, setMethod,
+    setQuery, setReturnFormat).
+    """
+
     def __init__(self, values):
         self._values = list(values)
 
@@ -39,14 +80,26 @@ class _FakeService:
 
 
 def _mock_triplestore(monkeypatch, responses):
+    """Return a TripleStore whose network layer is replaced with _FakeService.
+
+    `responses` is passed directly to _FakeService, so each entry may be a
+    plain dict/value (success) or an Exception subclass instance (failure).
+    `sleep` is patched to a no-op so retry back-off doesn't slow down tests.
+    """
     ts = TripleStore("https://example.invalid/sparql")
     ts.service = _FakeService(responses)
     monkeypatch.setattr("src.triplestore.sleep", lambda _: None)
     return ts
 
 
+# ---------------------------------------------------------------------------
+# Retry behaviour — transient errors
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.unit
 def test_execute_query_retries_on_json_decode_error(monkeypatch):
+    """A JSONDecodeError on the first attempt is retried; the second succeeds."""
     ts = _mock_triplestore(
         monkeypatch,
         [
@@ -61,6 +114,7 @@ def test_execute_query_retries_on_json_decode_error(monkeypatch):
 
 @pytest.mark.unit
 def test_execute_query_retries_on_http_503(monkeypatch):
+    """HTTP 503 (service unavailable) is a transient server error and should be retried."""
     ts = _mock_triplestore(
         monkeypatch,
         [
@@ -88,8 +142,14 @@ def test_execute_query_retries_on_http_429(monkeypatch):
     assert result == {"ok": True}
 
 
+# ---------------------------------------------------------------------------
+# Non-retryable errors
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.unit
 def test_execute_query_does_not_retry_http_400(monkeypatch):
+    """HTTP 400 is a client error (bad query); it propagates immediately without retrying."""
     ts = _mock_triplestore(
         monkeypatch,
         [
@@ -101,9 +161,14 @@ def test_execute_query_does_not_retry_http_400(monkeypatch):
         ts.execute_query("SELECT * WHERE {?s ?p ?o}")
 
 
+# ---------------------------------------------------------------------------
+# Retry exhaustion
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.unit
 def test_execute_query_raises_after_all_attempts_exhausted(monkeypatch):
-    """After max_attempts failures the original exception propagates."""
+    """When every attempt fails, the exception from the final attempt propagates to the caller."""
     ts = _mock_triplestore(
         monkeypatch,
         [
@@ -118,8 +183,14 @@ def test_execute_query_raises_after_all_attempts_exhausted(monkeypatch):
     assert exc_info.value.code == 503
 
 
+# ---------------------------------------------------------------------------
+# Parameter validation
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.unit
 def test_execute_query_rejects_invalid_max_attempts(monkeypatch):
+    """max_attempts=0 is rejected immediately with a ValueError before any query is sent."""
     ts = _mock_triplestore(monkeypatch, [])
     with pytest.raises(ValueError, match="max_attempts"):
         ts.execute_query("SELECT * WHERE {?s ?p ?o}", max_attempts=0)
@@ -127,6 +198,7 @@ def test_execute_query_rejects_invalid_max_attempts(monkeypatch):
 
 @pytest.mark.unit
 def test_execute_query_rejects_negative_delay(monkeypatch):
+    """A negative retry_base_delay_seconds is rejected immediately with a ValueError."""
     ts = _mock_triplestore(monkeypatch, [])
     with pytest.raises(ValueError, match="retry_base_delay_seconds"):
         ts.execute_query("SELECT * WHERE {?s ?p ?o}", retry_base_delay_seconds=-1)

--- a/uv.lock
+++ b/uv.lock
@@ -177,7 +177,7 @@ wheels = [
 
 [[package]]
 name = "babel-pipeline"
-version = "1.14"
+version = "1.17"
 source = { editable = "." }
 dependencies = [
     { name = "apybiomart" },


### PR DESCRIPTION
## Summary

Hardens `TripleStore.execute_query()` against transient SPARQL endpoint failures with a bounded exponential-backoff retry.

- Retries on HTTP 429 (rate limiting), HTTP 5xx, `JSONDecodeError`, and `OSError` (covers `TimeoutError`, `URLError`, connection resets, etc.); never retries other 4xx (deterministic client errors).
- Exponential backoff: attempt 1 → 1 s, attempt 2 → 2 s, attempt 3 → 4 s, …
- Attempt count and base delay come from a new `sparql:` block in `config.yaml` (`max_attempts`, `retry_base_delay_seconds`), overridable per call.
- Input validation raises `ValueError` on `max_attempts < 1` or `retry_base_delay_seconds < 0` before any retry logic runs.
- Internal helpers (`_dispatch_with_retries`, `_wait_before_retry`) are private.
- Module logger lowered from `ERROR` to `WARNING` so retry/backoff messages are visible.

The `uv.lock` babel-pipeline version line is synced `1.14` → `1.17` to match `pyproject.toml` (the lock was already stale on `main`).

## Test plan

- [x] `uv run pytest -m unit -q tests/test_triplestore.py` — retries on JSON-decode
  error, HTTP 503, and HTTP 429; does not retry HTTP 400; raises after all attempts
  exhausted; rejects invalid `max_attempts` and negative delay.
- [x] `uv run ruff check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)