### PR TITLE
clique-diff: report the incoming side of cross-compendium moves

### DIFF
--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -132,6 +132,16 @@ counts: a nested `clique_count` (`before`/`after`/`diff`/`diff_percent`) plus
 `changed_before_cliques`, `dropped_member_count` (the headline regression signal),
 `moved_member_count`, `regrouped_member_count`, and `leader_changed_count`.
 
+Two further fields, `moved_in_member_count` and `moved_in_clique_count`, report the *incoming*
+side of moves: members that arrived in this compendium from another compendium's before-cliques,
+and how many distinct after-cliques here received them. They exist because every other stat is
+before-clique-centric — a `moved` row is filed under the *source* compendium, so a compendium that
+only *receives* retyped members (e.g. `PhenotypicFeature.txt` gaining cliques that split off
+disease cliques) would otherwise show `changed_before_cliques: 0` and look untouched, with its
+gained cliques visible only as a positive `clique_count.diff`. When triaging a diff, read
+`moved_in_clique_count` on every receiving compendium and pull the corresponding `moved` rows
+(`destination_compendium == <file>`) from the CSV — they name each gained clique.
+
 `diff_percent` is `null` when the before build had no cliques in that compendium but the after
 build has some: the percentage is undefined, and `0.0` would misread as "unchanged". It is `0.0`
 only when the two counts genuinely match.

--- a/tests/tools/test_clique_diff_tool.py
+++ b/tests/tools/test_clique_diff_tool.py
@@ -128,7 +128,9 @@ def test_moved_vs_dropped_distinguished_across_files(tmp_path):
 
     A moved row should name the *destination clique* it landed in — leader, label, type, size
     and compendium file — so the row is readable without inferring anything from
-    ``example_members`` (which truncates at five members).
+    ``example_members`` (which truncates at five members). Also checks the receiving side: the
+    destination compendium's before-clique-centric stats show nothing, but ``moved_in_*`` surfaces
+    the gained clique.
     """
     bdir, adir = tmp_path / "before", tmp_path / "after"
     bdir.mkdir()
@@ -150,8 +152,14 @@ def test_moved_vs_dropped_distinguished_across_files(tmp_path):
     assert moved[0]["after_size"] == 2
     assert summary["Disease.txt"]["dropped_member_count"] == 0
     assert summary["Disease.txt"]["moved_member_count"] == 1
+    assert summary["Disease.txt"]["moved_in_member_count"] == 0  # Disease received nothing
     # clique_count is nested with a before/after/diff/diff_percent breakdown.
     assert summary["Disease.txt"]["clique_count"] == {"before": 1, "after": 1, "diff": 0, "diff_percent": 0.0}
+    # The receiving compendium has no *changed* before-clique (HP:2 is a wholly new clique), so
+    # every before-clique-centric stat is zero there; only moved_in_* reveals the gained clique.
+    assert summary["PhenotypicFeature.txt"]["changed_before_cliques"] == 0
+    assert summary["PhenotypicFeature.txt"]["moved_in_member_count"] == 1
+    assert summary["PhenotypicFeature.txt"]["moved_in_clique_count"] == 1
 
 
 @pytest.mark.unit
@@ -179,6 +187,9 @@ def test_moved_members_landing_in_different_cliques_get_a_row_each(tmp_path):
     assert sorted(r["destination"] for r in moved) == ["HP:5", "MP:7"]
     assert all(r["member_count"] == 1 for r in moved)
     assert summary["Disease.txt"]["moved_member_count"] == 2
+    # Both landed in PhenotypicFeature as two distinct new cliques.
+    assert summary["PhenotypicFeature.txt"]["moved_in_member_count"] == 2
+    assert summary["PhenotypicFeature.txt"]["moved_in_clique_count"] == 2
 
 
 @pytest.mark.unit

--- a/tools/clique_diff/diff.py
+++ b/tools/clique_diff/diff.py
@@ -48,13 +48,20 @@ Output:
   reader never has to guess which build was before vs after or what the diff isolates.
   ``compendia`` maps each filename to its counts: a nested ``clique_count``
   (``before``/``after``/``diff``/``diff_percent``) plus ``changed_before_cliques``,
-  ``dropped_member_count`` (the headline regression signal), ``moved_member_count``,
+  ``dropped_member_count`` (the headline regression signal), ``moved_member_count`` (members that
+  left *this* compendium, re-typed into another), ``moved_in_member_count`` and
+  ``moved_in_clique_count`` (the mirror image: members that *arrived* here from another
+  compendium's cliques, and how many distinct after-cliques here received them),
   ``regrouped_member_count``, and ``leader_changed_count``. ``diff_percent`` is ``null`` when
   the before build had no cliques at all but the after build has some — the percentage is
-  undefined there, and reporting ``0.0`` would read as "nothing changed". NOTE: a clique that exists only in
-  the after build (no before counterpart — e.g. a wholly new MP-only clique) is not a change
-  row, since the diff iterates before-cliques; such additions surface only as a positive
-  ``clique_count.diff``, which is why a build adding thousands of cliques can show few rows.
+  undefined there, and reporting ``0.0`` would read as "nothing changed". The
+  ``moved_in_*`` fields exist because every other stat is before-clique-centric, so a compendium
+  that only *receives* retyped members (e.g. a disease clique shedding a phenotype group that
+  becomes a new ``PhenotypicFeature`` clique) would otherwise look untouched — its gained cliques
+  show up only as a positive ``clique_count.diff`` and as ``moved`` rows filed under the *source*
+  compendium. NOTE: a clique that exists only in the after build with *no* before member anywhere
+  in the compared files (e.g. a wholly new MP-only clique) is still not a change row, since the
+  diff iterates before-cliques; such additions surface only as a positive ``clique_count.diff``.
 """
 
 import argparse
