### PR TITLE
Add clique-diff and source-discovery primitives (src/model/)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,6 +346,14 @@ docstrings, and when to add a pipeline test) that the individual conventions bel
   This is cheap, survives refactors, and is the first thing read when revisiting an ingest. Name
   functions for what they do — e.g. `fetch_*` (not `get_*`) when the call hits the network.
 
+- **Test documentation** — every test function should have a one-line docstring that names the
+  scenario being exercised and the key assertion, especially when the test name alone is not
+  enough to understand the edge case (e.g. "A source CURIE already in the before-clique via xref
+  is reported as preexisting, not added"). Group related tests with a `# ---` section comment and
+  a label (e.g. `# Basic classification`, `# Edge cases`, `# Utilities`). Update the module
+  docstring to list the groups and briefly describe what each covers. This makes it easy to scan
+  a test file for coverage without reading every body.
+
 - **Test assertion helpers** — `tests/conftest.py` exports `assert_labels_file_valid`,
   `assert_synonyms_file_valid`, `assert_ids_file_valid`, `assert_concordance_file_valid`,
   `assert_taxa_file_valid`, and `assert_descriptions_file_valid` (plus `read_tsv`). Use these

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,13 +346,14 @@ docstrings, and when to add a pipeline test) that the individual conventions bel
   This is cheap, survives refactors, and is the first thing read when revisiting an ingest. Name
   functions for what they do — e.g. `fetch_*` (not `get_*`) when the call hits the network.
 
-- **Test documentation** — every test function should have a docstring that explains what is being tested
-  and what the expectation is. A good test docstring will explain the scenario being tested (e.g. "A source
-  CURIE already in the before-clique via xref is reported as preexisting, not added"). Group related tests
-  with a `# ---` section comment and a label (e.g. `# Basic classification`, `# Edge cases`, `# Utilities`).
-  Documentation at the top of the test file can be useful in explaining what this set of tests is testing.
-  Update the module docstring to list the groups and briefly describe what each covers. This makes it easy to
-  scan a test file for coverage without reading every body.
+- **Test documentation** — every test function should have a docstring that explains what is being
+  tested and what the expectation is. A good test docstring will explain the scenario being tested
+  (e.g. "A source CURIE already in the before-clique via xref is reported as preexisting, not
+  added"). Group related tests with a `# ---` section comment and a label (e.g.
+  `# Basic classification`, `# Edge cases`, `# Utilities`). Documentation at the top of the test
+  file can be useful in explaining what this set of tests is testing. Update the module docstring to
+  list the groups and briefly describe what each covers. This makes it easy to scan a test file for
+  coverage without reading every body.
 
 - **Test assertion helpers** — `tests/conftest.py` exports `assert_labels_file_valid`,
   `assert_synonyms_file_valid`, `assert_ids_file_valid`, `assert_concordance_file_valid`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,6 +261,19 @@ When adding or enhancing a data source ingest, `docs/Development.md` ("Enhancing
 ingest") collects the process-level lessons (which attribute files to emit, IDs-file typing,
 docstrings, and when to add a pipeline test) that the individual conventions below back up.
 
+- **`babel_pipeline` vs `biolink_type`** — these two concepts are easy to confuse because the
+  codebase (and this file) sometimes uses the vague phrase "semantic type" for either. Keep them
+  distinct in code and variable names:
+  - **`babel_pipeline`** is the pipeline directory name: `anatomy`, `chemical`, `diseasephenotype`,
+    etc. It is a Babel artifact — an intermediate-file namespace, not a vocabulary term.
+  - **`biolink_type`** is the Biolink class URI stored in compendia: `biolink:AnatomicalEntity`,
+    `biolink:SmallMolecule`, etc. Multiple Biolink types can map to the same `babel_pipeline`
+    (e.g. `anatomy` covers both `biolink:AnatomicalEntity` and `biolink:GrossAnatomicalStructure`).
+  - **`umls_semantic_type`** (or `sty`) is yet a third thing: a UMLS TUI code / tree string used
+    only inside the UMLS ingest. Do not conflate it with either of the above.
+  Prefer these three explicit names in code. Avoid "semantic type" as a bare phrase unless quoting
+  an external vocabulary (e.g. "UMLS semantic type").
+
 - **Commits** — if you need to make a large change, break it into multiple commits so it's clearer
   what changes are related.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,13 +346,13 @@ docstrings, and when to add a pipeline test) that the individual conventions bel
   This is cheap, survives refactors, and is the first thing read when revisiting an ingest. Name
   functions for what they do — e.g. `fetch_*` (not `get_*`) when the call hits the network.
 
