### PR TITLE
Let a new run reuse the PubMed downloads, and stop --continue corrupting recursive wget fetches

### DIFF
--- a/docs/RunningBabel.md
+++ b/docs/RunningBabel.md
@@ -73,6 +73,47 @@ If you only need the intermediates for a single semantic type (for example, to g
 source-impact report — see [AddingNewSources.md](./AddingNewSources.md)), building just that
 target is much cheaper than `snakemake --cores N` with no target.
 
+### Preloading PubMed downloads
+
+PubMed is the largest download in the pipeline (~1,500 gzipped XML files across `baseline/` and
+`updatefiles/`), and almost all of it is unchanged between runs. You can carry it forward into a
+new run's download directory:
+
+```shell
+mkdir -p <new-run>/babel_downloads/PubMed
+mv <old-run>/babel_downloads/PubMed/baseline    <new-run>/babel_downloads/PubMed/
+mv <old-run>/babel_downloads/PubMed/updatefiles <new-run>/babel_downloads/PubMed/
+rm -f <new-run>/babel_downloads/PubMed/{baseline,updatefiles}/*.md5
+```
+
+Three things make this work, and each is easy to break:
+
+* **Do not copy the `downloaded` or `verified` marker files.** Those are what Snakemake tracks; if
+  they are present it skips the download and verification rules entirely, and you never pick up the
+  new updatefiles.
+* **Preserve modification times.** `mv` (or `cp -p` / `rsync -a`) preserves them; a plain `cp` does
+  not. `download_pubmed` runs `wget --timestamping`, which re-downloads a file only when the
+  server's copy is newer than the local one or the sizes differ. With mtimes intact, a file PubMed
+  has since revised is correctly re-fetched.
+* **Delete the `.md5` files rather than carrying them over.** They are a few kilobytes each and cost
+  nothing to re-download, and fetching them fresh means `verify_pubmed` checks every carried-over
+  `.gz` against a checksum that came from NCBI in *this* run. Carrying over a stale `.gz`/`.md5`
+  pair, which is self-consistent, would let a superseded file pass verification.
+
+`verify_pubmed` then MD5s every `.gz` in both directories — the carried-over files included — and
+re-downloads any that fail, so a corrupt or truncated file from the previous run heals itself.
+Checksumming the full corpus takes a few minutes; it happens on every run regardless.
+
+A recursive, timestamped download never passes `--continue` to wget (`pull_via_wget()` drops it):
+wget resumes by *appending* the bytes it thinks are missing to whatever local file it finds, which
+silently corrupts a file whose content changed upstream rather than merely being truncated. Any file
+that disagrees with the server on size or mtime is therefore re-fetched in full, at the cost of
+restarting — rather than resuming — a large file whose download was interrupted.
+
+The `baseline/` and `updatefiles/` directories are deliberately *not* declared as `directory()`
+outputs of `download_pubmed`. Snakemake recursively deletes existing `directory()` outputs before
+running a job, which would delete anything preloaded into them.
+
 ### Common build issues
 
 * **Stale Snakemake lock.** If a previous run was killed (Ctrl-C, OOM, power loss) Snakemake

--- a/docs/RunningBabel.md
+++ b/docs/RunningBabel.md
@@ -83,10 +83,11 @@ new run's download directory:
 mkdir -p <new-run>/babel_downloads/PubMed
 mv <old-run>/babel_downloads/PubMed/baseline    <new-run>/babel_downloads/PubMed/
 mv <old-run>/babel_downloads/PubMed/updatefiles <new-run>/babel_downloads/PubMed/