@@ -280,6 +287,16 @@ def diff_builds(before_dir, after_dir, filenames):
             "regrouped_member_count": sum(r["member_count"] for r in records if r["destination_kind"] == "regrouped"),
             "leader_changed_count": sum(1 for r in records if r["destination_kind"] == "leader_changed"),
         }
+
+    # Second pass for the incoming side of moves. A `moved` row is filed under its *source*
+    # compendium (the before-clique's file), so a receiving compendium's own before-clique-centric
+    # stats never see it. Computed here, after `rows` is complete, because a moved row's
+    # destination file may have been summarised before its source file was processed.
+    for fname in summary:
+        incoming = [r for r in rows if r["destination_kind"] == "moved" and r["destination_compendium"] == fname]
+        summary[fname]["moved_in_member_count"] = sum(r["member_count"] for r in incoming)
+        summary[fname]["moved_in_clique_count"] = len({r["destination"] for r in incoming})
+
     return rows, summary
 
 
@@ -357,7 +374,8 @@ def main(argv=None):
     for fname, s in sorted(summary.items()):
         print(
             f"  {fname}: {s['changed_before_cliques']} changed cliques, "
-            f"{s['dropped_member_count']} dropped members, {s['moved_member_count']} moved"
+            f"{s['dropped_member_count']} dropped members, {s['moved_member_count']} moved out, "
+            f"{s['moved_in_clique_count']} cliques gained from moves in"
         )
     print(f"Total members dropped from the compared compendia: {total_dropped}")
 


### PR DESCRIPTION
## What

`babel-clique-diff`'s per-compendium summary is entirely **before-clique-centric**, so a `moved`
row — a member that left one compendium and re-typed into another — is recorded only under its
**source** compendium. A compendium that *only receives* retyped members therefore looks untouched
in its own stats, and its gained cliques show up merely as a positive `clique_count.diff` that is
easy to read as noise.

This bit us on the MONDO close-match guard diff (#888): activating the guard split 14 disease
cliques and pushed a phenotype group out of each into a brand-new `PhenotypicFeature.txt` clique.
The tool reported `PhenotypicFeature.txt: changed_before_cliques: 1` — which read as "essentially
unaffected" — even though the diff had, correctly, recorded all 14 as `moved` rows under
`Disease.txt` (with `destination_compendium == PhenotypicFeature.txt`). The data was complete; the
summary just never surfaced the receiving end.

## Change

Adds two fields per compendium to the summary JSON:

- `moved_in_member_count` — members that arrived here from another compendium's before-cliques.
- `moved_in_clique_count` — how many distinct after-cliques here received them.

They're computed after the row pass (a moved row's destination file may be summarised before its
source file). The console output now ends each compendium line with `N cliques gained from moves
in`. On the #888 build this flips the misleading `PhenotypicFeature.txt: 1 changed clique` into:

```
PhenotypicFeature.txt: 1 changed cliques, 0 dropped members, 2 moved out, 14 cliques gained from moves in
```

No change to the CSV or to how rows are classified — the `moved` rows already named every
destination clique; this only makes the receiving compendium's summary reflect them.

## Scope note

This does **not** enumerate genuinely-new after-cliques whose members had no before presence
anywhere in the compared files (e.g. a wholly new MP-only clique) — those remain visible only as a
positive `clique_count.diff`, as before. Every cross-compendium retype *is* reachable through a
`moved` row, which is the gap this closes.

## Tests

Extends the two "moved across files" tests in `tests/tools/test_clique_diff_tool.py` to assert the
receiving compendium's `moved_in_member_count` / `moved_in_clique_count` (and that a
before-clique-centric `changed_before_cliques` stays 0 there). Docstring and
`docs/tools/README.md` updated.

- `uv run pytest tests/tools/test_clique_diff_tool.py tests/test_clique_diff.py -q` — 20 passed
- `uv run ruff check` / `ruff format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
