### PR TITLE
Document what Ubergraph's SPARQL results actually contain

### DIFF
--- a/docs/sources/README.md
+++ b/docs/sources/README.md
@@ -10,6 +10,11 @@ One directory per data source, named by the source's CURIE prefix (the same pref
 `src/prefixes.py` and in `babel_downloads/<PREFIX>/`). A source directory may contain multiple
 files when there is enough to say (ingestion, synonyms, known issues, etc.).
 
+Some sources have no CURIE prefix of their own — Ubergraph, for instance, is a merged triplestore
+serving identifiers from many prefixes. Name those directories after the source in its own
+capitalisation (`Ubergraph/`, not `UBERGRAPH/`), so that an all-caps directory name always means
+"this is a CURIE prefix you can look up".
+
 When you learn something non-obvious about how a source is ingested, add it here rather than
 letting it accumulate in `CLAUDE.md` — `CLAUDE.md` should point here, not duplicate the detail.
 
@@ -26,6 +31,10 @@ letting it accumulate in `CLAUDE.md` — `CLAUDE.md` should point here, not dupl
 - **MESH** ([MESH/Ingestion.md](./MESH/Ingestion.md)) — how MeSH is partitioned across compendia
   by tree letter, how Supplementary Concept Records (SCRs) are typed and routed, the
   chemical/protein D-tree split, and which MeSH branches/SCR classes we deliberately skip.
+- **Ubergraph** ([Ubergraph/curie-validation.md](./Ubergraph/curie-validation.md)) — the merged
+  reasoned triplestore behind the shared label/synonym/description files: what its SPARQL results
+  actually contain (bare IRIs, blank nodes, fragment IRIs mangled by `Text.opt_to_curie()`,
+  Relation Ontology predicates), and where the filtering that rejects them lives.
 - **UMLS** ([UMLS/Leftover.md](./UMLS/Leftover.md)) — the "leftover UMLS" compendium: how
   unclaimed UMLS concepts are swept up and typed, the manual STY→Biolink override tables and the
   drift test that keeps them honest, and the coverage report under `reports/umls/`.