-- **Test documentation** — every test function should have a one-line docstring that names the
-  scenario being exercised and the key assertion, especially when the test name alone is not
-  enough to understand the edge case (e.g. "A source CURIE already in the before-clique via xref
-  is reported as preexisting, not added"). Group related tests with a `# ---` section comment and
-  a label (e.g. `# Basic classification`, `# Edge cases`, `# Utilities`). Update the module
-  docstring to list the groups and briefly describe what each covers. This makes it easy to scan
-  a test file for coverage without reading every body.
+- **Test documentation** — every test function should have a docstring that explains what is being tested
+  and what the expectation is. A good test docstring will explain the scenario being tested (e.g. "A source
+  CURIE already in the before-clique via xref is reported as preexisting, not added"). Group related tests
+  with a `# ---` section comment and a label (e.g. `# Basic classification`, `# Edge cases`, `# Utilities`).
+  Documentation at the top of the test file can be useful in explaining what this set of tests is testing.
+  Update the module docstring to list the groups and briefly describe what each covers. This makes it easy to
+  scan a test file for coverage without reading every body.
 
 - **Test assertion helpers** — `tests/conftest.py` exports `assert_labels_file_valid`,
   `assert_synonyms_file_valid`, `assert_ids_file_valid`, `assert_concordance_file_valid`,

--- a/src/model/clique_diff.py
+++ b/src/model/clique_diff.py
@@ -22,6 +22,13 @@ from dataclasses import dataclass, field
 
 import jsonlines
 
+# GlomDict is the dict produced by babel_utils.glom() and consumed by build_compendia.
+# Every CURIE key maps to its clique's *shared mutable set* — many keys point to the exact
+# same set object (that is the union-find invariant). Consumers must not mutate the sets;
+# Mapping[str, Iterable[str]] signals read-only intent and is wide enough to accept both the
+# live glom output (dict[str, set[str]]) and any read-only view of the same structure.
+# Functions here exploit the shared-identity property by deduplicating via id() rather than
+# value equality, which reduces O(identifiers) frozenset constructions to O(cliques).
 GlomDict = Mapping[str, "Iterable[str]"]
 
 

--- a/src/model/clique_diff.py
+++ b/src/model/clique_diff.py
@@ -64,9 +64,9 @@ class MergedClique:
 
 @dataclass
 class SourceImpactDiff:
-    """Result of comparing before/after clique state for a single semantic type."""
+    """Result of comparing before/after clique state for a single Babel pipeline type."""
 
-    semantic_type: str
+    babel_pipeline: str
     source_curies: frozenset[str]
     pure_new_cliques: list[frozenset[str]] = field(default_factory=list)
     expanded_cliques: list[ExpandedClique] = field(default_factory=list)
@@ -109,7 +109,7 @@ def diff_cliques(
     after: GlomDict,
     source_curies: Iterable[str],
     *,
-    semantic_type: str,
+    babel_pipeline: str,
 ) -> SourceImpactDiff:
     """Bucket the differences between two clique states into pure_new / expanded / merged.
 
@@ -178,7 +178,7 @@ def diff_cliques(
             )
 
     return SourceImpactDiff(
-        semantic_type=semantic_type,
+        babel_pipeline=babel_pipeline,
         source_curies=source_curies_fs,
         pure_new_cliques=pure_new,
         expanded_cliques=expanded,

--- a/src/model/clique_diff.py
+++ b/src/model/clique_diff.py
@@ -1,0 +1,202 @@
+"""Primitives for diffing Babel clique state with and without a given source.
+
+The CLI in ``src/cli/source_impact_report.py`` is the main consumer. The "synthetic"
+comparison mode calls a semantic-type-specific compute function (e.g.
+``anatomy.compute_cliques_for_impact_report``) twice — once with the new source's
+intermediate files excluded, once with them included — and then calls ``diff_cliques``
+here to bucket the differences.
+
+A clique is represented as a ``frozenset[str]`` of CURIEs. The glom output (used by
+``build_compendia``) is a ``dict[curie, set[curie]]`` where every CURIE points to its
+clique's mutable set; ``cliques_set`` collapses that to the deduplicated frozenset view.
+
+The "remote" comparison mode reads JSONL compendia from a previous Babel build and uses
+``cliques_from_compendia`` to derive the same frozenset view from disk.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from collections.abc import Iterable, Iterator, Mapping
+from dataclasses import dataclass, field
+
+import jsonlines
+
+GlomDict = Mapping[str, "Iterable[str]"]
+
+
+@dataclass(frozen=True)
+class ExpandedClique:
+    """A before-clique that gained at least one source CURIE without merging.
+
+    ``added_source_curies`` is the strict difference (after - before): source CURIEs that
+    were not already in the before-clique. ``promoted_source_curies`` is the intersection:
+    source CURIEs already pulled into the clique by some other source's xref, which the
+    new source now claims as first-class typed identifiers. When ``added_source_curies``
+    is empty, the clique's identifier set is unchanged — the new source only "promotes"
+    pre-existing xref leaves into typed identifiers. Callers that want to count clique
+    growth should check ``added_source_curies`` rather than ``promoted_source_curies``.
+    """
+
+    before_clique: frozenset[str]
+    added_source_curies: frozenset[str]
+    after_clique: frozenset[str]
+    promoted_source_curies: frozenset[str] = frozenset()
+
+
+@dataclass(frozen=True)
+class MergedClique:
+    """Two or more before-cliques that were bridged into one after-clique by new-source
+    CURIEs."""
+
+    before_cliques: tuple[frozenset[str], ...]
+    source_curies_involved: frozenset[str]
+    after_clique: frozenset[str]
+
+
+@dataclass
+class SourceImpactDiff:
+    """Result of comparing before/after clique state for a single semantic type."""
+
+    semantic_type: str
+    source_curies: frozenset[str]
+    pure_new_cliques: list[frozenset[str]] = field(default_factory=list)
+    expanded_cliques: list[ExpandedClique] = field(default_factory=list)
+    merged_cliques: list[MergedClique] = field(default_factory=list)
+    before_clique_count: int = 0
+    after_clique_count: int = 0
+
+
+def cliques_set(glom_dict: GlomDict) -> frozenset[frozenset[str]]:
+    """Collapse a glom dict-of-sets to a deduplicated set of cliques.
+
+    ``build_compendia`` produces a dict where every CURIE points to its mutable clique
+    set; many keys share the same set object. We materialise that as a frozenset of
+    frozensets for downstream set operations.
+    """
+    # Deduplicate by object identity first (many CURIEs share the same set object),
+    # then freeze — reduces N freeze calls to K (one per unique clique).
+    unique_sets = {id(v): v for v in glom_dict.values()}.values()
+    return frozenset(frozenset(v) for v in unique_sets)
+
+
+def _lookup_table(glom_dict: GlomDict) -> dict[str, frozenset[str]]:
+    """Return a {curie: clique-as-frozenset} lookup derived from a glom dict.
+
+    Memoises the frozenset conversion by object identity (same trick as
+    ``cliques_set``) so we do O(cliques) freezes rather than O(identifiers).
+    """
+    out: dict[str, frozenset[str]] = {}
+    frozen_cache: dict[int, frozenset[str]] = {}
+    for curie, members in glom_dict.items():
+        key = id(members)
+        if key not in frozen_cache:
+            frozen_cache[key] = frozenset(members)
+        out[curie] = frozen_cache[key]
+    return out
+
+
+def diff_cliques(
+    before: GlomDict,
+    after: GlomDict,
+    source_curies: Iterable[str],
+    *,
+    semantic_type: str,
+) -> SourceImpactDiff:
+    """Bucket the differences between two clique states into pure_new / expanded / merged.
+
+    For each after-clique that contains any source-attributed CURIE:
+
+    - if the clique has no non-source CURIEs, or its non-source CURIEs were absent from
+      ``before`` entirely, it's a **pure new** clique (the source contributed everything,
+      either directly via its ids file or indirectly via its concord rows introducing new
+      aliases);
+    - if the non-source CURIEs all belonged to exactly one before-clique, the source
+      **expanded** that clique;
+    - if the non-source CURIEs spanned two or more before-cliques, the source **merged**
+      them.
+
+    Note that ``source_curies`` should be the union across all prefixes the source
+    declared — it is intentionally not derived from ``source_prefix`` because a source
+    may declare CURIEs under multiple prefixes.
+    """
+    source_curies_fs = frozenset(source_curies)
+    before_lookup = _lookup_table(before)
+    after_cliques = cliques_set(after)
+    before_clique_count = len({id(v): v for v in before.values()})
+
+    pure_new: list[frozenset[str]] = []
+    expanded: list[ExpandedClique] = []
+    merged: list[MergedClique] = []
+
+    for clique in after_cliques:
+        source_in_clique = clique & source_curies_fs
+        if not source_in_clique:
+            continue
+        non_source = clique - source_curies_fs
+
+        if not non_source:
+            pure_new.append(clique)
+            continue
+
+        before_cliques_set: set[frozenset[str]] = set()
+        for curie in non_source:
+            bc = before_lookup.get(curie)
+            if bc is not None:
+                before_cliques_set.add(bc)
+
+        if len(before_cliques_set) == 0:
+            pure_new.append(clique)
+        elif len(before_cliques_set) == 1:
+            (only_bc,) = before_cliques_set
+            truly_added = source_in_clique - only_bc
+            already_present = source_in_clique & only_bc
+            expanded.append(
+                ExpandedClique(
+                    before_clique=only_bc,
+                    added_source_curies=truly_added,
+                    promoted_source_curies=already_present,
+                    after_clique=clique,
+                )
+            )
+        else:
+            ordered = tuple(sorted(before_cliques_set, key=lambda c: min(c)))
+            merged.append(
+                MergedClique(
+                    before_cliques=ordered,
+                    source_curies_involved=source_in_clique,
+                    after_clique=clique,
+                )
+            )
+
+    return SourceImpactDiff(
+        semantic_type=semantic_type,
+        source_curies=source_curies_fs,
+        pure_new_cliques=pure_new,
+        expanded_cliques=expanded,
+        merged_cliques=merged,
+        before_clique_count=before_clique_count,
+        after_clique_count=len(after_cliques),
+    )
+
+
+def load_compendium(path: pathlib.Path | str) -> Iterator[dict]:
+    """Stream clique dicts from a JSONL compendium file."""
+    with jsonlines.open(path) as reader:
+        yield from reader
+
+
+def cliques_from_compendia(paths: Iterable[pathlib.Path | str]) -> frozenset[frozenset[str]]:
+    """Materialise the set of cliques across one or more compendium JSONL files.
+
+    Each clique is represented as a frozenset of its identifier CURIEs (the ``i`` field
+    of each entry in ``clique["identifiers"]``). Used by the remote-compare mode of the
+    source-impact report.
+    """
+    out: set[frozenset[str]] = set()
+    for path in paths:
+        for clique in load_compendium(path):
+            members = frozenset(ident["i"] for ident in clique.get("identifiers", []))
+            if members:
+                out.add(members)
+    return frozenset(out)

--- a/src/model/clique_diff.py
+++ b/src/model/clique_diff.py
@@ -30,18 +30,19 @@ class ExpandedClique:
     """A before-clique that gained at least one source CURIE without merging.
 
     ``added_source_curies`` is the strict difference (after - before): source CURIEs that
-    were not already in the before-clique. ``promoted_source_curies`` is the intersection:
-    source CURIEs already pulled into the clique by some other source's xref, which the
-    new source now claims as first-class typed identifiers. When ``added_source_curies``
-    is empty, the clique's identifier set is unchanged — the new source only "promotes"
-    pre-existing xref leaves into typed identifiers. Callers that want to count clique
-    growth should check ``added_source_curies`` rather than ``promoted_source_curies``.
+    were not already in the before-clique. ``preexisting_source_curies`` is the intersection:
+    source CURIEs that were already present in the before-clique — pulled in by some other
+    source's xref — before this source was added. The new source does not change clique
+    membership for these CURIEs; it only re-types them from anonymous xref targets to
+    first-class typed identifiers. When ``added_source_curies`` is empty, the clique's
+    identifier set is unchanged. Callers that want to count clique growth should check
+    ``added_source_curies`` rather than ``preexisting_source_curies``.
     """
 
     before_clique: frozenset[str]
     added_source_curies: frozenset[str]
     after_clique: frozenset[str]
-    promoted_source_curies: frozenset[str] = frozenset()
+    preexisting_source_curies: frozenset[str] = frozenset()
 
 
 @dataclass(frozen=True)
@@ -155,7 +156,7 @@ def diff_cliques(
                 ExpandedClique(
                     before_clique=only_bc,
                     added_source_curies=truly_added,
-                    promoted_source_curies=already_present,
+                    preexisting_source_curies=already_present,
                     after_clique=clique,
                 )
             )

--- a/src/model/clique_diff.py
+++ b/src/model/clique_diff.py
@@ -129,7 +129,7 @@ def diff_cliques(
     expanded: list[ExpandedClique] = []
     merged: list[MergedClique] = []
 
-    for clique in after_cliques:
+    for clique in sorted(after_cliques, key=min):
         source_in_clique = clique & source_curies_fs
         if not source_in_clique:
             continue

--- a/src/model/source.py
+++ b/src/model/source.py
@@ -1,17 +1,22 @@
 """Discover how a Babel source contributes to the build outputs.
 
 Given a source name like "EMAPA", walks every
-``<intermediate_root>/<semantic_type>/ids/<name>`` and
-``<intermediate_root>/<semantic_type>/concords/<name>`` and assembles a structured
+``<intermediate_root>/<pipeline>/ids/<name>`` and
+``<intermediate_root>/<pipeline>/concords/<name>`` and assembles a structured
 description that the source-impact report tool can render.
 
 A Babel source can vary along three axes simultaneously, so every aggregate is a
 collection:
 
-- multiple semantic types (e.g., MESH contributes to anatomy, chemical, disease)
-- multiple biolink types within a semantic type (UBERON declares both
+- multiple pipelines (e.g., MESH contributes to anatomy, chemical, disease)
+- multiple biolink types within a pipeline (UBERON declares both
   ``biolink:AnatomicalEntity`` and ``biolink:GrossAnatomicalStructure`` in one ids file)
 - multiple prefixes per ids file (rare but supported)
+
+.. note::
+    PR #742 (source-impact report tool) also uses the old ``semantic_type`` / ``by_semantic_type``
+    naming in its own variables (``SEMANTIC_TYPE_CONFIG``, ``diffs_by_semantic_type``,
+    ``--semantic-types`` CLI flag). Update those when rebasing #742 onto this branch.
 """
 
 from __future__ import annotations
@@ -63,10 +68,10 @@ def scan_concords_for_curies(
 
 
 @dataclass
-class SemanticTypeContribution:
-    """One source's contribution within a single semantic type."""
+class PipelineContribution:
+    """One source's contribution within a single babel_pipeline directory."""
 
-    semantic_type: str
+    pipeline: str
     ids_path: pathlib.Path | None
     concords_path: pathlib.Path | None
 
@@ -149,76 +154,76 @@ class SemanticTypeContribution:
 
 @dataclass
 class SourceContribution:
-    """Aggregated description of a source across every semantic type it touches."""
+    """Aggregated description of a source across every babel_pipeline it touches."""
 
     name: str
-    by_semantic_type: dict[str, SemanticTypeContribution]
+    by_pipeline: dict[str, PipelineContribution]
 
     @property
-    def semantic_types(self) -> frozenset[str]:
-        return frozenset(self.by_semantic_type.keys())
+    def pipelines(self) -> frozenset[str]:
+        return frozenset(self.by_pipeline.keys())
 
     @property
     def prefixes(self) -> frozenset[str]:
         out: set[str] = set()
-        for stc in self.by_semantic_type.values():
-            out.update(stc.curies_by_prefix.keys())
+        for pc in self.by_pipeline.values():
+            out.update(pc.curies_by_prefix.keys())
         return frozenset(out)
 
     @property
     def declared_biolink_types(self) -> frozenset[str]:
         out: set[str] = set()
-        for stc in self.by_semantic_type.values():
-            out.update(stc.declared_biolink_types)
+        for pc in self.by_pipeline.values():
+            out.update(pc.declared_biolink_types)
         return frozenset(out)
 
     @property
     def declared_type_counts(self) -> dict[str, int]:
-        """Total CURIEs declaring each biolink type, summed across all semantic types.
+        """Total CURIEs declaring each biolink type, summed across all pipelines.
 
         Rows without a declared type are bucketed under the empty string (mirroring
-        ``SemanticTypeContribution.declared_type_counts``).
+        ``PipelineContribution.declared_type_counts``).
         """
         counts: dict[str, int] = defaultdict(int)
-        for stc in self.by_semantic_type.values():
-            for declared, count in stc.declared_type_counts.items():
+        for pc in self.by_pipeline.values():
+            for declared, count in pc.declared_type_counts.items():
                 counts[declared] += count
         return dict(counts)
 
     @property
     def total_identifier_count(self) -> int:
-        return sum(len(stc.all_curies) for stc in self.by_semantic_type.values())
+        return sum(len(pc.all_curies) for pc in self.by_pipeline.values())
 
     @property
     def total_concord_row_count(self) -> int:
-        return sum(len(stc.concord_pairs) for stc in self.by_semantic_type.values())
+        return sum(len(pc.concord_pairs) for pc in self.by_pipeline.values())
 
 
 def discover_source(name: str, intermediate_root: pathlib.Path | str) -> SourceContribution:
     """Discover where a named source contributes across the intermediate build outputs.
 
-    Walks ``<intermediate_root>/<semantic_type>/ids/<name>`` and
-    ``<intermediate_root>/<semantic_type>/concords/<name>`` for every semantic-type
-    subdirectory and records a SemanticTypeContribution wherever the source has either
-    file. Returns a SourceContribution; callers can check ``by_semantic_type`` to detect
-    a source name that is not present anywhere.
+    Walks ``<intermediate_root>/<pipeline>/ids/<name>`` and
+    ``<intermediate_root>/<pipeline>/concords/<name>`` for every pipeline subdirectory
+    and records a PipelineContribution wherever the source has either file. Returns a
+    SourceContribution; callers can check ``by_pipeline`` to detect a source name that is
+    not present anywhere.
     """
     intermediate_root = pathlib.Path(intermediate_root)
     if not intermediate_root.exists():
         raise FileNotFoundError(f"Intermediate root does not exist: {intermediate_root}")
-    by_st: dict[str, SemanticTypeContribution] = {}
-    for st_dir in sorted(intermediate_root.iterdir()):
-        if not st_dir.is_dir():
+    by_pipeline: dict[str, PipelineContribution] = {}
+    for pipeline_dir in sorted(intermediate_root.iterdir()):
+        if not pipeline_dir.is_dir():
             continue
-        ids_path = st_dir / "ids" / name
-        concords_path = st_dir / "concords" / name
+        ids_path = pipeline_dir / "ids" / name
+        concords_path = pipeline_dir / "concords" / name
         has_ids = ids_path.exists()
         has_concords = concords_path.exists()
         if not (has_ids or has_concords):
             continue
-        by_st[st_dir.name] = SemanticTypeContribution(
-            semantic_type=st_dir.name,
+        by_pipeline[pipeline_dir.name] = PipelineContribution(
+            pipeline=pipeline_dir.name,
             ids_path=ids_path if has_ids else None,
             concords_path=concords_path if has_concords else None,
         )
-    return SourceContribution(name=name, by_semantic_type=by_st)
+    return SourceContribution(name=name, by_pipeline=by_pipeline)

--- a/src/model/source.py
+++ b/src/model/source.py
@@ -31,23 +31,26 @@ def scan_concords_for_curies(
     concords_dir: pathlib.Path | str,
     source_curies: Iterable[str],
 ) -> list[tuple[str, str, str, str]]:
-    """Scan every concord file in a directory for rows touching any source CURIE.
+    """Scan every concord file in a directory tree for rows touching any source CURIE.
 
     Returns ``(subject, predicate, object, asserted_by)`` tuples where ``asserted_by`` is
-    the concord file's basename — the source that *declared* the cross-reference. A
-    source's cross-references frequently live in *another* source's concord file (e.g.
-    EMAPA's own concord is empty, but UBERON's concord carries ``UBERON:… xref EMAPA:…``
-    rows), so this scans every file in the directory rather than only the source's own
-    concord. Metadata sidecars (``metadata-*`` / ``*.yaml``) are skipped.
+    the path of the concord file relative to ``concords_dir`` — the source that *declared*
+    the cross-reference. A source's cross-references frequently live in *another* source's
+    concord file (e.g. EMAPA's own concord is empty, but UBERON's concord carries
+    ``UBERON:… xref EMAPA:…`` rows), so this scans every file in the directory tree rather
+    than only the source's own concord. Subdirectories are included (e.g.
+    ``chemicals/concords/UNICHEM/UNICHEM_*`` files). Metadata sidecars
+    (``metadata-*`` / ``*.yaml``) are skipped.
     """
     concords_dir = pathlib.Path(concords_dir)
     source_set = frozenset(source_curies)
     rows: list[tuple[str, str, str, str]] = []
     if not concords_dir.exists():
         return rows
-    for path in sorted(concords_dir.iterdir()):
+    for path in sorted(concords_dir.rglob("*")):
         if not path.is_file() or path.name.startswith("metadata-") or path.name.endswith(".yaml"):
             continue
+        asserted_by = str(path.relative_to(concords_dir))
         with path.open() as f:
             for line in f:
                 parts = line.rstrip("\n").split("\t")
@@ -55,7 +58,7 @@ def scan_concords_for_curies(
                     continue
                 subject, predicate, obj = parts[0], parts[1], parts[2]
                 if subject in source_set or obj in source_set:
-                    rows.append((subject, predicate, obj, path.name))
+                    rows.append((subject, predicate, obj, asserted_by))
     return rows
 
 

--- a/src/model/source.py
+++ b/src/model/source.py
@@ -1,0 +1,221 @@
+"""Discover how a Babel source contributes to the build outputs.
+
+Given a source name like "EMAPA", walks every
+``<intermediate_root>/<semantic_type>/ids/<name>`` and
+``<intermediate_root>/<semantic_type>/concords/<name>`` and assembles a structured
+description that the source-impact report tool can render.
+
+A Babel source can vary along three axes simultaneously, so every aggregate is a
+collection:
+
+- multiple semantic types (e.g., MESH contributes to anatomy, chemical, disease)
+- multiple biolink types within a semantic type (UBERON declares both
+  ``biolink:AnatomicalEntity`` and ``biolink:GrossAnatomicalStructure`` in one ids file)
+- multiple prefixes per ids file (rare but supported)
+"""
+
+from __future__ import annotations
+
+import pathlib
+from collections import defaultdict
+from collections.abc import Iterable
+from dataclasses import dataclass
+from functools import cached_property
+
+
+def _prefix_of(curie: str) -> str:
+    return curie.split(":", 1)[0]
+
+
+def scan_concords_for_curies(
+    concords_dir: pathlib.Path | str,
+    source_curies: Iterable[str],
+) -> list[tuple[str, str, str, str]]:
+    """Scan every concord file in a directory for rows touching any source CURIE.
+
+    Returns ``(subject, predicate, object, asserted_by)`` tuples where ``asserted_by`` is
+    the concord file's basename — the source that *declared* the cross-reference. A
+    source's cross-references frequently live in *another* source's concord file (e.g.
+    EMAPA's own concord is empty, but UBERON's concord carries ``UBERON:… xref EMAPA:…``
+    rows), so this scans every file in the directory rather than only the source's own
+    concord. Metadata sidecars (``metadata-*`` / ``*.yaml``) are skipped.
+    """
+    concords_dir = pathlib.Path(concords_dir)
+    source_set = frozenset(source_curies)
+    rows: list[tuple[str, str, str, str]] = []
+    if not concords_dir.exists():
+        return rows
+    for path in sorted(concords_dir.iterdir()):
+        if not path.is_file() or path.name.startswith("metadata-") or path.name.endswith(".yaml"):
+            continue
+        with path.open() as f:
+            for line in f:
+                parts = line.rstrip("\n").split("\t")
+                if len(parts) < 3:
+                    continue
+                subject, predicate, obj = parts[0], parts[1], parts[2]
+                if subject in source_set or obj in source_set:
+                    rows.append((subject, predicate, obj, path.name))
+    return rows
+
+
+@dataclass
+class SemanticTypeContribution:
+    """One source's contribution within a single semantic type."""
+
+    semantic_type: str
+    ids_path: pathlib.Path | None
+    concords_path: pathlib.Path | None
+
+    @cached_property
+    def _ids_rows(self) -> list[tuple[str, str | None]]:
+        if self.ids_path is None or not self.ids_path.exists():
+            return []
+        rows: list[tuple[str, str | None]] = []
+        with self.ids_path.open() as f:
+            for line in f:
+                parts = line.rstrip("\n").split("\t")
+                if not parts or not parts[0]:
+                    continue
+                curie = parts[0]
+                declared_type = parts[1] if len(parts) > 1 and parts[1] else None
+                rows.append((curie, declared_type))
+        return rows
+
+    @cached_property
+    def all_curies(self) -> frozenset[str]:
+        return frozenset(curie for curie, _ in self._ids_rows)
+
+    @cached_property
+    def curies_by_prefix(self) -> dict[str, frozenset[str]]:
+        buckets: dict[str, set[str]] = defaultdict(set)
+        for curie, _ in self._ids_rows:
+            buckets[_prefix_of(curie)].add(curie)
+        return {k: frozenset(v) for k, v in buckets.items()}
+
+    @cached_property
+    def declared_types_by_curie(self) -> dict[str, str | None]:
+        return {curie: declared for curie, declared in self._ids_rows}
+
+    @cached_property
+    def declared_biolink_types(self) -> frozenset[str]:
+        return frozenset(t for t in self.declared_types_by_curie.values() if t)
+
+    @cached_property
+    def declared_type_counts(self) -> dict[str, int]:
+        """How many CURIEs in this source's ids file declare each biolink type.
+
+        Rows without a declared type are bucketed under the empty string so callers can
+        report "undeclared" explicitly.
+        """
+        counts: dict[str, int] = defaultdict(int)
+        for declared in self.declared_types_by_curie.values():
+            counts[declared or ""] += 1
+        return dict(counts)
+
+    @cached_property
+    def concord_pairs(self) -> list[tuple[str, str, str]]:
+        if self.concords_path is None or not self.concords_path.exists():
+            return []
+        triples: list[tuple[str, str, str]] = []
+        with self.concords_path.open() as f:
+            for line in f:
+                parts = line.rstrip("\n").split("\t")
+                if len(parts) < 3:
+                    continue
+                triples.append((parts[0], parts[1], parts[2]))
+        return triples
+
+    @cached_property
+    def concord_partner_prefix_counts(self) -> dict[str, int]:
+        """Count of partner-prefix occurrences across the concord file.
+
+        For each row in the concord file, contributes one count to whichever endpoint's
+        prefix is *not* one of the source's own (as declared in the ids file). This
+        isolates how many bridges go to each external vocabulary.
+        """
+        own_prefixes = set(self.curies_by_prefix.keys())
+        counts: dict[str, int] = defaultdict(int)
+        for c1, _, c2 in self.concord_pairs:
+            for c in (c1, c2):
+                prefix = _prefix_of(c)
+                if prefix not in own_prefixes:
+                    counts[prefix] += 1
+        return dict(counts)
+
+
+@dataclass
+class SourceContribution:
+    """Aggregated description of a source across every semantic type it touches."""
+
+    name: str
+    by_semantic_type: dict[str, SemanticTypeContribution]
+
+    @property
+    def semantic_types(self) -> frozenset[str]:
+        return frozenset(self.by_semantic_type.keys())
+
+    @property
+    def prefixes(self) -> frozenset[str]:
+        out: set[str] = set()
+        for stc in self.by_semantic_type.values():
+            out.update(stc.curies_by_prefix.keys())
+        return frozenset(out)
+
+    @property
+    def declared_biolink_types(self) -> frozenset[str]:
+        out: set[str] = set()
+        for stc in self.by_semantic_type.values():
+            out.update(stc.declared_biolink_types)
+        return frozenset(out)
+
+    @property
+    def declared_type_counts(self) -> dict[str, int]:
+        """Total CURIEs declaring each biolink type, summed across all semantic types.
+
+        Rows without a declared type are bucketed under the empty string (mirroring
+        ``SemanticTypeContribution.declared_type_counts``).
+        """
+        counts: dict[str, int] = defaultdict(int)
+        for stc in self.by_semantic_type.values():
+            for declared, count in stc.declared_type_counts.items():
+                counts[declared] += count
+        return dict(counts)
+
+    @property
+    def total_identifier_count(self) -> int:
+        return sum(len(stc.all_curies) for stc in self.by_semantic_type.values())
+
+    @property
+    def total_concord_row_count(self) -> int:
+        return sum(len(stc.concord_pairs) for stc in self.by_semantic_type.values())
+
+
+def discover_source(name: str, intermediate_root: pathlib.Path | str) -> SourceContribution:
+    """Discover where a named source contributes across the intermediate build outputs.
+
+    Walks ``<intermediate_root>/<semantic_type>/ids/<name>`` and
+    ``<intermediate_root>/<semantic_type>/concords/<name>`` for every semantic-type
+    subdirectory and records a SemanticTypeContribution wherever the source has either
+    file. Returns a SourceContribution; callers can check ``by_semantic_type`` to detect
+    a source name that is not present anywhere.
+    """
+    intermediate_root = pathlib.Path(intermediate_root)
+    if not intermediate_root.exists():
+        raise FileNotFoundError(f"Intermediate root does not exist: {intermediate_root}")
+    by_st: dict[str, SemanticTypeContribution] = {}
+    for st_dir in sorted(intermediate_root.iterdir()):
+        if not st_dir.is_dir():
+            continue
+        ids_path = st_dir / "ids" / name
+        concords_path = st_dir / "concords" / name
+        has_ids = ids_path.exists()
+        has_concords = concords_path.exists()
+        if not (has_ids or has_concords):
+            continue
+        by_st[st_dir.name] = SemanticTypeContribution(
+            semantic_type=st_dir.name,
+            ids_path=ids_path if has_ids else None,
+            concords_path=concords_path if has_concords else None,
+        )
+    return SourceContribution(name=name, by_semantic_type=by_st)

--- a/tests/test_clique_diff.py
+++ b/tests/test_clique_diff.py
@@ -1,9 +1,20 @@
 """Unit tests for src/model/clique_diff.py.
 
-Exercises diff_cliques against hand-built before/after glom-dict states so the four-way
-categorisation (pure_new / expanded / merged / unrelated) is locked in. Includes a
-multi-prefix source_curies case to confirm the diff logic does not silently special-case
-a single-prefix source.
+Exercises diff_cliques against hand-built before/after glom-dict states.
+
+Test groups
+-----------
+Basic classification (pure_new / expanded / merged / unrelated):
+    The four mutually exclusive buckets that diff_cliques produces. Each test
+    constructs a minimal before/after pair that should land entirely in one bucket.
+
+Edge cases:
+    Behaviours that the bucket names alone do not make obvious — multi-prefix sources,
+    the added-vs-preexisting split, and concord-introduced aliases.
+
+Utilities (cliques_set, cliques_from_compendia):
+    The helper functions that collapse a glom dict or JSONL compendia to the frozenset
+    view consumed by diff_cliques.
 """
 
 import pytest
@@ -26,8 +37,14 @@ def _glom_dict_from_cliques(cliques):
     return out
 
 
+# ---------------------------------------------------------------------------
+# Basic classification
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.unit
 def test_diff_classifies_pure_new_clique_of_only_source_curies():
+    """A clique whose every member is a source CURIE is pure_new — it did not exist before."""
     before = _glom_dict_from_cliques([{"A:1"}])
     after = _glom_dict_from_cliques([{"A:1"}, {"NEW:1", "NEW:2"}])
     diff = diff_cliques(before, after, {"NEW:1", "NEW:2"}, babel_pipeline="t")
@@ -39,6 +56,7 @@ def test_diff_classifies_pure_new_clique_of_only_source_curies():
 
 @pytest.mark.unit
 def test_diff_classifies_expanded_clique():
+    """A source CURIE joining a single existing before-clique is an expansion of that clique."""
     before = _glom_dict_from_cliques([{"A:1", "B:1"}])
     after = _glom_dict_from_cliques([{"A:1", "B:1", "NEW:1"}])
     diff = diff_cliques(before, after, {"NEW:1"}, babel_pipeline="t")
@@ -54,6 +72,7 @@ def test_diff_classifies_expanded_clique():
 
 @pytest.mark.unit
 def test_diff_classifies_merged_cliques():
+    """A source CURIE that bridges two distinct before-cliques into one is a merge."""
     before = _glom_dict_from_cliques([{"A:1", "B:1"}, {"C:1", "D:1"}])
     after = _glom_dict_from_cliques([{"A:1", "B:1", "C:1", "D:1", "NEW:1"}])
     diff = diff_cliques(before, after, {"NEW:1"}, babel_pipeline="t")
@@ -71,6 +90,7 @@ def test_diff_classifies_merged_cliques():
 
 @pytest.mark.unit
 def test_diff_ignores_cliques_with_no_source_curies():
+    """After-cliques that contain no source CURIE at all are silently skipped."""
     before = _glom_dict_from_cliques([{"A:1"}, {"B:1"}])
     after = _glom_dict_from_cliques([{"A:1"}, {"B:1"}, {"NEW:1"}])
     diff = diff_cliques(before, after, {"NEW:1"}, babel_pipeline="t")
@@ -78,6 +98,11 @@ def test_diff_ignores_cliques_with_no_source_curies():
     assert len(diff.pure_new_cliques) == 1
     assert diff.expanded_cliques == []
     assert diff.merged_cliques == []
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
@@ -134,6 +159,11 @@ def test_diff_treats_concord_introduced_aliases_as_pure_new():
     assert frozenset({"SRC:1", "ALIAS:1"}) in set(diff.pure_new_cliques)
 
 
+# ---------------------------------------------------------------------------
+# Utilities
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.unit
 def test_cliques_set_collapses_shared_set_references():
     """glom dicts point many CURIEs at the same set object; cliques_set must dedupe."""
@@ -145,6 +175,7 @@ def test_cliques_set_collapses_shared_set_references():
 
 @pytest.mark.unit
 def test_cliques_from_compendia_reads_jsonl(tmp_path):
+    """Reads the ``i`` field from each identifier entry across one or more JSONL compendium files."""
     path = tmp_path / "Foo.txt"
     path.write_text(
         '{"type":"biolink:Foo","identifiers":[{"i":"A:1","l":"a"},{"i":"B:1","l":"b"}]}\n'

--- a/tests/test_clique_diff.py
+++ b/tests/test_clique_diff.py
@@ -1,0 +1,154 @@
+"""Unit tests for src/model/clique_diff.py.
+
+Exercises diff_cliques against hand-built before/after glom-dict states so the four-way
+categorisation (pure_new / expanded / merged / unrelated) is locked in. Includes a
+multi-prefix source_curies case to confirm the diff logic does not silently special-case
+a single-prefix source.
+"""
+
+import pytest
+
+from src.model.clique_diff import (
+    cliques_from_compendia,
+    cliques_set,
+    diff_cliques,
+)
+
+
+def _glom_dict_from_cliques(cliques):
+    """Helper: build a {curie: set} glom-style dict where every CURIE in a clique points
+    to that clique's shared set object."""
+    out = {}
+    for members in cliques:
+        s = set(members)
+        for c in members:
+            out[c] = s
+    return out
+
+
+@pytest.mark.unit
+def test_diff_classifies_pure_new_clique_of_only_source_curies():
+    before = _glom_dict_from_cliques([{"A:1"}])
+    after = _glom_dict_from_cliques([{"A:1"}, {"NEW:1", "NEW:2"}])
+    diff = diff_cliques(before, after, {"NEW:1", "NEW:2"}, semantic_type="t")
+
+    assert {frozenset({"NEW:1", "NEW:2"})} == set(diff.pure_new_cliques)
+    assert diff.expanded_cliques == []
+    assert diff.merged_cliques == []
+
+
+@pytest.mark.unit
+def test_diff_classifies_expanded_clique():
+    before = _glom_dict_from_cliques([{"A:1", "B:1"}])
+    after = _glom_dict_from_cliques([{"A:1", "B:1", "NEW:1"}])
+    diff = diff_cliques(before, after, {"NEW:1"}, semantic_type="t")
+
+    assert diff.pure_new_cliques == []
+    assert diff.merged_cliques == []
+    assert len(diff.expanded_cliques) == 1
+    expanded = diff.expanded_cliques[0]
+    assert expanded.before_clique == frozenset({"A:1", "B:1"})
+    assert expanded.added_source_curies == frozenset({"NEW:1"})
+    assert expanded.after_clique == frozenset({"A:1", "B:1", "NEW:1"})
+
+
+@pytest.mark.unit
+def test_diff_classifies_merged_cliques():
+    before = _glom_dict_from_cliques([{"A:1", "B:1"}, {"C:1", "D:1"}])
+    after = _glom_dict_from_cliques([{"A:1", "B:1", "C:1", "D:1", "NEW:1"}])
+    diff = diff_cliques(before, after, {"NEW:1"}, semantic_type="t")
+
+    assert diff.pure_new_cliques == []
+    assert diff.expanded_cliques == []
+    assert len(diff.merged_cliques) == 1
+    merged = diff.merged_cliques[0]
+    assert set(merged.before_cliques) == {
+        frozenset({"A:1", "B:1"}),
+        frozenset({"C:1", "D:1"}),
+    }
+    assert merged.source_curies_involved == frozenset({"NEW:1"})
+
+
+@pytest.mark.unit
+def test_diff_ignores_cliques_with_no_source_curies():
+    before = _glom_dict_from_cliques([{"A:1"}, {"B:1"}])
+    after = _glom_dict_from_cliques([{"A:1"}, {"B:1"}, {"NEW:1"}])
+    diff = diff_cliques(before, after, {"NEW:1"}, semantic_type="t")
+
+    assert len(diff.pure_new_cliques) == 1
+    assert diff.expanded_cliques == []
+    assert diff.merged_cliques == []
+
+
+@pytest.mark.unit
+def test_diff_handles_multi_prefix_source_curies():
+    """A single source may declare CURIEs under more than one prefix; the diff must
+    treat all of them as 'source' regardless of prefix."""
+    before = _glom_dict_from_cliques([{"A:1", "B:1"}, {"C:1"}])
+    after = _glom_dict_from_cliques(
+        [
+            {"A:1", "B:1", "SRC_A:1"},
+            {"C:1", "SRC_B:1"},
+        ]
+    )
+    diff = diff_cliques(before, after, {"SRC_A:1", "SRC_B:1"}, semantic_type="t")
+
+    assert diff.pure_new_cliques == []
+    assert diff.merged_cliques == []
+    assert {ec.added_source_curies for ec in diff.expanded_cliques} == {
+        frozenset({"SRC_A:1"}),
+        frozenset({"SRC_B:1"}),
+    }
+
+
+@pytest.mark.unit
+def test_diff_splits_truly_added_from_promoted_source_curies():
+    """When a source's CURIE is already in the before-clique via xref from another
+    source, ``added_source_curies`` must not include it — only ``promoted_source_curies``
+    should. The before-clique itself is unchanged in that case; the new source just
+    promotes the xref leaf to a typed identifier."""
+    # SRC:1 is pre-existing in the before-clique via someone else's xref; adding the
+    # SRC source's ids file doesn't grow the clique, it just types SRC:1.
+    before = _glom_dict_from_cliques([{"A:1", "B:1", "SRC:1"}])
+    after = _glom_dict_from_cliques([{"A:1", "B:1", "SRC:1"}])
+    diff = diff_cliques(before, after, {"SRC:1"}, semantic_type="t")
+
+    assert len(diff.expanded_cliques) == 1
+    ec = diff.expanded_cliques[0]
+    assert ec.added_source_curies == frozenset()
+    assert ec.promoted_source_curies == frozenset({"SRC:1"})
+    assert ec.before_clique == ec.after_clique
+
+
+@pytest.mark.unit
+def test_diff_treats_concord_introduced_aliases_as_pure_new():
+    """If a source's concord introduces non-source CURIEs that weren't in any before
+    clique, the resulting after-clique is reported as pure_new — without the source,
+    those CURIEs would not be in Babel at all."""
+    before = _glom_dict_from_cliques([{"A:1"}])  # ALIAS:1 not present in before
+    after = _glom_dict_from_cliques([{"A:1"}, {"SRC:1", "ALIAS:1"}])
+    diff = diff_cliques(before, after, {"SRC:1"}, semantic_type="t")
+
+    assert diff.expanded_cliques == []
+    assert diff.merged_cliques == []
+    assert frozenset({"SRC:1", "ALIAS:1"}) in set(diff.pure_new_cliques)
+
+
+@pytest.mark.unit
+def test_cliques_set_collapses_shared_set_references():
+    """glom dicts point many CURIEs at the same set object; cliques_set must dedupe."""
+    shared = {"X:1", "Y:1"}
+    glom_dict = {"X:1": shared, "Y:1": shared, "Z:1": {"Z:1"}}
+    out = cliques_set(glom_dict)
+    assert out == frozenset({frozenset({"X:1", "Y:1"}), frozenset({"Z:1"})})
+
+
+@pytest.mark.unit
+def test_cliques_from_compendia_reads_jsonl(tmp_path):
+    path = tmp_path / "Foo.txt"
+    path.write_text(
+        '{"type":"biolink:Foo","identifiers":[{"i":"A:1","l":"a"},{"i":"B:1","l":"b"}]}\n'
+        '{"type":"biolink:Foo","identifiers":[{"i":"C:1","l":"c"}]}\n'
+    )
+    out = cliques_from_compendia([path])
+    assert out == frozenset({frozenset({"A:1", "B:1"}), frozenset({"C:1"})})

--- a/tests/test_clique_diff.py
+++ b/tests/test_clique_diff.py
@@ -30,7 +30,7 @@ def _glom_dict_from_cliques(cliques):
 def test_diff_classifies_pure_new_clique_of_only_source_curies():
     before = _glom_dict_from_cliques([{"A:1"}])
     after = _glom_dict_from_cliques([{"A:1"}, {"NEW:1", "NEW:2"}])
-    diff = diff_cliques(before, after, {"NEW:1", "NEW:2"}, semantic_type="t")
+    diff = diff_cliques(before, after, {"NEW:1", "NEW:2"}, babel_pipeline="t")
 
     assert {frozenset({"NEW:1", "NEW:2"})} == set(diff.pure_new_cliques)
     assert diff.expanded_cliques == []
@@ -41,7 +41,7 @@ def test_diff_classifies_pure_new_clique_of_only_source_curies():
 def test_diff_classifies_expanded_clique():
     before = _glom_dict_from_cliques([{"A:1", "B:1"}])
     after = _glom_dict_from_cliques([{"A:1", "B:1", "NEW:1"}])
-    diff = diff_cliques(before, after, {"NEW:1"}, semantic_type="t")
+    diff = diff_cliques(before, after, {"NEW:1"}, babel_pipeline="t")
 
     assert diff.pure_new_cliques == []
     assert diff.merged_cliques == []
@@ -56,7 +56,7 @@ def test_diff_classifies_expanded_clique():
 def test_diff_classifies_merged_cliques():
     before = _glom_dict_from_cliques([{"A:1", "B:1"}, {"C:1", "D:1"}])
     after = _glom_dict_from_cliques([{"A:1", "B:1", "C:1", "D:1", "NEW:1"}])
-    diff = diff_cliques(before, after, {"NEW:1"}, semantic_type="t")
+    diff = diff_cliques(before, after, {"NEW:1"}, babel_pipeline="t")
 
     assert diff.pure_new_cliques == []
     assert diff.expanded_cliques == []
@@ -73,7 +73,7 @@ def test_diff_classifies_merged_cliques():
 def test_diff_ignores_cliques_with_no_source_curies():
     before = _glom_dict_from_cliques([{"A:1"}, {"B:1"}])
     after = _glom_dict_from_cliques([{"A:1"}, {"B:1"}, {"NEW:1"}])
-    diff = diff_cliques(before, after, {"NEW:1"}, semantic_type="t")
+    diff = diff_cliques(before, after, {"NEW:1"}, babel_pipeline="t")
 
     assert len(diff.pure_new_cliques) == 1
     assert diff.expanded_cliques == []
@@ -91,7 +91,7 @@ def test_diff_handles_multi_prefix_source_curies():
             {"C:1", "SRC_B:1"},
         ]
     )
-    diff = diff_cliques(before, after, {"SRC_A:1", "SRC_B:1"}, semantic_type="t")
+    diff = diff_cliques(before, after, {"SRC_A:1", "SRC_B:1"}, babel_pipeline="t")
 
     assert diff.pure_new_cliques == []
     assert diff.merged_cliques == []
@@ -111,7 +111,7 @@ def test_diff_splits_truly_added_from_preexisting_source_curies():
     # SRC source's ids file doesn't grow the clique, it just types SRC:1.
     before = _glom_dict_from_cliques([{"A:1", "B:1", "SRC:1"}])
     after = _glom_dict_from_cliques([{"A:1", "B:1", "SRC:1"}])
-    diff = diff_cliques(before, after, {"SRC:1"}, semantic_type="t")
+    diff = diff_cliques(before, after, {"SRC:1"}, babel_pipeline="t")
 
     assert len(diff.expanded_cliques) == 1
     ec = diff.expanded_cliques[0]
@@ -127,7 +127,7 @@ def test_diff_treats_concord_introduced_aliases_as_pure_new():
     those CURIEs would not be in Babel at all."""
     before = _glom_dict_from_cliques([{"A:1"}])  # ALIAS:1 not present in before
     after = _glom_dict_from_cliques([{"A:1"}, {"SRC:1", "ALIAS:1"}])
-    diff = diff_cliques(before, after, {"SRC:1"}, semantic_type="t")
+    diff = diff_cliques(before, after, {"SRC:1"}, babel_pipeline="t")
 
     assert diff.expanded_cliques == []
     assert diff.merged_cliques == []

--- a/tests/test_clique_diff.py
+++ b/tests/test_clique_diff.py
@@ -102,11 +102,11 @@ def test_diff_handles_multi_prefix_source_curies():
 
 
 @pytest.mark.unit
-def test_diff_splits_truly_added_from_promoted_source_curies():
+def test_diff_splits_truly_added_from_preexisting_source_curies():
     """When a source's CURIE is already in the before-clique via xref from another
-    source, ``added_source_curies`` must not include it — only ``promoted_source_curies``
-    should. The before-clique itself is unchanged in that case; the new source just
-    promotes the xref leaf to a typed identifier."""
+    source, ``added_source_curies`` must not include it — only ``preexisting_source_curies``
+    should. The before-clique itself is unchanged in that case; the new source only
+    re-types the xref leaf to a typed identifier without growing the clique."""
     # SRC:1 is pre-existing in the before-clique via someone else's xref; adding the
     # SRC source's ids file doesn't grow the clique, it just types SRC:1.
     before = _glom_dict_from_cliques([{"A:1", "B:1", "SRC:1"}])
@@ -116,7 +116,7 @@ def test_diff_splits_truly_added_from_promoted_source_curies():
     assert len(diff.expanded_cliques) == 1
     ec = diff.expanded_cliques[0]
     assert ec.added_source_curies == frozenset()
-    assert ec.promoted_source_curies == frozenset({"SRC:1"})
+    assert ec.preexisting_source_curies == frozenset({"SRC:1"})
     assert ec.before_clique == ec.after_clique
 
 

--- a/tests/test_source_discovery.py
+++ b/tests/test_source_discovery.py
@@ -1,16 +1,26 @@
 """Unit tests for src/model/source.py.
 
+A Babel source can vary along three axes simultaneously (see src/model/source.py):
+
+- **babel_pipeline** — which intermediate directory the source contributes to
+  (e.g. ``anatomy``, ``chemical``). MESH spans several; most sources span one.
+- **biolink_type** — the Biolink class URI written in the ids file's second column.
+  Multiple types may appear in one ids file (e.g. UBERON mixes ``AnatomicalEntity``
+  and ``GrossAnatomicalStructure``).
+- **prefix** — the CURIE prefix of the identifiers. Rare but supported: a single
+  source file can emit ``PREFIXA:…`` and ``PREFIXB:…`` rows.
+
 Test groups
 -----------
 scan_concords_for_curies:
     Row-matching and asserter-recording logic. Key behaviours: matches either endpoint
-    of a concord triple; records the file path relative to concords_dir as the asserter;
-    skips metadata sidecars; recurses into subdirectories (e.g. UNICHEM/*).
+    of a concord triple; records the concord file path relative to ``concords_dir`` as
+    the asserter; skips ``metadata-*`` sidecars; recurses into subdirectories
+    (e.g. ``UNICHEM/UNICHEM_*``).
 
 discover_source — structure:
-    The four axes a source can vary along — single vs multi babel_pipeline, single vs
-    multi biolink_type within one pipeline, single vs multi prefix — each verified with a
-    minimal fixture tree.
+    Baseline (single everything) plus one test per axis, confirming that
+    ``SourceContribution`` correctly aggregates across each dimension.
 
 discover_source — edge cases:
     Missing source name, missing intermediate root, and metadata sidecar filtering.
@@ -27,6 +37,12 @@ from src.model.source import discover_source, scan_concords_for_curies
 
 @pytest.mark.unit
 def test_scan_concords_for_curies_matches_either_endpoint_and_records_asserter(tmp_path):
+    """Matches rows where the source CURIE is subject or object; skips rows and files with no match.
+
+    Also verifies that ``asserted_by`` is the concord file path relative to ``concords_dir``
+    (``"UBERON"``, not the full path), and that metadata sidecars are never scanned even if
+    they contain matching content.
+    """
     concords = tmp_path / "anatomy" / "concords"
     concords.mkdir(parents=True)
     # EMAPA's own concord is empty; its xrefs live in UBERON's concord.
@@ -50,6 +66,7 @@ def test_scan_concords_for_curies_matches_either_endpoint_and_records_asserter(t
 
 @pytest.mark.unit
 def test_scan_concords_for_curies_missing_dir_returns_empty(tmp_path):
+    """Returns an empty list rather than raising when the concords directory does not exist."""
     assert scan_concords_for_curies(tmp_path / "nope", {"EMAPA:1"}) == []
 
 
@@ -72,7 +89,12 @@ def _make_source_tree(root, source_name, semantic_type, ids_lines=None, concord_
 
 @pytest.mark.unit
 def test_discover_single_prefix_single_type_single_semantic_type(tmp_path):
-    """Baseline: one source, one babel_pipeline, one biolink_type, one prefix."""
+    """Baseline: one source, one babel_pipeline, one biolink_type, one prefix.
+
+    Verifies the full shape of ``SourceContribution`` — semantic_types, prefixes,
+    declared_biolink_types, total counts, and the per-pipeline ``declared_type_counts``
+    and ``concord_partner_prefix_counts`` breakdowns.
+    """
     _make_source_tree(
         tmp_path,
         "EMAPA",
@@ -144,14 +166,9 @@ def test_discover_multi_semantic_type(tmp_path):
     assert len(contrib.by_semantic_type["chemical"].all_curies) == 2
 
 
-# ---------------------------------------------------------------------------
-# discover_source — edge cases
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.unit
 def test_discover_multi_prefix(tmp_path):
-    """A source may write rows under more than one prefix."""
+    """A source may write rows under more than one prefix (rare but supported)."""
     _make_source_tree(
         tmp_path,
         "WEIRD",
@@ -170,6 +187,11 @@ def test_discover_multi_prefix(tmp_path):
         "PREFIXA": 1,
         "PREFIXB": 1,
     }
+
+
+# ---------------------------------------------------------------------------
+# discover_source — edge cases
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit

--- a/tests/test_source_discovery.py
+++ b/tests/test_source_discovery.py
@@ -27,7 +27,7 @@ def test_scan_concords_for_curies_matches_either_endpoint_and_records_asserter(t
 
     assert ("UBERON:1", "xref", "EMAPA:10", "UBERON") in rows
     assert ("EMAPA:20", "skos:exactMatch", "CL:2", "UBERON") in rows
-    assert all(r[3] == "UBERON" for r in rows), "asserted_by is the concord file basename"
+    assert all(r[3] == "UBERON" for r in rows), "asserted_by is the concord file path relative to concords_dir"
     assert not any("UBERON:3" in r for r in rows), "rows without a source CURIE are dropped"
     assert len(rows) == 2
 
@@ -159,6 +159,25 @@ def test_discover_missing_source_returns_empty_contribution(tmp_path):
 def test_discover_raises_when_intermediate_root_missing(tmp_path):
     with pytest.raises(FileNotFoundError):
         discover_source("EMAPA", tmp_path / "missing")
+
+
+@pytest.mark.unit
+def test_scan_concords_for_curies_recurses_into_subdirectories(tmp_path):
+    """Concord files in subdirectories (e.g. chemicals/concords/UNICHEM/UNICHEM_*) must be
+    scanned; asserted_by should be the relative path from concords_dir."""
+    concords = tmp_path / "chemicals" / "concords"
+    unichem_dir = concords / "UNICHEM"
+    unichem_dir.mkdir(parents=True)
+    (unichem_dir / "UNICHEM_7").write_text("PUBCHEM.COMPOUND:1\txref\tCHEMBL.COMPOUND:2\n")
+    (unichem_dir / "UNICHEM_22").write_text("PUBCHEM.COMPOUND:1\txref\tCHEBI:999\n")
+    # Metadata sidecars in subdirectories are also skipped.
+    (unichem_dir / "metadata-UNICHEM_7.yaml").write_text("name: unichem\n")
+
+    rows = scan_concords_for_curies(concords, {"PUBCHEM.COMPOUND:1"})
+
+    assert len(rows) == 2
+    asserters = {r[3] for r in rows}
+    assert asserters == {"UNICHEM/UNICHEM_7", "UNICHEM/UNICHEM_22"}
 
 
 @pytest.mark.unit

--- a/tests/test_source_discovery.py
+++ b/tests/test_source_discovery.py
@@ -1,12 +1,29 @@
 """Unit tests for src/model/source.py.
 
-Covers the four dimensions a Babel source can vary along: single, multi-biolink-type
-(UBERON-style), multi-semantic-type (MESH-style), and multi-prefix.
+Test groups
+-----------
+scan_concords_for_curies:
+    Row-matching and asserter-recording logic. Key behaviours: matches either endpoint
+    of a concord triple; records the file path relative to concords_dir as the asserter;
+    skips metadata sidecars; recurses into subdirectories (e.g. UNICHEM/*).
+
+discover_source — structure:
+    The four axes a source can vary along — single vs multi babel_pipeline, single vs
+    multi biolink_type within one pipeline, single vs multi prefix — each verified with a
+    minimal fixture tree.
+
+discover_source — edge cases:
+    Missing source name, missing intermediate root, and metadata sidecar filtering.
 """
 
 import pytest
 
 from src.model.source import discover_source, scan_concords_for_curies
+
+
+# ---------------------------------------------------------------------------
+# scan_concords_for_curies
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
@@ -37,7 +54,13 @@ def test_scan_concords_for_curies_missing_dir_returns_empty(tmp_path):
     assert scan_concords_for_curies(tmp_path / "nope", {"EMAPA:1"}) == []
 
 
+# ---------------------------------------------------------------------------
+# discover_source — structure
+# ---------------------------------------------------------------------------
+
+
 def _make_source_tree(root, source_name, semantic_type, ids_lines=None, concord_lines=None):
+    """Write minimal ids/ and concords/ files under ``root/<semantic_type>/`` for one source."""
     ids_dir = root / semantic_type / "ids"
     concords_dir = root / semantic_type / "concords"
     ids_dir.mkdir(parents=True, exist_ok=True)
@@ -50,6 +73,7 @@ def _make_source_tree(root, source_name, semantic_type, ids_lines=None, concord_
 
 @pytest.mark.unit
 def test_discover_single_prefix_single_type_single_semantic_type(tmp_path):
+    """Baseline: one source, one babel_pipeline, one biolink_type, one prefix."""
     _make_source_tree(
         tmp_path,
         "EMAPA",
@@ -98,7 +122,7 @@ def test_discover_multi_biolink_type_within_one_semantic_type(tmp_path):
 
 @pytest.mark.unit
 def test_discover_multi_semantic_type(tmp_path):
-    """MESH-style source spanning anatomy and chemical compendia."""
+    """MESH-style source present in two babel_pipeline directories (anatomy and chemical)."""
     _make_source_tree(
         tmp_path,
         "MESH",
@@ -119,6 +143,11 @@ def test_discover_multi_semantic_type(tmp_path):
     assert contrib.declared_biolink_types == frozenset({"biolink:AnatomicalEntity", "biolink:ChemicalEntity"})
     assert len(contrib.by_semantic_type["anatomy"].all_curies) == 1
     assert len(contrib.by_semantic_type["chemical"].all_curies) == 2
+
+
+# ---------------------------------------------------------------------------
+# discover_source — edge cases
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
@@ -146,6 +175,7 @@ def test_discover_multi_prefix(tmp_path):
 
 @pytest.mark.unit
 def test_discover_missing_source_returns_empty_contribution(tmp_path):
+    """A source name with no ids or concords files anywhere returns an empty contribution."""
     (tmp_path / "anatomy" / "ids").mkdir(parents=True)
     (tmp_path / "anatomy" / "concords").mkdir(parents=True)
 
@@ -157,6 +187,7 @@ def test_discover_missing_source_returns_empty_contribution(tmp_path):
 
 @pytest.mark.unit
 def test_discover_raises_when_intermediate_root_missing(tmp_path):
+    """Passing a non-existent intermediate root raises FileNotFoundError rather than silently returning empty."""
     with pytest.raises(FileNotFoundError):
         discover_source("EMAPA", tmp_path / "missing")
 

--- a/tests/test_source_discovery.py
+++ b/tests/test_source_discovery.py
@@ -1,0 +1,175 @@
+"""Unit tests for src/model/source.py.
+
+Covers the four dimensions a Babel source can vary along: single, multi-biolink-type
+(UBERON-style), multi-semantic-type (MESH-style), and multi-prefix.
+"""
+
+import pytest
+
+from src.model.source import discover_source, scan_concords_for_curies
+
+
+@pytest.mark.unit
+def test_scan_concords_for_curies_matches_either_endpoint_and_records_asserter(tmp_path):
+    concords = tmp_path / "anatomy" / "concords"
+    concords.mkdir(parents=True)
+    # EMAPA's own concord is empty; its xrefs live in UBERON's concord.
+    (concords / "EMAPA").write_text("")
+    (concords / "UBERON").write_text(
+        "UBERON:1\txref\tEMAPA:10\n"  # source CURIE on the object side
+        "EMAPA:20\tskos:exactMatch\tCL:2\n"  # source CURIE on the subject side
+        "UBERON:3\txref\tCL:4\n"  # no source CURIE — skipped
+    )
+    # Metadata sidecars must be ignored.
+    (concords / "metadata-UBERON.yaml").write_text("UBERON:1\txref\tEMAPA:10\n")
+
+    rows = scan_concords_for_curies(concords, {"EMAPA:10", "EMAPA:20"})
+
+    assert ("UBERON:1", "xref", "EMAPA:10", "UBERON") in rows
+    assert ("EMAPA:20", "skos:exactMatch", "CL:2", "UBERON") in rows
+    assert all(r[3] == "UBERON" for r in rows), "asserted_by is the concord file basename"
+    assert not any("UBERON:3" in r for r in rows), "rows without a source CURIE are dropped"
+    assert len(rows) == 2
+
+
+@pytest.mark.unit
+def test_scan_concords_for_curies_missing_dir_returns_empty(tmp_path):
+    assert scan_concords_for_curies(tmp_path / "nope", {"EMAPA:1"}) == []
+
+
+def _make_source_tree(root, source_name, semantic_type, ids_lines=None, concord_lines=None):
+    ids_dir = root / semantic_type / "ids"
+    concords_dir = root / semantic_type / "concords"
+    ids_dir.mkdir(parents=True, exist_ok=True)
+    concords_dir.mkdir(parents=True, exist_ok=True)
+    if ids_lines is not None:
+        (ids_dir / source_name).write_text("\n".join(ids_lines) + "\n")
+    if concord_lines is not None:
+        (concords_dir / source_name).write_text("\n".join(concord_lines) + "\n")
+
+
+@pytest.mark.unit
+def test_discover_single_prefix_single_type_single_semantic_type(tmp_path):
+    _make_source_tree(
+        tmp_path,
+        "EMAPA",
+        "anatomy",
+        ids_lines=["EMAPA:1\tbiolink:AnatomicalEntity", "EMAPA:2\tbiolink:AnatomicalEntity"],
+        concord_lines=["EMAPA:1\txref\tUBERON:1"],
+    )
+
+    contrib = discover_source("EMAPA", tmp_path)
+
+    assert contrib.semantic_types == frozenset({"anatomy"})
+    assert contrib.prefixes == frozenset({"EMAPA"})
+    assert contrib.declared_biolink_types == frozenset({"biolink:AnatomicalEntity"})
+    assert contrib.total_identifier_count == 2
+    assert contrib.total_concord_row_count == 1
+
+    stc = contrib.by_semantic_type["anatomy"]
+    assert stc.declared_type_counts == {"biolink:AnatomicalEntity": 2}
+    assert stc.concord_partner_prefix_counts == {"UBERON": 1}
+
+
+@pytest.mark.unit
+def test_discover_multi_biolink_type_within_one_semantic_type(tmp_path):
+    """An ids file may mix biolink types in its second column — UBERON does this with
+    AnatomicalEntity and GrossAnatomicalStructure."""
+    _make_source_tree(
+        tmp_path,
+        "UBERON",
+        "anatomy",
+        ids_lines=[
+            "UBERON:1\tbiolink:AnatomicalEntity",
+            "UBERON:2\tbiolink:GrossAnatomicalStructure",
+            "UBERON:3\tbiolink:AnatomicalEntity",
+        ],
+    )
+
+    contrib = discover_source("UBERON", tmp_path)
+
+    assert contrib.declared_biolink_types == frozenset({"biolink:AnatomicalEntity", "biolink:GrossAnatomicalStructure"})
+    stc = contrib.by_semantic_type["anatomy"]
+    assert stc.declared_type_counts == {
+        "biolink:AnatomicalEntity": 2,
+        "biolink:GrossAnatomicalStructure": 1,
+    }
+
+
+@pytest.mark.unit
+def test_discover_multi_semantic_type(tmp_path):
+    """MESH-style source spanning anatomy and chemical compendia."""
+    _make_source_tree(
+        tmp_path,
+        "MESH",
+        "anatomy",
+        ids_lines=["MESH:A1\tbiolink:AnatomicalEntity"],
+    )
+    _make_source_tree(
+        tmp_path,
+        "MESH",
+        "chemical",
+        ids_lines=["MESH:C1\tbiolink:ChemicalEntity", "MESH:C2\tbiolink:ChemicalEntity"],
+    )
+
+    contrib = discover_source("MESH", tmp_path)
+
+    assert contrib.semantic_types == frozenset({"anatomy", "chemical"})
+    assert contrib.total_identifier_count == 3
+    assert contrib.declared_biolink_types == frozenset({"biolink:AnatomicalEntity", "biolink:ChemicalEntity"})
+    assert len(contrib.by_semantic_type["anatomy"].all_curies) == 1
+    assert len(contrib.by_semantic_type["chemical"].all_curies) == 2
+
+
+@pytest.mark.unit
+def test_discover_multi_prefix(tmp_path):
+    """A source may write rows under more than one prefix."""
+    _make_source_tree(
+        tmp_path,
+        "WEIRD",
+        "anatomy",
+        ids_lines=[
+            "PREFIXA:1\tbiolink:AnatomicalEntity",
+            "PREFIXB:1\tbiolink:AnatomicalEntity",
+        ],
+    )
+
+    contrib = discover_source("WEIRD", tmp_path)
+
+    assert contrib.prefixes == frozenset({"PREFIXA", "PREFIXB"})
+    stc = contrib.by_semantic_type["anatomy"]
+    assert {p: len(c) for p, c in stc.curies_by_prefix.items()} == {
+        "PREFIXA": 1,
+        "PREFIXB": 1,
+    }
+
+
+@pytest.mark.unit
+def test_discover_missing_source_returns_empty_contribution(tmp_path):
+    (tmp_path / "anatomy" / "ids").mkdir(parents=True)
+    (tmp_path / "anatomy" / "concords").mkdir(parents=True)
+
+    contrib = discover_source("NONEXISTENT", tmp_path)
+    assert contrib.by_semantic_type == {}
+    assert contrib.semantic_types == frozenset()
+    assert contrib.total_identifier_count == 0
+
+
+@pytest.mark.unit
+def test_discover_raises_when_intermediate_root_missing(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        discover_source("EMAPA", tmp_path / "missing")
+
+
+@pytest.mark.unit
+def test_discover_skips_metadata_yaml_files(tmp_path):
+    """discover_source should only treat files literally named <SOURCE>, not metadata-* siblings."""
+    concord_dir = tmp_path / "anatomy" / "concords"
+    concord_dir.mkdir(parents=True)
+    (concord_dir / "EMAPA").write_text("EMAPA:1\txref\tUBERON:1\n")
+    (concord_dir / "metadata-EMAPA.yaml").write_text("name: build_anatomy_obo_relationships()\n")
+    (tmp_path / "anatomy" / "ids").mkdir(parents=True)
+
+    contrib = discover_source("EMAPA", tmp_path)
+    assert contrib.semantic_types == frozenset({"anatomy"})
+    assert contrib.total_concord_row_count == 1

--- a/tests/test_source_discovery.py
+++ b/tests/test_source_discovery.py
@@ -20,7 +20,6 @@ import pytest
 
 from src.model.source import discover_source, scan_concords_for_curies
 
-
 # ---------------------------------------------------------------------------
 # scan_concords_for_curies
 # ---------------------------------------------------------------------------

--- a/tests/test_source_discovery.py
+++ b/tests/test_source_discovery.py
@@ -75,10 +75,10 @@ def test_scan_concords_for_curies_missing_dir_returns_empty(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def _make_source_tree(root, source_name, semantic_type, ids_lines=None, concord_lines=None):
-    """Write minimal ids/ and concords/ files under ``root/<semantic_type>/`` for one source."""
-    ids_dir = root / semantic_type / "ids"
-    concords_dir = root / semantic_type / "concords"
+def _make_source_tree(root, source_name, pipeline, ids_lines=None, concord_lines=None):
+    """Write minimal ids/ and concords/ files under ``root/<pipeline>/`` for one source."""
+    ids_dir = root / pipeline / "ids"
+    concords_dir = root / pipeline / "concords"
     ids_dir.mkdir(parents=True, exist_ok=True)
     concords_dir.mkdir(parents=True, exist_ok=True)
     if ids_lines is not None:
@@ -88,10 +88,10 @@ def _make_source_tree(root, source_name, semantic_type, ids_lines=None, concord_
 
 
 @pytest.mark.unit
-def test_discover_single_prefix_single_type_single_semantic_type(tmp_path):
+def test_discover_single_prefix_single_type_single_pipeline(tmp_path):
     """Baseline: one source, one babel_pipeline, one biolink_type, one prefix.
 
-    Verifies the full shape of ``SourceContribution`` — semantic_types, prefixes,
+    Verifies the full shape of ``SourceContribution`` — pipelines, prefixes,
     declared_biolink_types, total counts, and the per-pipeline ``declared_type_counts``
     and ``concord_partner_prefix_counts`` breakdowns.
     """
@@ -105,15 +105,15 @@ def test_discover_single_prefix_single_type_single_semantic_type(tmp_path):
 
     contrib = discover_source("EMAPA", tmp_path)
 
-    assert contrib.semantic_types == frozenset({"anatomy"})
+    assert contrib.pipelines == frozenset({"anatomy"})
     assert contrib.prefixes == frozenset({"EMAPA"})
     assert contrib.declared_biolink_types == frozenset({"biolink:AnatomicalEntity"})
     assert contrib.total_identifier_count == 2
     assert contrib.total_concord_row_count == 1
 
-    stc = contrib.by_semantic_type["anatomy"]
-    assert stc.declared_type_counts == {"biolink:AnatomicalEntity": 2}
-    assert stc.concord_partner_prefix_counts == {"UBERON": 1}
+    pc = contrib.by_pipeline["anatomy"]
+    assert pc.declared_type_counts == {"biolink:AnatomicalEntity": 2}
+    assert pc.concord_partner_prefix_counts == {"UBERON": 1}
 
 
 @pytest.mark.unit
@@ -134,15 +134,15 @@ def test_discover_multi_biolink_type_within_one_semantic_type(tmp_path):
     contrib = discover_source("UBERON", tmp_path)
 
     assert contrib.declared_biolink_types == frozenset({"biolink:AnatomicalEntity", "biolink:GrossAnatomicalStructure"})
-    stc = contrib.by_semantic_type["anatomy"]
-    assert stc.declared_type_counts == {
+    pc = contrib.by_pipeline["anatomy"]
+    assert pc.declared_type_counts == {
         "biolink:AnatomicalEntity": 2,
         "biolink:GrossAnatomicalStructure": 1,
     }
 
 
 @pytest.mark.unit
-def test_discover_multi_semantic_type(tmp_path):
+def test_discover_multi_pipeline(tmp_path):
     """MESH-style source present in two babel_pipeline directories (anatomy and chemical)."""
     _make_source_tree(
         tmp_path,
@@ -159,11 +159,11 @@ def test_discover_multi_semantic_type(tmp_path):
 
     contrib = discover_source("MESH", tmp_path)
 
-    assert contrib.semantic_types == frozenset({"anatomy", "chemical"})
+    assert contrib.pipelines == frozenset({"anatomy", "chemical"})
     assert contrib.total_identifier_count == 3
     assert contrib.declared_biolink_types == frozenset({"biolink:AnatomicalEntity", "biolink:ChemicalEntity"})
-    assert len(contrib.by_semantic_type["anatomy"].all_curies) == 1
-    assert len(contrib.by_semantic_type["chemical"].all_curies) == 2
+    assert len(contrib.by_pipeline["anatomy"].all_curies) == 1
+    assert len(contrib.by_pipeline["chemical"].all_curies) == 2
 
 
 @pytest.mark.unit
@@ -182,8 +182,8 @@ def test_discover_multi_prefix(tmp_path):
     contrib = discover_source("WEIRD", tmp_path)
 
     assert contrib.prefixes == frozenset({"PREFIXA", "PREFIXB"})
-    stc = contrib.by_semantic_type["anatomy"]
-    assert {p: len(c) for p, c in stc.curies_by_prefix.items()} == {
+    pc = contrib.by_pipeline["anatomy"]
+    assert {p: len(c) for p, c in pc.curies_by_prefix.items()} == {
         "PREFIXA": 1,
         "PREFIXB": 1,
     }
@@ -201,8 +201,8 @@ def test_discover_missing_source_returns_empty_contribution(tmp_path):
     (tmp_path / "anatomy" / "concords").mkdir(parents=True)
 
     contrib = discover_source("NONEXISTENT", tmp_path)
-    assert contrib.by_semantic_type == {}
-    assert contrib.semantic_types == frozenset()
+    assert contrib.by_pipeline == {}
+    assert contrib.pipelines == frozenset()
     assert contrib.total_identifier_count == 0
 
 
@@ -242,5 +242,5 @@ def test_discover_skips_metadata_yaml_files(tmp_path):
     (tmp_path / "anatomy" / "ids").mkdir(parents=True)
 
     contrib = discover_source("EMAPA", tmp_path)
-    assert contrib.semantic_types == frozenset({"anatomy"})
+    assert contrib.pipelines == frozenset({"anatomy"})
     assert contrib.total_concord_row_count == 1

--- a/uv.lock
+++ b/uv.lock
@@ -177,7 +177,7 @@ wheels = [
 
 [[package]]
 name = "babel-pipeline"
-version = "1.14"
+version = "1.17"
 source = { editable = "." }
 dependencies = [
     { name = "apybiomart" },


### PR DESCRIPTION
## Summary

Adds `src/model/` — two pure, fully unit-tested library modules that the source-impact report tool builds on. **Split out of #742** so the foundational primitives can be reviewed in isolation, ahead of the larger tool PR.

- **`clique_diff.py`** — represents glom output as `frozenset` cliques and buckets the before/after difference of adding a source into **pure-new / expanded / merged**, distinguishing structurally-added from promoted (already-present-via-xref) source CURIEs. Includes helpers to materialise cliques from JSONL compendia.
- **`source.py`** — `discover_source()` walks `<intermediate_root>/<pipeline>/{ids,concords}/<name>` and models a source as multi-pipeline, multi-biolink-type, and multi-prefix. `SemanticTypeContribution` was renamed to `PipelineContribution` (and `by_semantic_type` → `by_pipeline`) to match CLAUDE.md's `babel_pipeline` terminology; a TODO in the module docstring flags the corresponding rename needed in #742 when it is rebased.

### Note on unused-but-tested code

No production code consumes `src/model/` yet — its first consumer is the source-impact report tool (the slimmed #742, which will be rebased onto `main` after this merges). The modules ship with full unit tests (`tests/test_clique_diff.py`, `tests/test_source_discovery.py`) covering the diff classification and all four source-variation dimensions.

The `uv.lock` babel-pipeline version line is synced `1.14` → `1.17` to match `pyproject.toml` (already stale on `main`).

## Test plan

- [x] `uv run pytest -m unit -q tests/test_clique_diff.py tests/test_source_discovery.py` (19 passed)
- [x] `uv run ruff check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)