### PR TITLE
Type foods from their NCIt classification, beyond DrugBank (#935)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -161,25 +161,25 @@ chemical_ids:       [CHEMBL.COMPOUND, GTOPDB, CHEBI, UNII, HMDB, PUBCHEM.COMPOUN
 # this list so those cliques flow into DrugChemical conflation and the exports like any other chemical
 # output. (The processed extracts among them go to the already-present ComplexMolecularMixture.)
 chemical_outputs:   [MolecularMixture.txt, SmallMolecule.txt, Polypeptide.txt, ComplexMolecularMixture.txt, ChemicalEntity.txt, ChemicalMixture.txt, Drug.txt, Food.txt]
-# NCIt subtrees whose members are treated as foods when retyping DRUGBANK food-and-extract entries (issue
-# #828): NCIT:C1949 "Food" plus NCIT:C73913 "Seed" (nuts/grains like almond and wheat that NCIt files under
-# Seed, not Food). NCIt types a food by what it is rather than what it came from, so this covers non-plant
-# foods (scallop, venison, beef liver) too. A structureless DRUGBANK entry counts as food material if its
-# UNII is classified under either root OR its UNII carries a botanical-database flag (PLANTS/GRIN/MPNS,
-# which reaches the plant materials NCIt has no food class for); such material becomes biolink:Food, or
-# biolink:ComplexMolecularMixture when it is an extract (see drugbank_extract_markers).
-drugbank_food_ncit_roots:
+# NCIt subtrees whose members are foods (issues #828, #935): NCIT:C1949 "Food" plus NCIT:C73913 "Seed"
+# (nuts/grains like almond and wheat that NCIt files under Seed, not Food). NCIt types a food by what it is
+# rather than what it came from, so this covers non-plant foods (scallop, venison, beef liver) too.
+# A concept whose NCIt class is under either root contributes biolink:Food evidence to its clique — a
+# DRUGBANK entry via its UNII (#828), and any UNII or UMLS concept via NCIt directly (#935). The evidence
+# is a *vote*, not an override (see chemicals.create_typed_sets): NCIt also calls water and riboflavin
+# foods, and a clique that votes SmallMolecule keeps SmallMolecule.
+food_ncit_roots:
   - NCIT:C1949 # "Food" -- https://ncithesaurus.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=C1949
   - NCIT:C73913 # "Seed" -- https://ncithesaurus.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=C73913
 # NCIt subtrees whose members are NEVER food, however botanical they are (issue #828). A botanical flag
 # says "plant material", not "food", so on its own it must not overrule an NCIt class that says this is a
 # drug: without this veto DRUGBANK:DB00965 "Ethiodized oil" (an iodinated poppy-seed-oil contrast agent)
-# and DRUGBANK:DB05051 "BZL101" (an antineoplastic) are typed biolink:Food. A vetoed entry stays
-# biolink:ChemicalEntity — we make no claim — and an explicit drugbank_food_ncit_roots classification
-# still wins, so a food that is also a diagnostic agent (inulin) is unaffected. Keep these roots NARROW:
-# NCIT:C1909 "Pharmacologic Substance" is deliberately absent because NCIt files cocoa butter, garlic oil,
-# rice bran and green tea under it, and vetoing on it would throw out real foods.
-drugbank_nonfood_ncit_roots:
+# and DRUGBANK:DB05051 "BZL101" (an antineoplastic) are typed biolink:Food. A vetoed entry contributes no
+# food evidence at all — we make no claim — and an explicit food_ncit_roots classification still wins, so a
+# food that is also a diagnostic agent (inulin) is unaffected. Keep these roots NARROW: NCIT:C1909
+# "Pharmacologic Substance" is deliberately absent because NCIt files cocoa butter, garlic oil, rice bran
+# and green tea under it, and vetoing on it would throw out real foods.
+nonfood_ncit_roots:
   - NCIT:C1966 # "Imaging Agent" -- https://ncithesaurus.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=C1966
   - NCIT:C274 # "Antineoplastic Agent" -- https://ncithesaurus.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=C274
 # Case-insensitive name/synonym substrings that mark a DRUGBANK food material as a processed

--- a/docs/sources/DRUGBANK/CLAUDE.md
+++ b/docs/sources/DRUGBANK/CLAUDE.md
@@ -30,7 +30,7 @@ readers in `src/datahandlers/unii.py`:
   botanical subset (`read_plant_uniis`) when you want plants/foods.
 
 A botanical flag means "plant material", not "food", so it must never overrule an NCIt class that
-says the entry is a drug — hence `config.yaml: drugbank_nonfood_ncit_roots`, the never-food veto
+says the entry is a drug — hence `config.yaml: nonfood_ncit_roots`, the never-food veto
 that keeps [`DRUGBANK:DB00965`](https://go.drugbank.com/drugs/DB00965) "Ethiodized oil" (a
 poppy-seed-oil contrast agent) out of `biolink:Food`. Keep those roots narrow, and do **not** reach
 for UMLS semantic types instead: they are far coarser than NCIt's classes here, and the

--- a/docs/sources/DRUGBANK/food-and-extracts/README.md
+++ b/docs/sources/DRUGBANK/food-and-extracts/README.md
@@ -66,7 +66,7 @@ chemical). Then:
    **`biolink:ComplexMolecularMixture`** (bark/root/pollen extracts, herbal tinctures).
 3. A botanical flag says "plant material", not "food", so on its own it must not overrule an NCIt
    class that says the entry is a **drug**. A row whose NCIt class is under