--- a/docs/sources/Ubergraph/curie-validation.md
+++ b/docs/sources/Ubergraph/curie-validation.md
@@ -1,0 +1,116 @@
+# Ubergraph: what its IRIs look like, and how Babel filters them
+
+Ubergraph is queried over SPARQL (`src/ubergraph.py`) and is the source of the shared label,
+synonym, and description files under `babel_downloads/common/ubergraph/`. Unlike most Babel
+sources it is not a single vocabulary: it is a merged reasoned triplestore over dozens of OBO
+ontologies, so a single query returns identifiers from ~200 prefixes at once, plus a tail of
+things that are not ontology terms at all.
+
+This page records what actually comes back, because the filtering code that deals with it is
+subtle and currently wrong in ways that are easy to miss.
+
+## The filter as it stands today
+
+`src/datahandlers/obo.py` repeats this guard three times, once each in `pull_uber_labels()`,
+`pull_uber_descriptions()`, and `pull_uber_synonyms()`:
+
+```python
+prefix in ["http", "ro"] or prefix.startswith("t") or "#" in prefix
+```
+
+It is trying to reject four different things at once, and it only partly succeeds.
+
+## What Ubergraph returns that is not a CURIE
+
+### Bare IRIs
+
+`Text.opt_to_curie()` recognises a fixed list of IRI patterns (OBO PURLs, Orphanet, EFO, OMIM,
+identifiers.org, and a few more). Anything it does not recognise, and anything whose conversion
+would produce a string with no colon, raises `ValueError`. The three result loops in
+`src/ubergraph.py` catch that and **fall back to using the raw IRI as-is**, so strings like
+`http://www.w3.org/2000/01/rdf-schema#label` flow downstream as if they were CURIEs. The
+`prefix in ["http", ...]` clause exists to catch those.
+
+It does not catch `https://` — see "Known leaks" below.
+
+### Blank nodes
+
+Ubergraph serialises blank nodes as `t` followed by digits, e.g. `t27502167`. These have no
+colon, so `Text.get_prefix()` raises `ValueError` on them. `UberGraph.is_blank_node()` already
+recognises this shape precisely (leading `t`, all remaining characters digits).
+
+The `prefix.startswith("t")` clause in `obo.py` is a looser restatement of that check. It is
+**live only in `pull_uber_labels()`**, which extracts the prefix with a bare `iri.split(":")[0]`
+and so sees the whole colon-less blank node as the "prefix". In `pull_uber_descriptions()` and
+`pull_uber_synonyms()`, which use `Text.get_prefix()`, the `ValueError` is caught first and the
+row is skipped before the `startswith("t")` test ever runs — the clause is dead code there.
+
+The clause is also over-broad: it would reject any legitimate lowercase prefix beginning with
+`t`. None exists in `src/prefixes.py` today (`TCDB` is the only `t` prefix and it is uppercase),
+so nothing is lost, but that is luck rather than design.
+
+### Fragment IRIs mangled into fake CURIEs
+
+`Text.opt_to_curie()` converts OBO PURLs by taking the last path segment and splitting it on `_`.
+When the last segment contains a fragment, the result is a syntactically invalid CURIE rather
+than a `ValueError`:
+
+| Input IRI | `opt_to_curie()` output |
+|---|---|
+| `http://purl.obolibrary.org/obo/UBERON_0000001` | `UBERON:0000001` |
+| `http://purl.obolibrary.org/obo/uberon/core#part_of` | `core#part:of` |
+| `http://purl.obolibrary.org/obo/OBO_REL#part_of` | `OBO:REL#:part:of` |
+
+The `"#" in prefix` clause catches the first of these two failures. It misses the second, because
+there the `#` lands in the local part and the prefix (`OBO`) looks innocuous.
+
+This mangling is a property of `opt_to_curie()`'s heuristic, not of Ubergraph or of RDF. An OWL
+ingest via pyoxigraph would not produce it — there a blank node is a `BlankNode` *type*, not a
+`t\d+` string, and IRIs are not string-split.
+
+### Relation Ontology terms
+
+`RO:0002213` "positively regulates", `RO:0002548` "end, days post coitum", and ~770 others are
+perfectly well-formed CURIEs. They are predicates, not entities, so Babel has no compendium for
+them. The `"ro"` entry in the filter's list is trying to exclude them.
+
+This is the important structural observation: **`"ro"` is a policy exclusion smuggled into a
+syntax check.** The other three clauses ask "is this even a CURIE?"; this one asks "do we want
+this vocabulary?". Conflating them is why the syntax half of the check was never scrutinised.
+
+## Known leaks
+
+Measured against the 3,816,207-row `babel_downloads/common/ubergraph/labels` from the
+2026-06-30 download:
+
+| Leak | Rows in `labels` | Why it slips through |
+|---|---|---|
+| `https://purl.brain-bican.org/…`, `https://orcid.org/…`, wikidata, `w3id.org/sssom` | 8,762 | the filter tests `"http"`, not `"https"` |
+| `RO:0002213` and friends | 772 | the filter tests lowercase `"ro"`; `opt_to_curie()` emits `RO` |
+| `OBO:REL#:part:of` | 1 | the `#` is in the local part, not the prefix |
+
+`synonyms.jsonl` leaks 1,331 `https:` rows the same way. `descriptions.jsonl` is clean. Bare
+`http://` IRIs and blank nodes are correctly dropped from all three.
+
+The `https://` rows break down as 6,895 BICAN taxonomy terms, 1,327 BICAN ontology terms, and a
+couple of dozen ORCIDs, Wikidata entries, and SSSOM URLs. The BICAN terms are real, labelled
+cell-type identifiers — worth a deliberate decision rather than an accidental one.
+
+To reproduce the histogram:
+
+```bash
+cut -f1 babel_downloads/common/ubergraph/labels | awk -F: '{print $1}' | sort | uniq -c | sort -rn
+```
+
+## Why the leaks are currently harmless
+
+`NodeFactory` (`src/node.py`) loads the common labels into a dict keyed by CURIE and looks
+entries up by identifier. No compendium contains an identifier with an `https` or `RO` prefix, so
+the junk rows are never read. They cost memory, not correctness. Nothing in the output is wrong
+today — but the invariant "everything in this file is a CURIE Babel could use" does not hold, and
+the next vocabulary Ubergraph adds under an unrecognised namespace will land here silently.
+
+Tracked in [NCATSTranslator/Babel#898](https://github.com/NCATSTranslator/Babel/issues/898), which
+proposes splitting the syntax check (move it into `src/ubergraph.py`, reusing `is_blank_node()`)
+from the policy exclusion (move it into `config.yaml`), and lists the research needed before the
+policy list can be written.


### PR DESCRIPTION
Documentation only — no code changes, no effect on any build.

`src/datahandlers/obo.py` filters Ubergraph results three times over with

```python
prefix in ["http", "ro"] or prefix.startswith("t") or "#" in prefix
```

Nothing explained what each clause was for. Working that out against the 2026-06-30 download turned up that the check is also wrong, so this PR records the findings rather than leaving them in a comment thread. The fix itself is deliberately deferred to #898, because getting the exclusion list wrong either admits bad identifiers or silently drops good ones from the next build.

## What the investigation found

The four clauses look like four instances of one check. They are two different kinds of check wearing one coat:

- **Syntactic** — "is this even a CURIE?" (`http`, `t…`, `#`), a property of the Ubergraph/SPARQL boundary.
- **Policy** — "do we want this vocabulary?" (`ro` is the Relation Ontology: predicates, not entities), which belongs in `config.yaml` next to `ubergraph_ontologies` — a list that already contains `RO`.

Because a policy exclusion was smuggled into a syntax check, the syntax half went unexamined. Measured leaks in `babel_downloads/common/ubergraph/labels`:

| Leak | Rows | Why |
|---|---|---|
| `https://purl.brain-bican.org/…`, ORCIDs, Wikidata, SSSOM | 8,762 | the filter tests `"http"`, not `"https"` |
| `RO:0002213` "positively regulates" and ~770 others | 772 | it tests lowercase `"ro"`; `opt_to_curie()` emits `RO` |
| `OBO:REL#:part:of` | 1 | the `#` lands in the local part, not the prefix |

`synonyms.jsonl` leaks 1,331 `https:` rows the same way. These are harmless *today* only because `NodeFactory` looks labels up by CURIE and no compendium carries an `https` or `RO` prefix — they cost memory, not correctness. That is luck: `TCDB` is the only real prefix starting with `t` and it survives only because it is uppercase.

Two details worth having written down: `UberGraph.is_blank_node()` already exists and is stricter than `startswith("t")`, but is only used to decide whether to *warn*, so the blank node still flows out as a raw string and forces `obo.py` to filter again. And the `#` garbage is manufactured by `Text.opt_to_curie()`, which splits OBO PURLs on `/` then `_` without validating the result — not by Ubergraph or by RDF.

## Naming

`docs/sources/README.md` said "one directory per data source, named by the source's CURIE prefix", which has no answer for Ubergraph: it is a merged triplestore serving identifiers from ~200 prefixes and owns none of them. The second commit reserves the all-caps directory name for real CURIE prefixes — so an all-caps name always means "you can look this prefix up" — and spells other sources in their own capitalisation.

Companion to #898, which carries the proposed design, the test plan, and the open research questions (notably: those 6,895 `https://purl.brain-bican.org/taxonomy/…` rows are real, labelled BICAN cell-type identifiers, and whether to drop or properly CURIE-ify them should be a choice rather than a side effect of a string comparison).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