-rm -f <new-run>/babel_downloads/PubMed/{baseline,updatefiles}/*.md5
+rm -f <new-run>/babel_downloads/PubMed/baseline/*.md5 \
+      <new-run>/babel_downloads/PubMed/updatefiles/*.md5
 ```
 
-Three things make this work, and each is easy to break:
+Two things make this work, and each is easy to break:
 
 * **Do not copy the `downloaded` or `verified` marker files.** Those are what Snakemake tracks; if
   they are present it skips the download and verification rules entirely, and you never pick up the
@@ -95,10 +96,13 @@ Three things make this work, and each is easy to break:
   not. `download_pubmed` runs `wget --timestamping`, which re-downloads a file only when the
   server's copy is newer than the local one or the sizes differ. With mtimes intact, a file PubMed
   has since revised is correctly re-fetched.
-* **Delete the `.md5` files rather than carrying them over.** They are a few kilobytes each and cost
-  nothing to re-download, and fetching them fresh means `verify_pubmed` checks every carried-over
-  `.gz` against a checksum that came from NCBI in *this* run. Carrying over a stale `.gz`/`.md5`
-  pair, which is self-consistent, would let a superseded file pass verification.
+
+Deleting the `.md5` files, as above, isn't strictly necessary: PubMed republishes a file's `.md5`
+whenever it revises the `.gz`, so with mtimes intact `--timestamping` re-fetches the checksum along
+with the file, and a stale-but-self-consistent `.gz`/`.md5` pair can't survive the download. It is
+cheap insurance against a preload that lost its mtimes — the `.md5` files are a few kilobytes each —
+so drop them and let `verify_pubmed` check every carried-over `.gz` against a checksum fetched in
+*this* run.
 
 `verify_pubmed` then MD5s every `.gz` in both directories — the carried-over files included — and
 re-downloads any that fail, so a corrupt or truncated file from the previous run heals itself.

--- a/docs/RunningBabel.md
+++ b/docs/RunningBabel.md
@@ -108,10 +108,11 @@ so drop them and let `verify_pubmed` check every carried-over `.gz` against a ch
 re-downloads any that fail, so a corrupt or truncated file from the previous run heals itself.
 Checksumming the full corpus takes a few minutes; it happens on every run regardless.
 
-A recursive, timestamped download never passes `--continue` to wget (`pull_via_wget()` drops it):
-wget resumes by *appending* the bytes it thinks are missing to whatever local file it finds, which
-silently corrupts a file whose content changed upstream rather than merely being truncated. Any file
-that disagrees with the server on size or mtime is therefore re-fetched in full, at the cost of
+A recursive download is always timestamped and never resumed: `pull_via_wget()` raises if a caller
+asks for `--continue` alongside recursion, or for recursion without `--timestamping`. wget resumes
+by *appending* the bytes it thinks are missing to whatever local file it finds, which silently
+corrupts a file whose content changed upstream rather than merely being truncated. Any file that
+disagrees with the server on size or mtime is therefore re-fetched in full, at the cost of
 restarting — rather than resuming — a large file whose download was interrupted.
 
 The `baseline/` and `updatefiles/` directories are deliberately *not* declared as `directory()`

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -419,8 +419,10 @@ def pull_via_wget(
     :param decompress: Whether this is a Gzip file that should be decompressed after download.
     :param subpath: The subdirectory of `babel_download` where this file should be stored.
     :param outpath: The full output directory to write this file to. Both subpath and outpath cannot be set at the same time.
-    :param continue_incomplete: Should wget continue an incomplete download? Ignored (forced off) in a
-        recursive download with timestamping, where resuming can corrupt a file that changed upstream.
+    :param continue_incomplete: Should wget continue an incomplete download? Must be False in a recursive
+        download, where resuming can corrupt a file whose content changed upstream; we raise if it isn't.
+    :param timestamping: Should wget re-fetch a file only when the server's copy is newer, or differs in
+        size, from ours? Must be True in a recursive download; we raise if it isn't.
     :param recurse: Do we want to download recursively? Should be from WgetRecursionOptions, such as WgetRecursionOptions.NO_RECURSION.
     :param retries: The number of retries to attempt.
     :param verify_gzip: If downloading a Gzip file that isn't being decompressed, verify that the
@@ -441,23 +443,29 @@ def pull_via_wget(
 
     ensure_parent_dir(dl_file_name)
 
-    # --continue resumes a download by appending to whatever local file it finds, which only makes
-    # sense if that file is a truncated prefix of the server's copy. In a recursive, timestamped
-    # download it may instead meet a file whose *content* has changed upstream (or one carried over
-    # from a previous run), and appending the tail of the new file to the old one silently produces
-    # a corrupt result. --timestamping already re-fetches, in full, any file whose size or mtime
-    # disagrees with the server's, so it makes --continue both unnecessary and unsafe here.
+    # A recursive download is always timestamped and never continued. --continue resumes by
+    # appending to whatever local file it finds, which is only correct if that file is a truncated
+    # prefix of the server's copy; recursing, we may instead meet a file whose *content* changed
+    # upstream (or one carried over from a previous run), and appending the tail of the new file to
+    # the old one silently produces a corrupt result. --timestamping is what re-fetches such a file,
+    # in full — and it is also what stops wget saving a second copy as `file.1` when the file is
+    # already there, which is the job --continue would otherwise be doing.
     #
-    # We only drop it when --timestamping is also on, even though the hazard is really "any
-    # recursive download": without -N, --continue is also what stops wget writing a second copy as
-    # `file.1` when a file is already present, so dropping it there would trade corruption for
-    # duplicates. Every recursive caller today passes timestamping=True; if you add a recursive
-    # caller without it, work out which of those two you want before relying on this. (In a
-    # non-recursive download we pass -O, which makes wget ignore --timestamping entirely, so
-    # --continue remains the only resume mechanism and is kept.)
-    if continue_incomplete and timestamping and recurse != WgetRecursionOptions.NO_RECURSION:
-        logger.info(f"Disabling --continue for recursive, timestamped download of {url}: see pull_via_wget().")
-        continue_incomplete = False
+    # (Non-recursive downloads pass -O, which makes wget ignore --timestamping entirely, so there
+    # --continue is the only resume mechanism and is kept.)
+    if recurse != WgetRecursionOptions.NO_RECURSION:
+        if continue_incomplete:
+            raise ValueError(
+                f"pull_via_wget({url}) cannot combine continue_incomplete=True with recursion: resuming a "
+                f"recursive download can corrupt a file whose content changed upstream. Pass "
+                f"continue_incomplete=False."
+            )
+        if not timestamping:
+            raise ValueError(
+                f"pull_via_wget({url}) cannot disable timestamping in a recursive download: without "
+                f"--timestamping, and with --continue unavailable, wget saves a second copy of every "
+                f"file we already have as `file.1`."
+            )
 
     # Prepare wget options.
     wget_command_line = [

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -421,7 +421,7 @@ def pull_via_wget(
     :param outpath: The full output directory to write this file to. Both subpath and outpath cannot be set at the same time.
     :param continue_incomplete: Should wget continue an incomplete download? Ignored (forced off) in a
         recursive download with timestamping, where resuming can corrupt a file that changed upstream.
-    :param recurse: Do we want to download recursively? Should be from Wget_Recursion_Options, such as Wget_Recursion_Options.NO_RECURSION.
+    :param recurse: Do we want to download recursively? Should be from WgetRecursionOptions, such as WgetRecursionOptions.NO_RECURSION.
     :param retries: The number of retries to attempt.
     :param verify_gzip: If downloading a Gzip file that isn't being decompressed, verify that the
         file is valid (by reading it entirely). Has no effect if decompress=True.

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -419,7 +419,8 @@ def pull_via_wget(
     :param decompress: Whether this is a Gzip file that should be decompressed after download.
     :param subpath: The subdirectory of `babel_download` where this file should be stored.
     :param outpath: The full output directory to write this file to. Both subpath and outpath cannot be set at the same time.
-    :param continue_incomplete: Should wget continue an incomplete download?
+    :param continue_incomplete: Should wget continue an incomplete download? Ignored (forced off) in a
+        recursive download with timestamping, where resuming can corrupt a file that changed upstream.
     :param recurse: Do we want to download recursively? Should be from Wget_Recursion_Options, such as Wget_Recursion_Options.NO_RECURSION.
     :param retries: The number of retries to attempt.
     :param verify_gzip: If downloading a Gzip file that isn't being decompressed, verify that the
@@ -439,6 +440,18 @@ def pull_via_wget(
         dl_file_name = os.path.join(download_dir, in_file_name)
 
     ensure_parent_dir(dl_file_name)
+
+    # --continue resumes a download by appending to whatever local file it finds, which only makes
+    # sense if that file is a truncated prefix of the server's copy. In a recursive, timestamped
+    # download it may instead meet a file whose *content* has changed upstream (or one carried over
+    # from a previous run), and appending the tail of the new file to the old one silently produces
+    # a corrupt result. --timestamping already re-fetches, in full, any file whose size or mtime
+    # disagrees with the server's, so it makes --continue both unnecessary and unsafe here. (In a
+    # non-recursive download we pass -O, which makes wget ignore --timestamping entirely, so
+    # --continue remains the only resume mechanism and is kept.)
+    if continue_incomplete and timestamping and recurse != WgetRecursionOptions.NO_RECURSION:
+        logger.info(f"Disabling --continue for recursive, timestamped download of {url}: see pull_via_wget().")
+        continue_incomplete = False
 
     # Prepare wget options.
     wget_command_line = [

--- a/src/babel_utils.py
+++ b/src/babel_utils.py
@@ -446,7 +446,13 @@ def pull_via_wget(
     # download it may instead meet a file whose *content* has changed upstream (or one carried over
     # from a previous run), and appending the tail of the new file to the old one silently produces
     # a corrupt result. --timestamping already re-fetches, in full, any file whose size or mtime
-    # disagrees with the server's, so it makes --continue both unnecessary and unsafe here. (In a
+    # disagrees with the server's, so it makes --continue both unnecessary and unsafe here.
+    #
+    # We only drop it when --timestamping is also on, even though the hazard is really "any
+    # recursive download": without -N, --continue is also what stops wget writing a second copy as
+    # `file.1` when a file is already present, so dropping it there would trade corruption for
+    # duplicates. Every recursive caller today passes timestamping=True; if you add a recursive
+    # caller without it, work out which of those two you want before relying on this. (In a
     # non-recursive download we pass -O, which makes wget ignore --timestamping entirely, so
     # --continue remains the only resume mechanism and is kept.)
     if continue_incomplete and timestamping and recurse != WgetRecursionOptions.NO_RECURSION:

--- a/src/createcompendia/publications.py
+++ b/src/createcompendia/publications.py
@@ -17,10 +17,15 @@ from src.util import ensure_parent_dir, get_logger
 
 logger = get_logger(__name__)
 
+# The same PubMed corpus, reachable two ways. We need both: NCBI's robots.txt
+# (https://ftp.ncbi.nlm.nih.gov/robots.txt) blocks a recursive HTTPS download, so the bulk fetch has
+# to go over FTP — but FTP is the less reliable of the two, so the single-file re-downloads that
+# repair a failed checksum use HTTPS.
+PUBMED_FTP_BASE = "ftp://ftp.ncbi.nlm.nih.gov/pubmed/"
+PUBMED_HTTPS_BASE = "https://ftp.ncbi.nlm.nih.gov/pubmed/"
 
-def download_pubmed(
-    download_file, pubmed_base="ftp://ftp.ncbi.nlm.nih.gov/pubmed/", pmc_base="https://ftp.ncbi.nlm.nih.gov/pub/pmc/"
-):
+
+def download_pubmed(download_file, pubmed_base=PUBMED_FTP_BASE, pmc_base="https://ftp.ncbi.nlm.nih.gov/pub/pmc/"):
     """
     Download PubMed. We download both the PubMed annual baseline and the daily update files,
     which are in the same format, but the baseline is set up at the start of the year and then
@@ -109,7 +114,7 @@ def verify_pubmed_download_against_md5(pubmed_filename, md5_filename):
     return False
 
 
-def verify_pubmed_downloads(pubmed_directories, done_filename, pubmed_base="https://ftp.ncbi.nlm.nih.gov/pubmed/"):
+def verify_pubmed_downloads(pubmed_directories, done_filename, pubmed_base=PUBMED_HTTPS_BASE):
     """
     download_pubmed() does a good job of downloading all the PubMed files, but every once in a while the download
     is corrupted (https://github.com/NCATSTranslator/Babel/issues/352). Luckily, PubMed also gives up `.md5` files
@@ -282,8 +287,8 @@ def parse_pubmed_into_tsvs(
         name="parse_pubmed_into_tsvs()",
         description="Parse PubMed files into TSVs and JSONL status files.",
         sources=[
-            {"type": "download", "name": "PubMed Baseline", "url": "ftp://ftp.ncbi.nlm.nih.gov/pubmed/baseline/"},
-            {"type": "download", "name": "PubMed Updates", "url": "ftp://ftp.ncbi.nlm.nih.gov/pubmed/updatefiles/"},
+            {"type": "download", "name": "PubMed Baseline", "url": f"{PUBMED_FTP_BASE}baseline/"},
+            {"type": "download", "name": "PubMed Updates", "url": f"{PUBMED_FTP_BASE}updatefiles/"},
         ],
         counts={
             "pmid_count": len(pmid_status.keys()),

--- a/src/createcompendia/publications.py
+++ b/src/createcompendia/publications.py
@@ -1,7 +1,6 @@
 import gzip
 import hashlib
 import json
-import logging
 import os
 import time
 import xml.etree.ElementTree as ET
@@ -80,7 +79,7 @@ def verify_pubmed_download_against_md5(pubmed_filename, md5_filename):
 
     # Is the PubMed file readable? Non-zero size?
     if not os.path.exists(pubmed_filename) or os.path.getsize(pubmed_filename) == 0:
-        logging.warning(f"Could not verify {pubmed_filename}: no such file or zero size.")
+        logger.warning(f"Could not verify {pubmed_filename}: no such file or zero size.")
         return False
 
     # Calculate the MD5 sum of the PubMed file.
@@ -89,7 +88,7 @@ def verify_pubmed_download_against_md5(pubmed_filename, md5_filename):
 
     # Read the expected MD5 checksum.
     if not os.path.exists(md5_filename):
-        logging.warning(f"Could not verify {pubmed_filename}: no MD5 file found at {md5_filename}.")
+        logger.warning(f"Could not verify {pubmed_filename}: no MD5 file found at {md5_filename}.")
         return False
 
     with open(md5_filename) as md5f:
@@ -102,7 +101,7 @@ def verify_pubmed_download_against_md5(pubmed_filename, md5_filename):
 
     if md5hash == expected_md5:
         return True
-    logging.warning(
+    logger.warning(
         f"Could not verify {pubmed_filename}: calculated MD5 hash {md5hash} is not equal to expected MD5 hash {expected_md5} in {md5_filename}."
     )
     return False
@@ -122,6 +121,15 @@ def verify_pubmed_downloads(pubmed_directories, done_filename, pubmed_base="http
     """
 
     for pubmed_directory in pubmed_directories:
+        # These directories aren't Snakemake outputs (see the comment on rule download_pubmed), so
+        # Snakemake won't rebuild them if they go missing: say what to do instead of dying in
+        # os.listdir() with a bare FileNotFoundError.
+        if not os.path.isdir(pubmed_directory):
+            raise RuntimeError(
+                f"PubMed download directory {pubmed_directory} does not exist: delete the "
+                f"'downloaded' marker file beside it to re-run download_pubmed."
+            )
+
         for filename in os.listdir(pubmed_directory):
             file_path = os.path.join(pubmed_directory, filename)
             subdir = os.path.basename(pubmed_directory)
@@ -132,7 +140,7 @@ def verify_pubmed_downloads(pubmed_directories, done_filename, pubmed_base="http
 
                 while not verify_pubmed_download_against_md5(file_path, file_path + ".md5"):
                     pubmed_url_base = pubmed_base + subdir + "/"
-                    logging.warning(f"Re-downloading {file_path} from HTTPS URL {pubmed_url_base}{filename}.")
+                    logger.warning(f"Re-downloading {file_path} from HTTPS URL {pubmed_url_base}{filename}.")
 
                     # We should delete the files before redownloading them, but if we did that and the download
                     # failed, we would not retry the download again. So instead, we truncate both files -- this
@@ -185,11 +193,11 @@ def parse_pubmed_into_tsvs(
 
         for pubmed_filename in baseline_filenames + updatefiles_filenames:
             if not pubmed_filename.endswith(".xml.gz"):
-                logging.warning(f"Skipping non-gzipped-XML file {pubmed_filename} in PubMed files.")
+                logger.warning(f"Skipping non-gzipped-XML file {pubmed_filename} in PubMed files.")
                 continue
 
             with gzip.open(pubmed_filename, "rt") as pubmedf:
-                logging.info(f"Parsing PubMed Baseline {pubmed_filename}")
+                logger.info(f"Parsing PubMed Baseline {pubmed_filename}")
 
                 start_time = time.time_ns()
                 count_articles = 0
@@ -254,7 +262,7 @@ def parse_pubmed_into_tsvs(
                                     concordf.write(f"{PMID}:{pmid.text}\teq\t{PMC}:{pmc.text}\n")
 
                 time_taken_in_seconds = float(time.time_ns() - start_time) / 1_000_000_000
-                logging.info(
+                logger.info(
                     f"Parsed {count_articles} articles from PubMed {pubmed_filename} in "
                     + f"{time_taken_in_seconds:.4f} seconds: {count_pmids} PMIDs, {count_dois} DOIs, "
                     + f"{count_pmcs} PMCs, "
@@ -324,7 +332,7 @@ def generate_compendium(concordances, metadata_yamls, identifiers, titles, publi
                 if id in labels:
                     # Don't emit a warning unless the title has actually changed.
                     if labels[id] != title:
-                        logging.warning(
+                        logger.warning(
                             f"Duplicate title for {id}: ignoring previous title '{labels[id]}', using new title '{title}'."
                         )
                 labels[id] = title

--- a/src/createcompendia/publications.py
+++ b/src/createcompendia/publications.py
@@ -48,7 +48,9 @@ def download_pubmed(
             decompress=False,
             subpath="PubMed",
             recurse=WgetRecursionOptions.RECURSE_SUBFOLDERS,
+            # A recursive download must be timestamped and must not resume: see pull_via_wget().
             timestamping=True,
+            continue_incomplete=False,
         )
 
     with ThreadPoolExecutor(max_workers=len(subdirs)) as pool:

--- a/src/snakefiles/publications.snakefile
+++ b/src/snakefiles/publications.snakefile
@@ -13,10 +13,13 @@ localrules:
 ### PubMed
 
 
+# The baseline/ and updatefiles/ directories are deliberately NOT declared as directory() outputs:
+# Snakemake recursively deletes existing directory() outputs before running a job, which would wipe
+# any PubMed files preloaded from a previous run. Keeping them undeclared lets wget --timestamping
+# skip files we already have (see docs/RunningBabel.md, "Preloading PubMed downloads"). The done
+# marker is what the downstream rules depend on.
 rule download_pubmed:
     output:
-        baseline_dir=directory(config["download_directory"] + "/PubMed/baseline"),
-        updatefiles_dir=directory(config["download_directory"] + "/PubMed/updatefiles"),
         done_file=config["download_directory"] + "/PubMed/downloaded",
     benchmark:
         config["output_directory"] + "/benchmarks/download_pubmed.tsv"
@@ -50,8 +53,6 @@ rule verify_pubmed:
 rule generate_pubmed_concords:
     input:
         config["download_directory"] + "/PubMed/verified",
-        baseline_dir=config["download_directory"] + "/PubMed/baseline",
-        updatefiles_dir=config["download_directory"] + "/PubMed/updatefiles",
     output:
         titles_file=config["download_directory"] + "/PubMed/titles.tsv",
         status_file=config["download_directory"] + "/PubMed/statuses.jsonl.gz",
@@ -63,10 +64,14 @@ rule generate_pubmed_concords:
     resources:
         runtime="24h",
         mem="128G",
+    params:
+        # Not inputs: see the comment on download_pubmed for why these directories are untracked.
+        baseline_dir=config["download_directory"] + "/PubMed/baseline",
+        updatefiles_dir=config["download_directory"] + "/PubMed/updatefiles",
     run:
         publications.parse_pubmed_into_tsvs(
-            input.baseline_dir,
-            input.updatefiles_dir,
+            params.baseline_dir,
+            params.updatefiles_dir,
             output.titles_file,
             output.status_file,
             output.pmid_id_file,

--- a/tests/babel_utils/test_pull_via_wget.py
+++ b/tests/babel_utils/test_pull_via_wget.py
@@ -58,6 +58,7 @@ def test_recursive_wget_downloads_every_file_into_an_empty_directory(http_server
         decompress=False,
         outpath=str(local_dir),
         recurse=WgetRecursionOptions.RECURSE_DIRECTORY_ONLY,
+        continue_incomplete=False,
     )
 
     assert (local_dir / "one.txt").read_text() == "one"
@@ -91,6 +92,7 @@ def test_recursive_wget_keeps_preloaded_files_and_downloads_only_the_new_ones(ht
         decompress=False,
         outpath=str(local_dir),
         recurse=WgetRecursionOptions.RECURSE_DIRECTORY_ONLY,
+        continue_incomplete=False,
     )
 
     # The preloaded file was not re-downloaded: its (distinguishable) local content survives.
@@ -107,8 +109,8 @@ def test_recursive_wget_redownloads_a_stale_preloaded_file_rather_than_resuming_
 
     This is the regression test for --continue: wget resumes by appending the bytes it is missing
     to the local file, so with --continue this download produced "old local contentt" — the stale
-    content plus the one-byte tail of the new file. pull_via_wget() now drops --continue for
-    recursive, timestamped downloads."""
+    content plus the one-byte tail of the new file. pull_via_wget() now refuses --continue in a
+    recursive download; this test proves the resulting fetch is a clean, whole-file one."""
     base_url, remote_dir = http_server
     (remote_dir / "files" / "revised.txt").write_text("new remote content")
 
@@ -127,6 +129,43 @@ def test_recursive_wget_redownloads_a_stale_preloaded_file_rather_than_resuming_
         decompress=False,
         outpath=str(local_dir),
         recurse=WgetRecursionOptions.RECURSE_DIRECTORY_ONLY,
+        continue_incomplete=False,
     )
 
     assert revised.read_text() == "new remote content"
+
+
+# UNSAFE OPTION COMBINATIONS
+#
+# These guards fire before wget is invoked, so these tests need neither the server nor the binary.
+
+
+@pytest.mark.unit
+def test_a_recursive_download_that_asks_to_continue_is_refused(tmp_path):
+    """Recursion plus --continue is the combination that corrupts a file changed upstream, so
+    pull_via_wget() should refuse it rather than quietly downloading with one of them dropped.
+    continue_incomplete defaults to True, so a recursive caller has to say otherwise."""
+    with pytest.raises(ValueError, match="cannot combine continue_incomplete=True with recursion"):
+        pull_via_wget(
+            "http://127.0.0.1:1/",
+            "files",
+            decompress=False,
+            outpath=str(tmp_path / "local"),
+            recurse=WgetRecursionOptions.RECURSE_DIRECTORY_ONLY,
+        )
+
+
+@pytest.mark.unit
+def test_a_recursive_download_without_timestamping_is_refused(tmp_path):
+    """With --continue refused, --timestamping is the only thing keeping wget from saving a second
+    copy of every file we already have as `file.1`, so a recursive download requires it."""
+    with pytest.raises(ValueError, match="cannot disable timestamping in a recursive download"):
+        pull_via_wget(
+            "http://127.0.0.1:1/",
+            "files",
+            decompress=False,
+            outpath=str(tmp_path / "local"),
+            recurse=WgetRecursionOptions.RECURSE_DIRECTORY_ONLY,
+            continue_incomplete=False,
+            timestamping=False,
+        )

--- a/tests/babel_utils/test_pull_via_wget.py
+++ b/tests/babel_utils/test_pull_via_wget.py
@@ -1,0 +1,132 @@
+"""Unit tests for pull_via_wget()'s recursive, timestamping download.
+
+This is the mechanism that makes preloading PubMed downloads from a previous run work (see
+docs/RunningBabel.md, "Preloading PubMed downloads"): a recursive `wget --timestamping` fetch
+must leave already-present files alone and download only the ones we don't have yet.
+
+The tests run against a throwaway HTTP server on localhost, so they need no external network —
+but they do need the `wget` binary, and are skipped if it isn't installed.
+"""
+
+import functools
+import os
+import shutil
+import threading
+import time
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from src.babel_utils import WgetRecursionOptions, pull_via_wget
+
+requires_wget = pytest.mark.skipif(shutil.which("wget") is None, reason="wget is not installed")
+
+
+@pytest.fixture
+def http_server(tmp_path):
+    """Serve tmp_path/'remote' over HTTP on localhost; yields (base_url, remote_dir)."""
+    remote_dir = tmp_path / "remote"
+    (remote_dir / "files").mkdir(parents=True)
+
+    handler = functools.partial(SimpleHTTPRequestHandler, directory=str(remote_dir))
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}/", remote_dir
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+# PRELOADING
+
+
+@requires_wget
+@pytest.mark.unit
+def test_recursive_wget_downloads_every_file_into_an_empty_directory(http_server, tmp_path):
+    """A recursive download into an empty directory should fetch every file the server offers."""
+    base_url, remote_dir = http_server
+    (remote_dir / "files" / "one.txt").write_text("one")
+    (remote_dir / "files" / "two.txt").write_text("two")
+
+    local_dir = tmp_path / "local"
+    pull_via_wget(
+        base_url,
+        "files",
+        decompress=False,
+        outpath=str(local_dir),
+        recurse=WgetRecursionOptions.RECURSE_DIRECTORY_ONLY,
+    )
+
+    assert (local_dir / "one.txt").read_text() == "one"
+    assert (local_dir / "two.txt").read_text() == "two"
+
+
+@requires_wget
+@pytest.mark.unit
+def test_recursive_wget_keeps_preloaded_files_and_downloads_only_the_new_ones(http_server, tmp_path):
+    """A file we already have (same size, not older than the server's copy) should be left
+    untouched, while a file we don't have yet should be downloaded. This is what lets a new
+    Babel run reuse the PubMed files carried over from a previous run."""
+    base_url, remote_dir = http_server
+    (remote_dir / "files" / "preloaded.txt").write_text("REMOTE content")
+    (remote_dir / "files" / "new.txt").write_text("brand new")
+
+    # Backdate the server's copy so that our local copy is unambiguously the newer one, which is
+    # what wget --timestamping compares. Same byte count: wget re-downloads on a size mismatch.
+    old = time.time() - 3600
+    os.utime(remote_dir / "files" / "preloaded.txt", (old, old))
+
+    local_dir = tmp_path / "local"
+    local_dir.mkdir()
+    preloaded = local_dir / "preloaded.txt"
+    preloaded.write_text("LOCAL content!")
+    assert preloaded.stat().st_size == (remote_dir / "files" / "preloaded.txt").stat().st_size
+
+    pull_via_wget(
+        base_url,
+        "files",
+        decompress=False,
+        outpath=str(local_dir),
+        recurse=WgetRecursionOptions.RECURSE_DIRECTORY_ONLY,
+    )
+
+    # The preloaded file was not re-downloaded: its (distinguishable) local content survives.
+    assert preloaded.read_text() == "LOCAL content!"
+    # The file we didn't have was downloaded.
+    assert (local_dir / "new.txt").read_text() == "brand new"
+
+
+@requires_wget
+@pytest.mark.unit
+def test_recursive_wget_redownloads_a_stale_preloaded_file_rather_than_resuming_it(http_server, tmp_path):
+    """A preloaded file the server has since revised should be re-downloaded in full, so that
+    carrying files forward can't pin us to a superseded copy.
+
+    This is the regression test for --continue: wget resumes by appending the bytes it is missing
+    to the local file, so with --continue this download produced "old local contentt" — the stale
+    content plus the one-byte tail of the new file. pull_via_wget() now drops --continue for
+    recursive, timestamped downloads."""
+    base_url, remote_dir = http_server
+    (remote_dir / "files" / "revised.txt").write_text("new remote content")
+
+    local_dir = tmp_path / "local"
+    local_dir.mkdir()
+    revised = local_dir / "revised.txt"
+    revised.write_text("old local content")
+
+    # Preloaded with its original (older) mtime preserved, as `mv`/`cp -p`/`rsync -a` would.
+    old = time.time() - 3600
+    os.utime(revised, (old, old))
+
+    pull_via_wget(
+        base_url,
+        "files",
+        decompress=False,
+        outpath=str(local_dir),
+        recurse=WgetRecursionOptions.RECURSE_DIRECTORY_ONLY,
+    )
+
+    assert revised.read_text() == "new remote content"

--- a/tests/createcompendia/test_publications.py
+++ b/tests/createcompendia/test_publications.py
@@ -30,11 +30,16 @@ def baseline_dir(tmp_path):
 
 @pytest.fixture
 def no_downloads(monkeypatch):
-    """Fail loudly if verification tries to download anything, and record any attempt."""
+    """Fail loudly if verification tries to download anything, and record any attempt.
+
+    Raising, rather than merely recording, matters: verify_pubmed_downloads() re-downloads in a
+    `while not verified` loop, so a stub that returned without fixing the file would spin forever.
+    """
     attempts = []
 
     def _fail(url_prefix, in_file_name, **kwargs):
         attempts.append(in_file_name)
+        raise AssertionError(f"unexpected re-download of {in_file_name}")
 
     monkeypatch.setattr(publications, "pull_via_wget", _fail)
     return attempts

--- a/tests/createcompendia/test_publications.py
+++ b/tests/createcompendia/test_publications.py
@@ -1,0 +1,143 @@
+"""Unit tests for the PubMed download verification in src/createcompendia/publications.py.
+
+verify_pubmed_downloads() is the backstop that makes it safe to carry PubMed files forward from a
+previous run (see docs/RunningBabel.md, "Preloading PubMed downloads"): it MD5s every downloaded
+`.gz` against the `.md5` file PubMed publishes alongside it, and re-downloads the ones that fail.
+"""
+
+import hashlib
+
+import pytest
+
+import src.createcompendia.publications as publications
+
+
+def write_pubmed_file(directory, name, content=b"pubmed article data"):
+    """Write a fake PubMed download and the matching `.md5` file PubMed would publish for it."""
+    path = directory / name
+    path.write_bytes(content)
+    md5 = hashlib.md5(content).hexdigest()
+    (directory / f"{name}.md5").write_text(f"MD5({name})= {md5}\n")
+    return path
+
+
+@pytest.fixture
+def baseline_dir(tmp_path):
+    directory = tmp_path / "baseline"
+    directory.mkdir()
+    return directory
+
+
+@pytest.fixture
+def no_downloads(monkeypatch):
+    """Fail loudly if verification tries to download anything, and record any attempt."""
+    attempts = []
+
+    def _fail(url_prefix, in_file_name, **kwargs):
+        attempts.append(in_file_name)
+
+    monkeypatch.setattr(publications, "pull_via_wget", _fail)
+    return attempts
+
+
+# VERIFYING A SINGLE FILE AGAINST ITS MD5
+
+
+@pytest.mark.unit
+def test_file_matching_its_md5_verifies(baseline_dir):
+    """A file whose MD5 matches the published checksum should verify."""
+    path = write_pubmed_file(baseline_dir, "pubmed26n0001.xml.gz")
+    assert publications.verify_pubmed_download_against_md5(str(path), f"{path}.md5")
+
+
+@pytest.mark.unit
+def test_file_not_matching_its_md5_fails_verification(baseline_dir):
+    """A file whose content no longer matches its published checksum — a corrupt or truncated
+    download, or one carried over from a previous run and since revised — should fail."""
+    path = write_pubmed_file(baseline_dir, "pubmed26n0001.xml.gz")
+    path.write_bytes(b"corrupted data")
+    assert not publications.verify_pubmed_download_against_md5(str(path), f"{path}.md5")
+
+
+@pytest.mark.unit
+def test_missing_file_fails_verification(baseline_dir):
+    """A file that doesn't exist should fail verification rather than raising."""
+    write_pubmed_file(baseline_dir, "pubmed26n0001.xml.gz")
+    missing = baseline_dir / "pubmed26n0002.xml.gz"
+    assert not publications.verify_pubmed_download_against_md5(str(missing), f"{missing}.md5")
+
+
+@pytest.mark.unit
+def test_zero_length_file_fails_verification(baseline_dir):
+    """A zero-length file should fail verification: verify_pubmed_downloads() truncates a file it is
+    about to re-download, so an empty file means an earlier re-download attempt didn't finish."""
+    path = write_pubmed_file(baseline_dir, "pubmed26n0001.xml.gz")
+    path.write_bytes(b"")
+    assert not publications.verify_pubmed_download_against_md5(str(path), f"{path}.md5")
+
+
+@pytest.mark.unit
+def test_missing_md5_file_fails_verification(baseline_dir):
+    """A download with no `.md5` alongside it should fail verification, so that it is re-downloaded
+    together with its checksum rather than trusted unchecked."""
+    path = baseline_dir / "pubmed26n0001.xml.gz"
+    path.write_bytes(b"pubmed article data")
+    assert not publications.verify_pubmed_download_against_md5(str(path), f"{path}.md5")
+
+
+@pytest.mark.unit
+def test_unreadable_md5_file_raises(baseline_dir):
+    """An `.md5` file we can't parse is a format change upstream, not a bad download: raise rather
+    than re-downloading the file forever."""
+    path = write_pubmed_file(baseline_dir, "pubmed26n0001.xml.gz")
+    (baseline_dir / "pubmed26n0001.xml.gz.md5").write_text("MD5(pubmed26n0001.xml.gz)= deadbeef\n")
+    with pytest.raises(RuntimeError, match="could not read MD5 hash"):
+        publications.verify_pubmed_download_against_md5(str(path), f"{path}.md5")
+
+
+# VERIFYING A DIRECTORY OF DOWNLOADS
+
+
+@pytest.mark.unit
+def test_verifying_good_downloads_downloads_nothing_and_writes_the_done_file(baseline_dir, tmp_path, no_downloads):
+    """Files that all match their checksums — including ones preloaded from a previous run — should
+    be left alone, with nothing re-downloaded and the done marker written."""
+    write_pubmed_file(baseline_dir, "pubmed26n0001.xml.gz")
+    write_pubmed_file(baseline_dir, "pubmed26n0002.xml.gz")
+    done_file = tmp_path / "verified"
+
+    publications.verify_pubmed_downloads([str(baseline_dir)], str(done_file))
+
+    assert no_downloads == []
+    assert done_file.exists()
+
+
+@pytest.mark.unit
+def test_verifying_a_corrupt_download_redownloads_it_and_its_md5(baseline_dir, tmp_path, monkeypatch):
+    """A file that fails its checksum should be re-downloaded along with its `.md5`, and the local
+    copies truncated first so that an interrupted re-download can't leave a file that verifies."""
+    good = write_pubmed_file(baseline_dir, "pubmed26n0001.xml.gz")
+    corrupt = write_pubmed_file(baseline_dir, "pubmed26n0002.xml.gz")
+    corrupt.write_bytes(b"corrupted data")
+
+    downloaded = []
+
+    def fake_pull_via_wget(url_prefix, in_file_name, **kwargs):
+        # Both files are truncated before the re-download starts.
+        if not downloaded:
+            assert corrupt.stat().st_size == 0
+            assert (baseline_dir / "pubmed26n0002.xml.gz.md5").stat().st_size == 0
+        downloaded.append(in_file_name)
+        # Serve a correct copy, as PubMed would, so verification converges.
+        write_pubmed_file(baseline_dir, "pubmed26n0002.xml.gz")
+
+    monkeypatch.setattr(publications, "pull_via_wget", fake_pull_via_wget)
+
+    done_file = tmp_path / "verified"
+    publications.verify_pubmed_downloads([str(baseline_dir)], str(done_file))
+
+    assert downloaded == ["pubmed26n0002.xml.gz", "pubmed26n0002.xml.gz.md5"]
+    assert publications.verify_pubmed_download_against_md5(str(corrupt), f"{corrupt}.md5")
+    # The file that was fine was never touched.
+    assert good.read_bytes() == b"pubmed article data"
+    assert done_file.exists()

--- a/tests/pipeline/test_publications.py
+++ b/tests/pipeline/test_publications.py
@@ -9,10 +9,13 @@ server: the second download pass over the same directory must leave the already-
 alone.
 
 Everything is written into a temporary download/output directory, so the test never touches (or
-clobbers) a real babel_downloads/babel_outputs tree.
+clobbers) a real babel_downloads/babel_outputs tree. That makes it an outlier among the pipeline
+tests, which reuse (and cache into) babel_downloads/ — it is marked `pipeline` anyway because it
+runs the rule bodies of a whole target end to end and takes minutes, which is what that mark buys:
+the 3600s timeout rather than `network`'s 600s, and its own xdist worker under `-n auto`.
 
 Run with:
-    uv run pytest tests/pipeline/test_publications.py --pipeline --no-cov -v
+    uv run pytest tests/pipeline/test_publications.py --pipeline --network --no-cov -v
 """
 
 import json
@@ -32,9 +35,12 @@ from src.util import ensure_parent_dir
 
 pytestmark = [pytest.mark.pipeline, pytest.mark.network]
 
-# How many files to take from each of baseline/ and updatefiles/. Each is a few tens of MB; five of
-# each is enough to exercise the parse and the compendium build without downloading the ~50 GB corpus.
-FILES_PER_DIRECTORY = 5
+# How many files to take from each of baseline/ and updatefiles/, out of the ~1,500-file, ~50 GB
+# corpus. Every file has the same format, so two of each already exercises every code path; the
+# count only scales how many articles we push through them. It is worth keeping small: parsing the
+# XML, not downloading it, dominates the runtime (at 5 files each the test took 155s, of which 119s
+# was the parse and only 20s the download; at 2 each it takes 64s).
+FILES_PER_DIRECTORY = 2
 
 
 def list_pubmed_files(subdir):

--- a/tests/pipeline/test_publications.py
+++ b/tests/pipeline/test_publications.py
@@ -1,0 +1,210 @@
+"""PubMed pipeline test: a miniature end-to-end publications build.
+
+Downloads a handful of real PubMed baseline and update files, verifies them against their published
+MD5 checksums, parses them into titles/ids/concords, and builds a small Publication.txt compendium —
+i.e. every step the `publications` Snakemake target runs, at a size that fits in a test.
+
+It also exercises preloading (docs/RunningBabel.md, "Preloading PubMed downloads") against the real
+server: the second download pass over the same directory must leave the already-downloaded files
+alone.
+
+Everything is written into a temporary download/output directory, so the test never touches (or
+clobbers) a real babel_downloads/babel_outputs tree.
+
+Run with:
+    uv run pytest tests/pipeline/test_publications.py --pipeline --no-cov -v
+"""
+
+import json
+import os
+import re
+
+import pytest
+import requests
+
+import src.createcompendia.publications as publications
+import src.util
+from src.babel_utils import pull_via_wget
+from src.categories import PUBLICATION
+from src.prefixes import PMID
+from src.util import ensure_parent_dir
+
+pytestmark = [pytest.mark.pipeline, pytest.mark.network]
+
+PUBMED_BASE = "https://ftp.ncbi.nlm.nih.gov/pubmed/"
+
+# How many files to take from each of baseline/ and updatefiles/. Each is a few tens of MB; five of
+# each is enough to exercise the parse and the compendium build without downloading the ~50 GB corpus.
+FILES_PER_DIRECTORY = 5
+
+
+def list_pubmed_files(subdir):
+    """Return the sorted names of the .xml.gz files PubMed publishes in `subdir`."""
+    response = requests.get(f"{PUBMED_BASE}{subdir}/", timeout=60)
+    response.raise_for_status()
+    return sorted(set(re.findall(r'href="(pubmed\d+n\d+\.xml\.gz)"', response.text)))
+
+
+@pytest.fixture(scope="module")
+def pubmed_config(tmp_path_factory):
+    """Point Babel's download and output directories at a temporary tree for this module."""
+    tmp = tmp_path_factory.mktemp("pubmed")
+    config = dict(src.util.get_config())
+    config["download_directory"] = str(tmp / "babel_downloads")
+    config["output_directory"] = str(tmp / "babel_outputs")
+
+    # write_compendium()'s factories load the common (UberGraph) labels/synonyms/descriptions as a
+    # fallback for CURIEs that have none of their own. Publications have none, and building the real
+    # files means a large UberGraph download, so stand in empty ones to keep this test self-contained.
+    for common_files in config["common"].values():
+        for common_file in common_files:
+            path = os.path.join(config["download_directory"], "common", common_file)
+            ensure_parent_dir(path)
+            open(path, "w").close()
+
+    original = src.util.config_yaml
+    src.util.config_yaml = config
+    yield config
+    src.util.config_yaml = original
+
+
+@pytest.fixture(scope="module")
+def pubmed_downloads(pubmed_config):
+    """Download FILES_PER_DIRECTORY files (and their .md5s) from each of baseline/ and updatefiles/,
+    into the same <download_directory>/PubMed/<subdir> layout the pipeline uses."""
+    directories = {}
+    for subdir in ("baseline", "updatefiles"):
+        filenames = list_pubmed_files(subdir)[:FILES_PER_DIRECTORY]
+        assert len(filenames) == FILES_PER_DIRECTORY, f"PubMed {subdir}/ listed only {len(filenames)} files"
+
+        for filename in filenames:
+            for name in (filename, f"{filename}.md5"):
+                pull_via_wget(
+                    f"{PUBMED_BASE}{subdir}/",
+                    name,
+                    decompress=False,
+                    subpath=f"PubMed/{subdir}",
+                )
+
+        directories[subdir] = os.path.join(pubmed_config["download_directory"], "PubMed", subdir)
+
+    return directories
+
+
+# DOWNLOADING AND VERIFYING
+
+
+def test_downloaded_files_verify_against_their_published_md5s(pubmed_downloads, tmp_path):
+    """Freshly downloaded PubMed files should pass MD5 verification without anything being
+    re-downloaded, and the `verified` done-marker should be written."""
+    done_file = tmp_path / "verified"
+
+    publications.verify_pubmed_downloads(list(pubmed_downloads.values()), str(done_file))
+
+    assert done_file.exists()
+    for directory in pubmed_downloads.values():
+        for filename in os.listdir(directory):
+            if filename.endswith(".gz"):
+                path = os.path.join(directory, filename)
+                assert publications.verify_pubmed_download_against_md5(path, f"{path}.md5")
+
+
+def test_redownloading_leaves_the_already_downloaded_files_alone(pubmed_downloads):
+    """Downloading again over a directory we've already filled should leave every file untouched —
+    this is what makes carrying PubMed files forward into a new run cheap."""
+    baseline = pubmed_downloads["baseline"]
+    before = {name: os.stat(os.path.join(baseline, name)).st_mtime_ns for name in sorted(os.listdir(baseline))}
+
+    filename = min(name for name in before if name.endswith(".xml.gz"))
+    pull_via_wget(f"{PUBMED_BASE}baseline/", filename, decompress=False, subpath="PubMed/baseline")
+
+    after = {name: os.stat(os.path.join(baseline, name)).st_mtime_ns for name in sorted(os.listdir(baseline))}
+    assert after == before
+
+
+# PARSING AND BUILDING THE COMPENDIUM
+
+
+@pytest.fixture(scope="module")
+def parsed_pubmed(pubmed_downloads, pubmed_config, tmp_path_factory):
+    """Parse the downloaded files into the titles / ids / concords / statuses the compendium needs."""
+    out = tmp_path_factory.mktemp("parsed")
+    outputs = {
+        "titles_file": str(out / "titles.tsv"),
+        "status_file": str(out / "statuses.jsonl.gz"),
+        "pmid_id_file": str(out / "PMID"),
+        "pmid_doi_concord_file": str(out / "PMID_DOI"),
+        "metadata_yaml": str(out / "metadata.yaml"),
+    }
+
+    publications.parse_pubmed_into_tsvs(
+        pubmed_downloads["baseline"],
+        pubmed_downloads["updatefiles"],
+        outputs["titles_file"],
+        outputs["status_file"],
+        outputs["pmid_id_file"],
+        outputs["pmid_doi_concord_file"],
+        outputs["metadata_yaml"],
+    )
+
+    return outputs
+
+
+def test_parsing_produces_pmid_ids_titles_and_doi_concords(parsed_pubmed):
+    """Parsing the downloaded files should yield PMID ids, titles, DOI/PMC concords and statuses."""
+    with open(parsed_pubmed["pmid_id_file"]) as f:
+        ids = [line.rstrip("\n").split("\t") for line in f]
+    assert ids, "no PMIDs parsed"
+    assert all(curie.startswith(f"{PMID}:") for curie, _ in ids)
+
+    with open(parsed_pubmed["titles_file"]) as f:
+        titles = [line.rstrip("\n").split("\t") for line in f]
+    assert titles, "no titles parsed"
+
+    with open(parsed_pubmed["pmid_doi_concord_file"]) as f:
+        concords = [line.rstrip("\n").split("\t") for line in f]
+    assert concords, "no concords parsed"
+    assert {relation for _, relation, _ in concords} == {"eq"}
+
+
+def test_building_a_publication_compendium(parsed_pubmed, pubmed_config, tmp_path):
+    """The parsed files should build into a Publication.txt whose cliques carry PMID identifiers and
+    the titles we parsed. Uses an empty icRDF.tsv: information content is not what's under test."""
+    icrdf = tmp_path / "icRDF.tsv"
+    icrdf.write_text("")
+
+    compendium = os.path.join(pubmed_config["output_directory"], "compendia", "Publication.txt")
+    publications.generate_compendium(
+        [parsed_pubmed["pmid_doi_concord_file"]],
+        [parsed_pubmed["metadata_yaml"]],
+        [parsed_pubmed["pmid_id_file"]],
+        [parsed_pubmed["titles_file"]],
+        compendium,
+        str(icrdf),
+    )
+
+    with open(compendium) as f:
+        cliques = [json.loads(line) for line in f]
+
+    assert cliques, "Publication.txt is empty"
+    for clique in cliques:
+        assert clique["type"] == PUBLICATION
+        assert clique["identifiers"], f"clique with no identifiers: {clique}"
+
+    # Every PMID we parsed should have made it into the compendium. (Identifiers are written with the
+    # compact on-disk keys: "i" is the CURIE, "l" the label — see docs/DataFormats.md.)
+    with open(parsed_pubmed["pmid_id_file"]) as f:
+        parsed_pmids = {line.split("\t")[0] for line in f}
+    labels = {identifier["i"]: identifier["l"] for clique in cliques for identifier in clique["identifiers"]}
+    assert parsed_pmids <= set(labels)
+
+    # A PMID and the DOI (or PMCID) we concorded it with should land in the same clique.
+    with open(parsed_pubmed["pmid_doi_concord_file"]) as f:
+        pmid, _, equivalent_curie = f.readline().rstrip("\n").split("\t")
+    clique_with_pmid = next(c for c in cliques if any(i["i"] == pmid for i in c["identifiers"]))
+    assert equivalent_curie in {identifier["i"] for identifier in clique_with_pmid["identifiers"]}
+
+    # Titles become the labels on their PMIDs.
+    with open(parsed_pubmed["titles_file"]) as f:
+        first_pmid, first_title = f.readline().rstrip("\n").split("\t")
+    assert labels[first_pmid] == first_title

--- a/tests/pipeline/test_publications.py
+++ b/tests/pipeline/test_publications.py
@@ -26,12 +26,11 @@ import src.createcompendia.publications as publications
 import src.util
 from src.babel_utils import pull_via_wget
 from src.categories import PUBLICATION
+from src.createcompendia.publications import PUBMED_HTTPS_BASE
 from src.prefixes import PMID
 from src.util import ensure_parent_dir
 
 pytestmark = [pytest.mark.pipeline, pytest.mark.network]
-
-PUBMED_BASE = "https://ftp.ncbi.nlm.nih.gov/pubmed/"
 
 # How many files to take from each of baseline/ and updatefiles/. Each is a few tens of MB; five of
 # each is enough to exercise the parse and the compendium build without downloading the ~50 GB corpus.
@@ -40,7 +39,7 @@ FILES_PER_DIRECTORY = 5
 
 def list_pubmed_files(subdir):
     """Return the sorted names of the .xml.gz files PubMed publishes in `subdir`."""
-    response = requests.get(f"{PUBMED_BASE}{subdir}/", timeout=60)
+    response = requests.get(f"{PUBMED_HTTPS_BASE}{subdir}/", timeout=60)
     response.raise_for_status()
     return sorted(set(re.findall(r'href="(pubmed\d+n\d+\.xml\.gz)"', response.text)))
 
@@ -80,7 +79,7 @@ def pubmed_downloads(pubmed_config):
         for filename in filenames:
             for name in (filename, f"{filename}.md5"):
                 pull_via_wget(
-                    f"{PUBMED_BASE}{subdir}/",
+                    f"{PUBMED_HTTPS_BASE}{subdir}/",
                     name,
                     decompress=False,
                     subpath=f"PubMed/{subdir}",
@@ -116,7 +115,7 @@ def test_redownloading_leaves_the_already_downloaded_files_alone(pubmed_download
     before = {name: os.stat(os.path.join(baseline, name)).st_mtime_ns for name in sorted(os.listdir(baseline))}
 
     filename = min(name for name in before if name.endswith(".xml.gz"))
-    pull_via_wget(f"{PUBMED_BASE}baseline/", filename, decompress=False, subpath="PubMed/baseline")
+    pull_via_wget(f"{PUBMED_HTTPS_BASE}baseline/", filename, decompress=False, subpath="PubMed/baseline")
 
     after = {name: os.stat(os.path.join(baseline, name)).st_mtime_ns for name in sorted(os.listdir(baseline))}
     assert after == before


### PR DESCRIPTION
Carrying the PubMed downloads (~50 GB, ~1,500 files across `baseline/` and `updatefiles/`) forward
into a new run didn't work, and fixing it surfaced a corruption bug in the shared wget helper.

## Preloaded PubMed files were deleted before wget ran

`download_pubmed` declared `babel_downloads/PubMed/{baseline,updatefiles}` as `directory()` outputs.
Snakemake **recursively deletes existing `directory()` outputs** before running a job, so anything
preloaded into them was wiped and the whole corpus re-downloaded. Copying the `downloaded` /
`verified` markers over too avoids that, but then Snakemake skips the rules entirely and no new
updatefiles ever arrive — so neither variant of preloading actually worked.

`download_pubmed` now declares only its `downloaded` marker, and `generate_pubmed_concords` takes the
two directories as `params` rather than `input` (nothing else referenced them; the markers already
sequence download → verify → parse). Untracked, the directories survive into the job, where
`wget --timestamping` fetches only what is new or changed and `verify_pubmed`'s MD5 check re-downloads
anything that fails its published checksum.

The cost of untracking them is that Snakemake can no longer rebuild a directory that goes missing, so
`verify_pubmed_downloads()` now raises a `RuntimeError` naming the marker file to delete rather than
dying in `os.listdir()` with a bare `FileNotFoundError`.

## `wget --continue` silently corrupted files that changed upstream

`--continue` resumes by *appending* the bytes it believes are missing to whatever local file it finds
— correct only if that file is a truncated prefix of the server's copy. In a recursive `--timestamping`
download it can instead meet a file whose content changed upstream, and appending the tail of the new
file to the old one produces a corrupt result: a test against a local HTTP server turned
`"old local content"` into `"old local contentt"`.

`pull_via_wget()` now **refuses** the combination outright rather than silently dropping `--continue`
and logging at `info` — an option combination that can't be honoured is a caller bug, not something to
paper over. Two guards, raised before wget is invoked:

* recursion + `continue_incomplete=True` → `ValueError` (the corruption above).
* recursion + `timestamping=False` → `ValueError`. This one is what lets the first be unconditional:
  without `-N`, and with `--continue` now unavailable, wget would save a second copy of every file we
  already have as `file.1`. The invariant is total — **a recursive download is always timestamped and
  never continued.**

`download_pubmed()` is the only recursive caller and passes `continue_incomplete=False`; every other
caller is non-recursive and passes `-O`, which makes wget ignore `--timestamping` entirely, so
`--continue` remains their only resume mechanism and is kept. There is therefore no window in which a
Babel step can hit the new exception. The cost is that an interrupted large recursive file restarts
rather than resumes.

## Preloading, documented

`docs/RunningBabel.md` gains a "Preloading PubMed downloads" section with the procedure and its two
sharp edges: don't copy the `downloaded`/`verified` markers, and preserve mtimes (`mv` / `cp -p` /
`rsync -a`, not a plain `cp`) — `wget --timestamping` is what decides whether a carried-over file is
still current. The procedure also drops the `.md5` files, which is cheap insurance rather than a
correctness requirement: PubMed republishes a file's `.md5` whenever it revises the `.gz`, so with
mtimes intact the checksum is re-fetched along with the file and a stale-but-self-consistent
`.gz`/`.md5` pair can't survive the download anyway.

## Housekeeping

The PubMed base URL appeared five times across the module and the tests — as the default `pubmed_base`
of `download_pubmed()` (FTP) and `verify_pubmed_downloads()` (HTTPS), twice more hardcoded in
`parse_pubmed_into_tsvs()`'s metadata sources, and once in the test. `PUBMED_FTP_BASE` and
`PUBMED_HTTPS_BASE` now carry it, with a comment on why the same corpus is fetched two ways: NCBI's
`robots.txt` blocks a recursive HTTPS download, so the bulk fetch goes over FTP, while the single-file
re-downloads that repair a failed checksum use the more reliable HTTPS. `publications.py` also now
logs through `get_logger()` rather than the root `logging` module, per AGENTS.md.

## Tests

* **Unit** — the MD5 backstop (`verify_pubmed_download_against_md5`, `verify_pubmed_downloads`): a
  matching file, a corrupt one, a missing one, a zero-length one, a missing or unparseable `.md5`, and
  that a clean directory re-downloads nothing while a corrupt file is truncated and re-fetched with its
  checksum. Plus `pull_via_wget()`'s recursive download against a throwaway localhost HTTP server:
  preloaded files survive, new files arrive, and a revised file is re-fetched in full rather than
  resumed (the regression test for the `--continue` bug). Two more assert each new guard raises; they
  need neither the server nor the `wget` binary, since the guards fire before the subprocess. All
  offline and fast, so they run in CI.

* **Pipeline** (`pipeline` + `network`, skipped by default) — the publications target in miniature
  against the real server: downloads two baseline and two update files with their `.md5`s, verifies
  them, confirms a second download pass leaves them untouched, parses them into ids/titles/concords,
  and builds a `Publication.txt`. Runs in ~64s:

  ```
  uv run pytest tests/pipeline/test_publications.py --pipeline --network --no-cov
  ```

  Two files from each directory rather than five, because parsing the XML — not downloading it —
  dominates: at five each the test took 155s, of which 119s was the parse and only 20s the download.
  Every PubMed file has the same format, so the count scales how many articles flow through the same
  code paths and nothing else.

  It redirects the download and output directories at a temp tree so it can't clobber a real
  `babel_outputs/compendia/Publication.txt`, and stands in empty `common/ubergraph/*` and `icRDF.tsv`
  files, which `write_compendium()`'s factories require but publications never use. That makes it the
  one pipeline test that doesn't reuse `babel_downloads/`; it keeps the `pipeline` mark anyway because
  it runs a whole target's rule bodies end to end and takes minutes, so it wants that mark's 3600s
  timeout rather than `network`'s 600s, and its own xdist worker under `-n auto`.

Full lint gate (ruff, snakefmt, rumdl), 325 unit tests, and the pipeline test all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