-   `config.yaml: drugbank_nonfood_ncit_roots` —
+   `config.yaml: nonfood_ncit_roots` —
    [`NCIT:C1966`](http://purl.obolibrary.org/obo/NCIT_C1966) "Imaging Agent",
    [`NCIT:C274`](http://purl.obolibrary.org/obo/NCIT_C274) "Antineoplastic Agent" — is left as
    `ChemicalEntity`. Without this veto, [`DRUGBANK:DB00965`](https://go.drugbank.com/drugs/DB00965)
@@ -82,7 +82,7 @@ classification still wins, so a food that is also a diagnostic agent
 ([`NCIT:C61506`](http://purl.obolibrary.org/obo/NCIT_C61506) "Inulin", used to measure GFR) is
 unaffected.
 
-Keep `drugbank_nonfood_ncit_roots` **narrow**.
+Keep `nonfood_ncit_roots` **narrow**.
 [`NCIT:C1909`](http://purl.obolibrary.org/obo/NCIT_C1909) "Pharmacologic Substance" is deliberately
 *not* on it: NCIt files cocoa butter, garlic oil, rice bran and green tea under it, so vetoing on it
 would throw out real foods.
@@ -119,7 +119,7 @@ per-entry evidence for that triage.
 ### Why the veto keys on NCIt subtrees, not UMLS semantic types
 
 Babel otherwise leans on UMLS semantic types (STY) rather than NCIt classes, so the obvious question
-is whether `drugbank_nonfood_ncit_roots` could be a list of never-food STYs instead. It cannot, for
+is whether `nonfood_ncit_roots` could be a list of never-food STYs instead. It cannot, for
 three reasons, each measured against this snapshot:
 
 - **STYs are too coarse.** The tightest semantic type that catches ethiodized oil is `T130`
@@ -142,19 +142,25 @@ Snapshot below) — they are how you decide what the *next* veto root should be.
 ## How it is wired
 
 - `chemical_ncit_food_codes` (rule) queries UberGraph for the NCIt Food/Seed subtrees
-  (`config.yaml: drugbank_food_ncit_roots`) → `ids/ncit_food_codes`.
+  (`config.yaml: food_ncit_roots`) → `ids/ncit_food_codes`.
 - `chemical_ncit_nonfood_codes` (rule) does the same for the never-food subtrees
-  (`config.yaml: drugbank_nonfood_ncit_roots`) → `ids/ncit_nonfood_codes`.
+  (`config.yaml: nonfood_ncit_roots`) → `ids/ncit_nonfood_codes`.
 - `chemical_drugbank_food_extracts` (rule) reads the DrugBank vocabulary CSV + the UNII
   records + those NCIt codes + `config.yaml: drugbank_extract_markers`, and writes
   `ids/DRUGBANK_food_extracts` (`DRUGBANK:xxx\tbiolink:Type`) —
   `datahandlers/drugbank.py:write_drugbank_food_extract_types`. The plant-flag set comes
   from the same UNII records file (`unii.py:read_plant_uniis`), so the rule needs no extra input.
-- `chemicals.create_typed_sets` forces any clique containing one of those CURIEs to the given type,
-  overriding the normal per-identifier type vote (the extracts carry no Babel type of their own, so
-  a vote would leave them as `ChemicalEntity`). The retype is clique-level: it assumes an extract
-  clique never also contains a genuine chemical, which holds because these are distinct UMLS/RXNORM
-  concepts and none of them share a clique with a CHEBI/PubChem structure.
+- `chemicals.create_typed_sets` takes those CURIEs as **food/extract evidence** on the clique they
+  land in: the evidence joins the clique's type vote as an extra candidate, and the most specific
+  type wins (`order`). These entries carry no Babel type of their own, and their cliques vote
+  nothing but `ChemicalEntity` — 672 of the 685 have concord partners, 1326 links, every one of them
+  `ChemicalEntity` — so `Food`/`ComplexMolecularMixture` wins and the retype happens.
+
+  The evidence used to be a hard *override* that skipped the vote. It stopped being one in
+  [#935](https://github.com/NCATSTranslator/Babel/issues/935), which types foods from NCIt beyond
+  DrugBank and so has to cope with cliques that *do* contain a real chemical: NCIt calls water a
+  food, and only a vote (with `Food` ranked below `SmallMolecule`) keeps water a small molecule. See
+  [`../../NCIT/food-typing.md`](../../NCIT/food-typing.md).
 - `Food.txt` and the pre-existing `ComplexMolecularMixture.txt` are both in
   `config.yaml: chemical_outputs`, so **no new output type is needed** for this change. `RXCUI`
   members survive because the chemical build already passes `extra_prefixes=[RXCUI]`. These cliques
@@ -193,7 +199,7 @@ Both files carry the same two audit columns, and they exist to be *acted on*: `*
 NCIt class's direct superclasses (`NCIT:C390 (Contrast Agent)`) and `*_semantic_types` its UMLS
 semantic types (`T130=Indicator, Reagent, or Diagnostic Aid`). Reading a `Food` row whose semantic
 type is `T121`/`T130`-ish — or whose parent is plainly an agent class — is how you find the next
-`drugbank_nonfood_ncit_roots` entry. That is also how ethiodized oil was found.
+`nonfood_ncit_roots` entry. That is also how ethiodized oil was found.
 
 To regenerate after a UNII refresh: run the `chemical_ncit_food_codes` and
 `chemical_ncit_nonfood_codes` rules (or `chemicals.write_ncit_descendant_codes`) to produce

--- a/docs/sources/DRUGBANK/food-and-extracts/scripts/generate_csvs.py
+++ b/docs/sources/DRUGBANK/food-and-extracts/scripts/generate_csvs.py
@@ -16,7 +16,7 @@ This is the committed generator for the sibling files:
 
 Both files carry two audit columns — the NCIt class's **direct parents** and its **UMLS semantic
 types** — so that a reviewer can see what sits above an entry and propose the next
-``config.yaml: drugbank_nonfood_ncit_roots`` entry (the never-food veto) from data rather than by
+``config.yaml: nonfood_ncit_roots`` entry (the never-food veto) from data rather than by
 eyeballing labels. The semantic types are derived from the entry's *NCIt* code, not from its UNII:
 UNIIs do map into UMLS directly (``MRCONSO`` ``SAB=MTHSPL``), but these products are all FDA drug
 ingredients there, so that route stamps ``T121`` "Pharmacologic Substance" on almost every one of
@@ -41,7 +41,7 @@ Inputs (pinned DrugBank vocabulary; current FDA UNII records):
     Snakemake rules, or directly (UberGraph query):
 
         uv run python -c "import src.createcompendia.chemicals as c, src.util as u; \\
-          c.write_ncit_descendant_codes(u.get_config()['drugbank_food_ncit_roots'], 'ncit_food_codes')"
+          c.write_ncit_descendant_codes(u.get_config()['food_ncit_roots'], 'ncit_food_codes')"
 
 Run (from the repo root):
 
@@ -208,7 +208,7 @@ def generate(
 
     # The audit columns: what sits directly above each NCIt class, and how UMLS types it. Both are
     # looked up in bulk once every row is known, and both exist so that a reviewer can source the next
-    # drugbank_nonfood_ncit_roots entry from the data (see this module's docstring and the README).
+    # nonfood_ncit_roots entry from the data (see this module's docstring and the README).
     ncit_curies = {r["ncit"] for r in a_rows} | {r["unii_ncit"] for r in b_rows}
     parents = fetch_ncit_parents(ncit_curies)
     semantic_types = read_ncit_semantic_types(mrconso, mrsty, ncit_curies)

--- a/docs/sources/NCIT/food-typing.md
+++ b/docs/sources/NCIT/food-typing.md
@@ -1,0 +1,70 @@
+# Typing foods from their NCIt classification
+
+[Issue #935](https://github.com/NCATSTranslator/Babel/issues/935), generalizing
+[#828](https://github.com/NCATSTranslator/Babel/issues/828)
+
+The NCI Thesaurus classifies concepts as foods —
+[`NCIT:C1949`](http://purl.obolibrary.org/obo/NCIT_C1949) "Food or Food Product" and
+[`NCIT:C73913`](http://purl.obolibrary.org/obo/NCIT_C73913) "Seed", where NCIt files the nuts and
+grains. [#828](https://github.com/NCATSTranslator/Babel/issues/828) used that classification to type
+**DrugBank** food entries as `biolink:Food` (see
+[`../DRUGBANK/food-and-extracts/README.md`](../DRUGBANK/food-and-extracts/README.md)). The same
+evidence exists for concepts DrugBank never mentions — swordfish, capsicum, cranberry, corn — and
+this is how they get typed too.
+
+## NCIt CURIEs are not clique members, so the classification is *projected*
+
+`NCIT` appears in neither `chemical_ids` nor `chemical_concords` (`config.yaml`), so no `NCIT:`
+CURIE is a member of a chemical clique. "Type the NCIt identifiers and let everything
+cross-referenced to them inherit it" therefore cannot work: there is nothing to inherit *from*. The
+classification has to be projected onto identifiers that **are** clique members
+(`chemicals.write_ncit_food_types` → `ids/ncit_food_types`, rule `chemical_ncit_food_types`):
+
+- **UMLS** — `MRCONSO.RRF`'s `SAB=NCI` rows map an NCIt code to its CUI. 997 CUIs.
+- **UNII** — the FDA UNII records' `NCIT` column. 286 UNIIs.
+- **RxNorm** — nothing of its own: an `RXCUI` rides along in the same clique as the CUI it shares a
+  concept with, and inherits the clique's type.
+
+UNIIs that carry an **InChI Key** are skipped: a defined molecule is already typed from its
+structure, and NCIt classifies plenty of defined molecules as foods (water, riboflavin, isoleucine,
+beta carotene).
+
+## The evidence is a vote, not an override
+
+This is the part that matters, and it is why #935 could not simply reuse #828's mechanism.
+
+`chemicals.create_typed_sets` used to *force* a clique's type whenever any member carried
+food/extract evidence, skipping the type vote entirely. That is safe for #828, whose entries are
+structureless by construction, but not here: NCIt calls **water** a food, and
+[`UMLS:C0043047`](https://uts.nlm.nih.gov/uts/umls/concept/C0043047) "Water" duly carries food
+evidence. Forcing it would retype water from `biolink:SmallMolecule` to `biolink:Food`.
+
+So the evidence now joins the vote as an extra candidate, and `order` decides:
+
+```text
+Drug > MolecularMixture > SmallMolecule > Polypeptide > ComplexMolecularMixture > Food
+     > ChemicalMixture > ChemicalEntity
+```
+
+`Food` sits **below** every structure-bearing type and **above** the uninformative
+`ChemicalMixture`/`ChemicalEntity` it exists to improve on. The consequences:
+
+- **Water stays a `SmallMolecule`.** Its clique votes `SmallMolecule` (from CHEBI and PubChem),
+  which is more specific than the food evidence.
+- **Swordfish becomes `Food`.** Its clique votes nothing but `ChemicalEntity`, which `Food` beats.
+- **An extract stays an extract.** `ComplexMolecularMixture` outranks `Food`, so a DrugBank extract
+  whose concept NCIt also calls a food (green tea) keeps the extract type.
+
+The "no InChI Key" structure guard that #828 hard-codes is, in this design, an emergent property of
+the ordering rather than a rule anyone has to remember. The UNII structure guard above is kept
+anyway as a second belt: it costs one column read and keeps a structure-bearing UNII from claiming
+`Food` in the rare clique that has no structure-typed member at all.
+
+## The never-food veto still applies
+
+`config.yaml: nonfood_ncit_roots` (imaging agents, antineoplastics) is subtracted from the food
+codes before projection, so a concept NCIt classifies as a drug contributes no food evidence — the
+same veto that keeps [`DRUGBANK:DB00965`](https://go.drugbank.com/drugs/DB00965) "Ethiodized oil"
+out of `Food`. Keep those roots narrow, and see the DrugBank README for why
+[`NCIT:C1909`](http://purl.obolibrary.org/obo/NCIT_C1909) "Pharmacologic Substance" is **not** among
+them, and why the (much coarser) UMLS semantic types are not used for this at all.

--- a/docs/sources/README.md
+++ b/docs/sources/README.md
@@ -23,6 +23,10 @@ letting it accumulate in `AGENTS.md` — `AGENTS.md` should point here, not dupl
   — retyping DrugBank food-and-extract products (foods, pollens, danders) out of
   `biolink:ChemicalEntity`: foods become `biolink:Food` via their UNII's NCIt class, non-food
   allergens become `biolink:ComplexMolecularMixture`.
+- **NCIT** ([NCIT/food-typing.md](./NCIT/food-typing.md)) — typing foods (swordfish, capsicum,
+  cranberry) as `biolink:Food` from NCIt's Food/Seed classification: why the classification has to
+  be *projected* onto UMLS/UNII rather than inherited from an `NCIT:` clique member, and why the
+  evidence is a type *vote* rather than an override (NCIt calls water a food).
 - **ENSEMBL** ([ENSEMBL/Download.md](./ENSEMBL/Download.md)) — how Ensembl identifiers are
   downloaded via the BioMart API: per-dataset retry logic, permanently broken datasets and how to
   skip them, the attribute-batching workaround, and how partial progress is preserved across

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -946,18 +946,17 @@ def build_compendia(
             types[x[0]] = x[1]
     logger.info(f"Loaded {len(types)} types from {type_file}: {get_memory_usage_summary()}")
 
-    # DRUGBANK food-and-extract CURIEs to force to a specific Biolink type (issue #828): foods to
-    # biolink:Food, non-food allergen extracts (pollens/danders/...) to biolink:ComplexMolecularMixture.
-    # These enter chemical cliques via the UMLS/RXNORM concords without a Babel-assigned type, so we
-    # retype the whole clique they land in rather than relying on the per-identifier type vote.
-    forced_types = {}
+    # Food/extract evidence (issues #828, #935): CURIEs whose NCIt class says "food" (biolink:Food) or
+    # whose DrugBank name says "extract" (biolink:ComplexMolecularMixture). These enter chemical cliques
+    # via the UMLS/RXNORM concords carrying no Babel type of their own, so this evidence joins the
+    # clique's type vote in create_typed_sets as an extra candidate — it does not override it.
+    food_types = {}
     with open(food_extract_types_file) as inf:
         for line in inf:
             curie, biolink_type = line.strip().split("\t")
-            forced_types[curie] = biolink_type
+            food_types[curie] = biolink_type
     logger.info(
-        f"Loaded {len(forced_types)} forced food-and-extract types from {food_extract_types_file}: "
-        f"{get_memory_usage_summary()}"
+        f"Loaded {len(food_types)} food-and-extract types from {food_extract_types_file}: {get_memory_usage_summary()}"
     )
 
     untyped_sets = set()
@@ -967,7 +966,7 @@ def build_compendia(
             untyped_sets.add(frozenset(s))
     logger.info(f"Loaded {len(untyped_sets)} untyped sets from {untyped_compendia_file}: {get_memory_usage_summary()}")
 
-    typed_sets = create_typed_sets(untyped_sets, types, forced_types)
+    typed_sets = create_typed_sets(untyped_sets, types, food_types)
     logger.info(
         f"Created {len(typed_sets)} typed sets from {len(untyped_sets)} untyped sets: {get_memory_usage_summary()}"
     )
@@ -998,38 +997,47 @@ def build_compendia(
             )
 
 
-def create_typed_sets(eqsets, types, forced_types=None):
+def create_typed_sets(eqsets, types, food_types=None):
     """
     Given a set of sets of equivalent identifiers, we want to type each one into
     being a subclass of ChemicalEntity.
 
     :param eqsets: A list of lists of identifiers (should NOT be a list of LabeledIDs, but a list of strings).
     :param types: A dictionary of known types for each identifier. (Some identifiers don't have known types.)
-    :param forced_types: {CURIE -> biolink_type} for DRUGBANK food/extracts (issue #828). A clique
-        containing any such CURIE is forced to that type (Food or ComplexMolecularMixture), overriding
-        the normal type vote; if members disagree the most specific type (earliest in ``order``) wins.
+    :param food_types: {CURIE -> biolink_type} of food/extract evidence (issues #828, #935): a UNII or
+        UMLS/DRUGBANK CURIE whose NCIt class says "food", or a DrugBank material whose name says
+        "extract". These CURIEs carry no Babel type of their own, so this evidence is added to the
+        clique's type vote as an extra candidate — *not* as an override. The most specific of the voted
+        and the food/extract types wins, per ``order``, which is what keeps water a SmallMolecule: NCIt
+        calls water a food, but its clique also votes SmallMolecule, and SmallMolecule is more specific.
     """
+    # Most specific first. FOOD sits *below* the structure-bearing types (SmallMolecule, MolecularMixture,
+    # Drug, Polypeptide) so that food evidence never demotes a defined molecule (water, riboflavin,
+    # isoleucine and beta carotene are all NCIt foods), and *above* the uninformative ChemicalMixture /
+    # ChemicalEntity, which is what it is meant to improve on. ComplexMolecularMixture outranks FOOD so
+    # that an extract stays an extract even when NCIt also calls it a food (issue #935).
     order = [
-        FOOD,
         DRUG,
         MOLECULAR_MIXTURE,
         SMALL_MOLECULE,
         POLYPEPTIDE,
         COMPLEX_MOLECULAR_MIXTURE,
+        FOOD,
         CHEMICAL_MIXTURE,
         CHEMICAL_ENTITY,
     ]
-    forced_types = forced_types or {}
+    food_types = food_types or {}
     typed_sets = defaultdict(set)
+
+    def assign(biolink_type, ids, food_evidence):
+        """Type a clique as the most specific of its voted type and any food/extract evidence on it."""
+        typed_sets[min({biolink_type} | food_evidence, key=order.index)].add(ids)
+
     # logging.warning(f"create_typed_sets: eqsets={eqsets}, types=...")
     for equivalent_ids in eqsets:
-        # A clique containing a DRUGBANK food/extract is retyped as a whole to its forced type
-        # (issue #828). ponytail: coarse clique-level override; an extract clique never contains a real
-        # chemical, so retyping the whole clique is safe.
-        forced = {forced_types[c] for c in equivalent_ids if c in forced_types}
-        if forced:
-            typed_sets[min(forced, key=order.index)].add(equivalent_ids)
-            continue
+        # The food/extract evidence on this clique, if any (issues #828, #935). It joins the vote below
+        # rather than overriding it.
+        food_evidence = {food_types[c] for c in equivalent_ids if c in food_types}
         # logging.warning(f"Processing equivalent_ids={equivalent_ids}.")
         # prefixes = set([ Text.get_curie(x) for x in equivalent_ids])
         prefixes = get_prefixes(equivalent_ids)
@@ -1046,7 +1054,7 @@ def create_typed_sets(eqsets, types, forced_types=None):
                         pass
 
                 if len(pctypes) == 1:
-                    typed_sets[list(pctypes)[0]].add(equivalent_ids)
+                    assign(list(pctypes)[0], equivalent_ids, food_evidence)
                     found = True
                 elif pctypes == {SMALL_MOLECULE, MOLECULAR_MIXTURE}:
                     # This is a common case (8,178 cases in 2022oct13) which occurs in cases where the InChI for
@@ -1074,8 +1082,8 @@ def create_typed_sets(eqsets, types, forced_types=None):
                         + f"into a biolink:MolecularMixture ({molecular_mixture_ids}) and "
                         + f"a biolink:SmallMolecule ({all_other_ids})"
                     )
-                    typed_sets[MOLECULAR_MIXTURE].add(frozenset(molecular_mixture_ids))
-                    typed_sets[SMALL_MOLECULE].add(frozenset(all_other_ids))
+                    assign(MOLECULAR_MIXTURE, frozenset(molecular_mixture_ids), food_evidence)
+                    assign(SMALL_MOLECULE, frozenset(all_other_ids), food_evidence)
                     found = True
                 else:
                     logging.warning(
@@ -1091,14 +1099,14 @@ def create_typed_sets(eqsets, types, forced_types=None):
                 # print(equivalent_ids)
                 # One thing that happens is that we can have PUBCHEMs that have been deleted, but are still in UNICHEM
                 # then the pubchem doesn't get assigned a type, but still ends up in the compendium
-                typed_sets[CHEMICAL_ENTITY].add(equivalent_ids)
+                assign(CHEMICAL_ENTITY, equivalent_ids, food_evidence)
             elif len(typecounts) == 1:
                 t = list(typecounts.keys())[0]
-                typed_sets[t].add(equivalent_ids)
+                assign(t, equivalent_ids, food_evidence)
             else:
                 # First attempt is majority vote, and after that by most specific
                 otypes = [(-c, order.index(t), t) for t, c in typecounts.items()]
                 otypes.sort()
                 t = otypes[0][2]
-                typed_sets[t].add(equivalent_ids)
+                assign(t, equivalent_ids, food_evidence)
     return typed_sets

--- a/src/createcompendia/chemicals.py
+++ b/src/createcompendia/chemicals.py
@@ -1,4 +1,5 @@
 import ast
+import csv
 import gzip
 import logging
 from collections import defaultdict
@@ -26,6 +27,8 @@ from src.categories import (
     POLYPEPTIDE,
     SMALL_MOLECULE,
 )
+from src.datahandlers.drugbank import read_ncit_code_set
+from src.datahandlers.umls import MRCONSO_CODE_COLUMN, MRCONSO_CUI_COLUMN, MRCONSO_SAB_COLUMN
 from src.datahandlers.unichem import UNICHEM_REFERENCE_TSV_HEADER, UNICHEM_STRUCT_TSV_HEADER
 from src.datahandlers.unichem import data_sources as unichem_data_sources
 from src.datahandlers.unii import UNII_RECORDS_CODE_COLUMN, UNII_RECORDS_ENCODING, read_organism_uniis
@@ -39,6 +42,7 @@ from src.prefixes import (
     INCHIKEY,
     KEGGCOMPOUND,
     MESH,
+    NCIT,
     PUBCHEMCOMPOUND,
     RXCUI,
     UMLS,
@@ -319,6 +323,49 @@ def write_ncit_descendant_codes(roots, outfile):
     with open(outfile, "w") as outf:
         for code in sorted(codes):
             outf.write(f"{code}\n")
+
+
+def write_ncit_food_types(mrconso, unii_records, food_codes_file, nonfood_codes_file, outfile):
+    """Write ``CURIE\\tbiolink:Food`` for every UMLS and UNII concept NCIt classifies as a food (#935).
+
+    #828 reaches DrugBank foods through their UNII's NCIt class. The same NCIt evidence exists for
+    concepts DrugBank never mentions (swordfish, capsicum, cranberry), but NCIt CURIEs are not members
+    of chemical cliques — ``NCIT`` is in neither ``chemical_ids`` nor ``chemical_concords`` — so the
+    classification has to be projected onto identifiers that *are* members:
+
+    - **UMLS**: MRCONSO's ``SAB=NCI`` rows map an NCIt code to its CUI. RxNorm needs no pass of its own;
+      an RXCUI rides along in the same clique.
+    - **UNII**: the UNII records' ``NCIT`` column. UNIIs that carry an InChI Key are skipped: those are
+      defined molecules, which Babel already types from their structure, and calling one a food adds
+      nothing (NCIt classifies water, riboflavin and beta carotene as foods).
+
+    The output feeds ``create_typed_sets`` as food *evidence*, which loses to any more specific type the
+    clique votes for — so a food that is also a small molecule stays a small molecule.
+    """
+    food_codes = read_ncit_code_set(food_codes_file) - read_ncit_code_set(nonfood_codes_file)
+    logger.info(f"Projecting {len(food_codes)} NCIt food codes onto UMLS and UNII concepts")
+
+    with open(outfile, "w") as outf:
+        cuis = set()
+        with open(mrconso) as inf:
+            for line in inf:
+                fields = line.split("|")
+                if fields[MRCONSO_SAB_COLUMN] == "NCI" and f"{NCIT}:{fields[MRCONSO_CODE_COLUMN]}" in food_codes:
+                    cuis.add(fields[MRCONSO_CUI_COLUMN])
+        for cui in sorted(cuis):
+            outf.write(f"{UMLS}:{cui}\t{FOOD}\n")
+
+        uniis = set()
+        with open(unii_records, encoding=UNII_RECORDS_ENCODING) as inf:
+            for row in csv.DictReader(inf, delimiter="\t"):
+                if row["INCHIKEY"].strip():
+                    continue
+                if row["NCIT"].strip() and f"{NCIT}:{row['NCIT'].strip()}" in food_codes:
+                    uniis.add(row["UNII"])
+        for unii in sorted(uniis):
+            outf.write(f"{UNII}:{unii}\t{FOOD}\n")
+
+    logger.info(f"Wrote food evidence for {len(cuis)} UMLS concepts and {len(uniis)} UNIIs to {outfile}")
 
 
 def write_drugbank_ids(infile, outfile):
@@ -937,7 +984,7 @@ def build_compendia(
     properties_jsonl_gz_files,
     metadata_yamls,
     icrdf_filename,
-    food_extract_types_file,
+    food_type_files,
 ):
     types = {}
     with open(type_file) as inf:
@@ -949,15 +996,17 @@ def build_compendia(
     # Food/extract evidence (issues #828, #935): CURIEs whose NCIt class says "food" (biolink:Food) or
     # whose DrugBank name says "extract" (biolink:ComplexMolecularMixture). These enter chemical cliques
     # via the UMLS/RXNORM concords carrying no Babel type of their own, so this evidence joins the
-    # clique's type vote in create_typed_sets as an extra candidate — it does not override it.
+    # clique's type vote in create_typed_sets as an extra candidate — it does not override it. Two files
+    # feed it, over disjoint CURIE spaces: the DrugBank materials (#828, DRUGBANK CURIEs) and the NCIt
+    # projection (#935, UMLS/UNII CURIEs). Where they name different members of the *same* clique and
+    # disagree, create_typed_sets takes the most specific type, so the load order here doesn't matter.
     food_types = {}
-    with open(food_extract_types_file) as inf:
-        for line in inf:
-            curie, biolink_type = line.strip().split("\t")
-            food_types[curie] = biolink_type
-    logger.info(
-        f"Loaded {len(food_types)} food-and-extract types from {food_extract_types_file}: {get_memory_usage_summary()}"
-    )
+    for food_type_file in food_type_files:
+        with open(food_type_file) as inf:
+            for line in inf:
+                curie, biolink_type = line.strip().split("\t")
+                food_types[curie] = biolink_type
+    logger.info(f"Loaded {len(food_types)} food-and-extract types from {food_type_files}: {get_memory_usage_summary()}")
 
     untyped_sets = set()
     with open(untyped_compendia_file) as inf:

--- a/src/datahandlers/umls.py
+++ b/src/datahandlers/umls.py
@@ -16,6 +16,17 @@ from src.util import get_logger
 
 logger = get_logger(__name__)
 
+# Column offsets in the pipe-delimited UMLS RRF files (UMLS Reference Manual, section 3.3):
+# MRCONSO is CUI|LAT|TS|LUI|STT|SUI|ISPREF|AUI|SAUI|SCUI|SDUI|SAB|TTY|CODE|...,
+# MRSTY is CUI|TUI|STN|STY|ATUI|CVF. Older code in this module still indexes these positionally
+# (x[11], x[13]); prefer these names in new code.
+MRCONSO_CUI_COLUMN = 0
+MRCONSO_SAB_COLUMN = 11
+MRCONSO_CODE_COLUMN = 13
+MRSTY_CUI_COLUMN = 0
+MRSTY_TUI_COLUMN = 1
+MRSTY_STY_COLUMN = 3
+
 
 def check_mrconso_line(line):
     """

--- a/src/snakefiles/chemical.snakefile
+++ b/src/snakefiles/chemical.snakefile
@@ -150,7 +150,7 @@ rule chemical_ncit_food_codes:
         config["output_directory"] + "/benchmarks/chemical_ncit_food_codes.tsv"
     retries: 3  # UberGraph sometimes fails mid-download and needs a retry.
     run:
-        chemicals.write_ncit_descendant_codes(config["drugbank_food_ncit_roots"], output.outfile)
+        chemicals.write_ncit_descendant_codes(config["food_ncit_roots"], output.outfile)
 
 
 rule chemical_ncit_nonfood_codes:
@@ -163,7 +163,7 @@ rule chemical_ncit_nonfood_codes:
         config["output_directory"] + "/benchmarks/chemical_ncit_nonfood_codes.tsv"
     retries: 3  # UberGraph sometimes fails mid-download and needs a retry.
     run:
-        chemicals.write_ncit_descendant_codes(config["drugbank_nonfood_ncit_roots"], output.outfile)
+        chemicals.write_ncit_descendant_codes(config["nonfood_ncit_roots"], output.outfile)
 
 
 rule chemical_drugbank_food_extracts:
@@ -189,6 +189,31 @@ rule chemical_drugbank_food_extracts:
             input.food_ncit_codes,
             input.nonfood_ncit_codes,
             config["drugbank_extract_markers"],
+            output.outfile,
+        )
+
+
+rule chemical_ncit_food_types:
+    # Foods that DrugBank never mentions (swordfish, capsicum, cranberry): every UMLS and UNII concept
+    # NCIt classifies as a food, projected onto the identifiers that actually sit in chemical cliques —
+    # issue #935. NCIt CURIEs are not clique members themselves, so the classification travels via
+    # MRCONSO (SAB=NCI -> CUI) and the UNII records' NCIT column; RXCUIs ride along in the same cliques.
+    # This is food *evidence* for the type vote, not an override: see chemicals.create_typed_sets.
+    input:
+        mrconso=config["download_directory"] + "/UMLS/MRCONSO.RRF",
+        unii_records=config["download_directory"] + "/UNII/Latest_UNII_Records.txt",
+        food_ncit_codes=config["intermediate_directory"] + "/chemicals/ids/ncit_food_codes",
+        nonfood_ncit_codes=config["intermediate_directory"] + "/chemicals/ids/ncit_nonfood_codes",
+    output:
+        outfile=config["intermediate_directory"] + "/chemicals/ids/ncit_food_types",
+    benchmark:
+        config["output_directory"] + "/benchmarks/chemical_ncit_food_types.tsv"
+    run:
+        chemicals.write_ncit_food_types(
+            input.mrconso,
+            input.unii_records,
+            input.food_ncit_codes,
+            input.nonfood_ncit_codes,
             output.outfile,
         )
 
@@ -394,7 +419,10 @@ rule chemical_compendia:
         metadata_yamls=[config["intermediate_directory"] + "/chemicals/partials/metadata-untyped_compendium.yaml"],
         properties_jsonl_gz=[config["intermediate_directory"] + "/chemicals/properties/get_chebi_concord.jsonl.gz"],
         icrdf_filename=config["download_directory"] + "/icRDF.tsv",
-        food_extract_types=config["intermediate_directory"] + "/chemicals/ids/DRUGBANK_food_extracts",
+        food_types=[
+            config["intermediate_directory"] + "/chemicals/ids/DRUGBANK_food_extracts",
+            config["intermediate_directory"] + "/chemicals/ids/ncit_food_types",
+        ],
     output:
         expand("{od}/compendia/{ap}", od=config["output_directory"], ap=config["chemical_outputs"]),
         temp(expand("{od}/synonyms/{ap}", od=config["output_directory"], ap=config["chemical_outputs"])),
@@ -411,7 +439,7 @@ rule chemical_compendia:
             input.properties_jsonl_gz,
             input.metadata_yamls,
             input.icrdf_filename,
-            input.food_extract_types,
+            input.food_types,
         )
 
 

--- a/src/ubergraph.py
+++ b/src/ubergraph.py
@@ -292,7 +292,7 @@ class UberGraph:
         non-redundant graph, where UberGraph keeps the asserted rdfs:subClassOf edges, rather than
         the closure in the redundant graph. Written for the DrugBank food-and-extract audit CSVs
         (issue #828), where a reviewer needs to see what sits immediately above an entry's NCIt class
-        in order to propose the next drugbank_nonfood_ncit_roots entry; the full ancestor closure is
+        in order to propose the next nonfood_ncit_roots entry; the full ancestor closure is
         too long to read.
 
         :param curies: An iterable of CURIEs to look up.

--- a/tests/createcompendia/test_chemicals.py
+++ b/tests/createcompendia/test_chemicals.py
@@ -10,7 +10,7 @@ import gzip
 
 import pytest
 
-from src.categories import COMPLEX_MOLECULAR_MIXTURE, FOOD, SMALL_MOLECULE
+from src.categories import CHEMICAL_ENTITY, COMPLEX_MOLECULAR_MIXTURE, FOOD, SMALL_MOLECULE
 from src.createcompendia.chemicals import create_typed_sets, write_unichem_concords
 from src.datahandlers.unichem import UNICHEM_REFERENCE_TSV_HEADER, UNICHEM_STRUCT_TSV_HEADER
 from src.datahandlers.unichem import data_sources as unichem_data_sources
@@ -91,37 +91,65 @@ def test_write_unichem_concords_raises_when_source_produces_no_entries(tmp_path)
 
 
 @pytest.mark.unit
-def test_create_typed_sets_forces_food_clique():
-    """A clique containing a DRUGBANK CURIE forced to Food should be typed biolink:Food regardless of
-    its other members' types, and keep every member (incl. RXCUI)."""
+def test_create_typed_sets_food_evidence_beats_chemical_entity():
+    """Food evidence on a clique whose members only vote ChemicalEntity should win: ChemicalEntity is
+    exactly the uninformative type the retype exists to improve on. Every member (incl. RXCUI) is kept."""
     trout = frozenset({"DRUGBANK:DB10626", "UMLS:C2725895", "RXCUI:882482"})
-    # A member is typed ChemicalEntity, which would otherwise win the vote — the forced type must override.
-    types = {"UMLS:C2725895": "biolink:ChemicalEntity"}
+    types = {"UMLS:C2725895": CHEMICAL_ENTITY}
 
-    typed = create_typed_sets({trout}, types, forced_types={"DRUGBANK:DB10626": FOOD})
+    typed = create_typed_sets({trout}, types, food_types={"DRUGBANK:DB10626": FOOD})
 
     assert trout in typed[FOOD]
     assert all(trout not in sets for t, sets in typed.items() if t != FOOD)
 
 
 @pytest.mark.unit
-def test_create_typed_sets_forces_non_food_allergen_to_mixture():
-    """A DRUGBANK allergen extract forced to ComplexMolecularMixture lands there, not in Food."""
+def test_create_typed_sets_food_evidence_loses_to_small_molecule():
+    """Food evidence must NOT demote a defined molecule: NCIt classifies water as a food, but its clique
+    votes SmallMolecule, which is more specific and wins (issue #935)."""
+    water = frozenset({"UNII:059QF0KO0R", "CHEBI:15377", "PUBCHEM.COMPOUND:962"})
+    types = {"CHEBI:15377": SMALL_MOLECULE, "PUBCHEM.COMPOUND:962": SMALL_MOLECULE}
+
+    typed = create_typed_sets({water}, types, food_types={"UNII:059QF0KO0R": FOOD})
+
+    assert water in typed[SMALL_MOLECULE]
+    assert water not in typed[FOOD]
+
+
+@pytest.mark.unit
+def test_create_typed_sets_extract_evidence_becomes_complex_molecular_mixture():
+    """A DrugBank extract carries ComplexMolecularMixture evidence and lands there, not in Food."""
     pollen = frozenset({"DRUGBANK:DB10351", "UMLS:C2684343"})
 
-    typed = create_typed_sets({pollen}, {}, forced_types={"DRUGBANK:DB10351": COMPLEX_MOLECULAR_MIXTURE})
+    typed = create_typed_sets({pollen}, {}, food_types={"DRUGBANK:DB10351": COMPLEX_MOLECULAR_MIXTURE})
 
     assert pollen in typed[COMPLEX_MOLECULAR_MIXTURE]
     assert pollen not in typed[FOOD]
 
 
 @pytest.mark.unit
-def test_create_typed_sets_leaves_non_forced_clique_untouched():
-    """A clique with no forced-type CURIE should keep its normal type (no forced_types leakage)."""
+def test_create_typed_sets_extract_evidence_beats_food_evidence():
+    """When a clique carries both kinds of evidence — DrugBank says extract, NCIt says the same concept is
+    a food — the extract wins, because ComplexMolecularMixture outranks Food."""
+    green_tea = frozenset({"DRUGBANK:DB13246", "UMLS:C0376263"})
+
+    typed = create_typed_sets(
+        {green_tea},
+        {},
+        food_types={"DRUGBANK:DB13246": COMPLEX_MOLECULAR_MIXTURE, "UMLS:C0376263": FOOD},
+    )
+
+    assert green_tea in typed[COMPLEX_MOLECULAR_MIXTURE]
+    assert green_tea not in typed[FOOD]
+
+
+@pytest.mark.unit
+def test_create_typed_sets_leaves_clique_without_food_evidence_untouched():
+    """A clique carrying no food/extract evidence keeps its normal type (no food_types leakage)."""
     normal = frozenset({"CHEBI:15377", "PUBCHEM.COMPOUND:962"})
     types = {"CHEBI:15377": SMALL_MOLECULE, "PUBCHEM.COMPOUND:962": SMALL_MOLECULE}
 
-    typed = create_typed_sets({normal}, types, forced_types={"DRUGBANK:DB10626": FOOD})
+    typed = create_typed_sets({normal}, types, food_types={"DRUGBANK:DB10626": FOOD})
 
     assert normal in typed[SMALL_MOLECULE]
     assert normal not in typed[FOOD]

--- a/tests/createcompendia/test_chemicals.py
+++ b/tests/createcompendia/test_chemicals.py
@@ -11,7 +11,8 @@ import gzip
 import pytest
 
 from src.categories import CHEMICAL_ENTITY, COMPLEX_MOLECULAR_MIXTURE, FOOD, SMALL_MOLECULE
-from src.createcompendia.chemicals import create_typed_sets, write_unichem_concords
+from src.createcompendia.chemicals import create_typed_sets, write_ncit_food_types, write_unichem_concords
+from src.datahandlers.umls import MRCONSO_CODE_COLUMN, MRCONSO_CUI_COLUMN, MRCONSO_SAB_COLUMN
 from src.datahandlers.unichem import UNICHEM_REFERENCE_TSV_HEADER, UNICHEM_STRUCT_TSV_HEADER
 from src.datahandlers.unichem import data_sources as unichem_data_sources
 from src.prefixes import CHEBI
@@ -153,3 +154,67 @@ def test_create_typed_sets_leaves_clique_without_food_evidence_untouched():
 
     assert normal in typed[SMALL_MOLECULE]
     assert normal not in typed[FOOD]
+
+
+# ----
+# write_ncit_food_types (issue #935)
+# ----
+
+
+def _write_mrconso(path, rows):
+    """Write an MRCONSO.RRF fragment. Each row is (CUI, SAB, CODE); other columns are padded."""
+    with open(path, "w") as out:
+        for cui, sab, code in rows:
+            fields = [""] * 18
+            fields[MRCONSO_CUI_COLUMN] = cui
+            fields[MRCONSO_SAB_COLUMN] = sab
+            fields[MRCONSO_CODE_COLUMN] = code
+            out.write("|".join(fields) + "\n")
+
+
+def _write_unii_records_for_food(path, rows):
+    """Write a UNII records TSV. Each row is a dict of column -> value; missing columns are blank."""
+    header = ["UNII", "Display Name", "NCIT", "INCHIKEY"]
+    with open(path, "w", encoding="windows-1252") as out:
+        out.write("\t".join(header) + "\n")
+        for row in rows:
+            out.write("\t".join(row.get(col, "") for col in header) + "\n")
+
+
+@pytest.mark.unit
+def test_write_ncit_food_types_projects_ncit_foods_onto_umls_and_unii(tmp_path):
+    """NCIt's food classification should reach the identifiers that are actually in chemical cliques: the
+    CUI of every SAB=NCI food code, and every structureless UNII whose NCIt class is a food. A UNII with an
+    InChI Key is skipped (a defined molecule is typed from its structure), and a never-food code (an
+    imaging agent) contributes nothing even if it somehow appears under a food root."""
+    mrconso = tmp_path / "MRCONSO.RRF"
+    _write_mrconso(
+        mrconso,
+        [
+            ("C0039299", "NCI", "C71920"),  # swordfish -> food code
+            ("C0039299", "MSH", "D013530"),  # same CUI, non-NCI source: must not matter
+            ("C0596170", "NCI", "C487"),  # ethiodized oil -> never-food code
+            ("C0012345", "NCI", "C99999"),  # not a food code at all
+        ],
+    )
+    records = tmp_path / "Latest_UNII_Records.txt"
+    _write_unii_records_for_food(
+        records,
+        [
+            {"UNII": "SWORDFISH1", "Display Name": "SWORDFISH", "NCIT": "C71920"},  # structureless food
+            {"UNII": "059QF0KO0R", "Display Name": "WATER", "NCIT": "C71920", "INCHIKEY": "XLYOFNOQ-UHFF"},
+            {"UNII": "NOTAFOOD01", "Display Name": "SOMETHING", "NCIT": "C99999"},  # not a food code
+        ],
+    )
+    food_codes = tmp_path / "ncit_food_codes"
+    food_codes.write_text("NCIT:C71920\nNCIT:C487\n")  # C487 is (implausibly) under a food root too...
+    nonfood_codes = tmp_path / "ncit_nonfood_codes"
+    nonfood_codes.write_text("NCIT:C487\n")  # ...but the never-food veto removes it
+    outfile = tmp_path / "ncit_food_types"
+
+    write_ncit_food_types(str(mrconso), str(records), str(food_codes), str(nonfood_codes), str(outfile))
+
+    assert set(outfile.read_text().splitlines()) == {
+        f"UMLS:C0039299\t{FOOD}",
+        f"UNII:SWORDFISH1\t{FOOD}",
+    }


### PR DESCRIPTION
Closes #935. Generalizes #828 / #918.

> [!NOTE]
> **Draft, and stacked on #918.** The base branch is `retype-allergenic-extracts-as-food`, so this diff shows only the two commits added on top. Retarget to `main` once #918 merges.

## What

#918 types **DrugBank** food entries as `biolink:Food` using their UNII's NCIt classification. The same NCIt evidence exists for concepts DrugBank never mentions — swordfish, capsicum, cranberry, corn — so this projects it onto them as well.

## Why "type the NCIt ids and let the xrefs inherit it" doesn't work

`NCIT` is in neither `chemical_ids` nor `chemical_concords`, so **no `NCIT:` CURIE is ever a member of a chemical clique**. There is nothing to inherit *from*. The classification has to be projected onto the identifiers that *are* members (`chemical_ncit_food_types` → `ids/ncit_food_types`):

- **UMLS** — `MRCONSO.RRF` `SAB=NCI` rows map an NCIt code to its CUI: **997 CUIs**.
- **UNII** — the FDA UNII records' `NCIT` column: **286 UNIIs**.
- **RxNorm** — nothing of its own; an `RXCUI` rides along in the same clique.

## The naive version retypes water

NCIt classifies **water, riboflavin, isoleucine, beta carotene and iodide ion** as foods — 301 of the 587 NCIt-food UNIIs carry an InChI Key. And `create_typed_sets` used to *force* a clique's type whenever a member carried food evidence, `continue`-ing past the type vote entirely (so `FOOD` being first in `order` was never what made a forced Food win — the vote simply did not run).

So the first commit makes the evidence a **vote** instead, and re-ranks `order`:

```text
Drug > MolecularMixture > SmallMolecule > Polypeptide > ComplexMolecularMixture > Food
     > ChemicalMixture > ChemicalEntity
```

`Food` sits below every structure-bearing type and above the uninformative `ChemicalMixture`/`ChemicalEntity` it exists to improve on. Consequently:

- **Water stays a `SmallMolecule`** — `UMLS:C0043047` "Water" *does* carry food evidence in the output; its clique votes `SmallMolecule`, which wins.
- **Swordfish becomes `Food`** — its clique votes nothing but `ChemicalEntity`.
- **An extract stays an extract** — `ComplexMolecularMixture` outranks `Food`.

The "no InChI Key" structure guard #828 hard-codes becomes an emergent property of the ordering. The UNII structure guard is kept anyway as a cheap second belt.

## Is it a no-op for #918's 685 cliques?

It should be, and the concords say it is: **672 of the 685 have concord partners (1326 links), and every partner is typed `ChemicalEntity`** — nothing in those cliques outranks `Food`/`ComplexMolecularMixture`, so the re-ranking cannot move them. That was an untested assertion in the food-and-extracts README until now.

**Still to do before this leaves draft:** a full `chemical` build and a `babel-clique-diff` against a pre-change build, to confirm the no-op on real cliques rather than on concord-derived approximations, and to eyeball what the 1283 new pieces of evidence actually retype.

## Also here

- `drugbank_{food,nonfood}_ncit_roots` → `{food,nonfood}_ncit_roots`: they stop being DrugBank-specific.
- MRCONSO/MRSTY column offsets promoted into `umls.py` rather than a third copy.
- New [`docs/sources/NCIT/food-typing.md`](docs/sources/NCIT/food-typing.md); the DrugBank README's now-false "overrides the type vote" claim is corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
