### PR TITLE
Distribute compendia as .txt.gz

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -23,7 +23,8 @@ include: "src/snakefiles/exports.snakefile"
 
 # Some general imports.
 import shutil
-from src.snakefiles.util import write_done
+from src.snakefiles import util
+from src.snakefiles.util import get_all_compendia, write_done
 
 # Some global settings.
 import os
@@ -110,3 +111,49 @@ rule uncompress_synonym_file:
         config["output_directory"] + "/benchmarks/uncompress_synonym_file_{synonym_file}.tsv"
     shell:
         "gunzip {input} -c > {output}"
+
+
+# Compendia are distributed as .txt.gz. Unlike a synonyms file -- which has exactly one consumer,
+# its own semantic type's rule, and so is compressed there -- a compendium is read by jobs across
+# the pipeline (DuckDB/Parquet export, KGX export, leftover_umls, both conflations, and the
+# per-compendium content reports). So compression gets its own rule, gated behind all of them.
+#
+# The compendia .txt are temp(), so Snakemake deletes each one as soon as its last consumer job
+# finishes. Because this rule is gated last, that is immediately after compression, and the two
+# copies never sit on disk together for long. Note that temp() only fires for consumers actually
+# in the DAG: a partial target such as `snakemake chemical` does not pull this rule in, so partial
+# builds leave their .txt files in place.
+#
+# There is deliberately no uncompress_compendium_file counterpart: a wildcard .txt.gz -> .txt rule
+# alongside this wildcard .txt -> .txt.gz one would be mutually satisfiable and risks an
+# AmbiguousRuleException. Use `gunzip -k` by hand if you need a .txt back from a finished build.
+rule compress_compendium:
+    input:
+        compendium=config["output_directory"] + "/compendia/{filename}.txt",
+        # Every job that reads an uncompressed compendium, so that temp() can reclaim the .txt
+        # the moment this rule finishes.
+        outputs_done=config["output_directory"] + "/reports/outputs_done",
+        duckdb_done=config["output_directory"] + "/duckdb/done",
+        kgx_done=config["output_directory"] + "/kgx/done",
+        # The individual content reports rather than reports/reports_done, so that
+        # check_compendia_gzipped_files can depend on this rule's output without a cycle.
+        content_reports=expand(
+            "{od}/reports/content/compendia/{stem}.json",
+            od=config["output_directory"],
+            stem=[os.path.splitext(fn)[0] for fn in get_all_compendia(config)],
+        ),
+    output:
+        gzipped=config["output_directory"] + "/compendia/{filename}.txt.gz",
+    benchmark:
+        config["output_directory"] + "/benchmarks/compress_compendium_{filename}.tsv"
+    resources:
+        # Single-threaded stdlib gzip; Protein.txt is the worst case. Matches the budget
+        # `rule protein` already carries for the comparable synonyms compression.
+        runtime="6h",
+    run:
+        # gzip_files() is the stdlib gzip module, so this is single-threaded, and all 25 of these
+        # jobs sit at the tail of the DAG. If that tail dominates wall-clock time, switch to pigz:
+        # it is multi-threaded and its output is standard gzip, so no consumer changes. Check
+        # benchmarks/compress_compendium_Protein.tsv after a full cluster run before deciding.
+        # See https://github.com/NCATSTranslator/Babel/issues/946.
+        util.gzip_files([input.compendium])

--- a/docs/DataFormats.md
+++ b/docs/DataFormats.md
@@ -5,8 +5,13 @@ There are three custom formats used within Babel outputs.
 ## Compendia files
 
 Compendia files are JSON Lines (JSONL) files in the `compendia/` directory. Each line consists of a
-single "clique" -- a set of identifiers that Babel believes represents the same concept. Here is an
-example from `compendia/Gene.txt` for the
+single "clique" -- a set of identifiers that Babel believes represents the same concept.
+
+A finished build distributes these gzipped, as `compendia/Gene.txt.gz`. The uncompressed
+`compendia/Gene.txt` exists only while the build is running: it is a Snakemake `temp()` output that
+`rule compress_compendium` replaces once every job that reads it has finished (see
+[Running Babel](RunningBabel.md#compendia-are-compressed-at-the-end-of-a-full-build)). Consumers
+should therefore expect `.txt.gz`. Here is an example from `compendia/Gene.txt.gz` for the
 [glucose-6-phosphatase catalytic subunit 1 (G6PC1)](https://www.ncbi.nlm.nih.gov/gene/2538) gene.
 
 ```json

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -15,12 +15,19 @@ to users who aren't system administrators for these tools:
 1. Create a new Babel release (see README.md for information).
 2. Store the Babel outputs alongside other Babel releases on Hatteras.
 3. Deploy a new NodeNorm instance
-   1. Split the Babel outputs into smaller files to improve load times and put them on a public web
-      server.
-   2. Update the Translator-devops repo with the URL to these Babel output files.
-   3. Create a [Redis R3 External] instance to store identifiers.
-   4. Run the [NodeNorm loader] to load the Babel outputs into a Redis instance.
-   5. Create a [NodeNorm web server] to share the data in a Redis instance.
+   1. Put the Babel outputs on a public web server. Compendia are distributed gzipped
+      (`compendia/Gene.txt.gz`) — see [Compendia files](DataFormats.md#compendia-files). **This
+      requires a NodeNorm loader that can read gzipped compendia**; see
+      [Loader requirements](#loader-requirements) below.
+   2. Historically this step also split the largest compendia (`Protein.txt`, `Publication.txt`,
+      `SmallMolecule.txt`, `Gene.txt`) with `split -d -l 10000000`, because the loader was slow on
+      large files. The loader rewrite in
+      [NodeNormalization#384](https://github.com/NCATSTranslator/NodeNormalization/pull/384) is
+      substantially faster, so check whether splitting is still needed before doing it.
+   3. Update the Translator-devops repo with the URL to these Babel output files.
+   4. Create a [Redis R3 External] instance to store identifiers.
+   5. Run the [NodeNorm loader] to load the Babel outputs into a Redis instance.
+   6. Create a [NodeNorm web server] to share the data in a Redis instance.
 4. Deploy a new NameRes instance (either
    [locally](https://github.com/NCATSTranslator/NameResolution/blob/master/documentation/Deployment.md)
    or
@@ -52,6 +59,19 @@ to users who aren't system administrators for these tools:
     9. Ask ITRB to start the NodeNorm Prod instance.
 11. Use the [Babel Validator] to test this release and check how it performs compared to the
     previous release. As a side-benefit, running these tests will warm up NameRes Solr's caches.
+
+## Loader requirements
+
+Babel compresses its compendia (`compendia/*.txt.gz`) as of the change that added
+`rule compress_compendium`. The [NodeNorm loader] must therefore be able to read gzipped compendia
+before a release built this way can be deployed. At the time of writing the loader opens compendia
+with a plain `open()` in `node_normalizer/loader/loader.py` (the validation read and the main
+ingest read), so it needs a suffix-keyed `gzip.open(..., "rt")`; Babel's output is standard gzip,
+so nothing more exotic is required. Tracked as
+[NodeNormalization#397](https://github.com/NCATSTranslator/NodeNormalization/issues/397).
+
+If you are deploying against a loader that predates that change, gunzip the compendia as part of
+step 3.1 rather than serving the `.gz` directly.
 
 [Babel Validator]: https://github.com/TranslatorSRI/babel-validation
 [Redis R3 External]: https://github.com/helxplatform/translator-devops/tree/ed25b5f5bfe2383ade8457da97341c90500f5291/helm/redis-r3-external

--- a/docs/RunningBabel.md
+++ b/docs/RunningBabel.md
@@ -119,6 +119,27 @@ The `baseline/` and `updatefiles/` directories are deliberately *not* declared a
 outputs of `download_pubmed`. Snakemake recursively deletes existing `directory()` outputs before
 running a job, which would delete anything preloaded into them.
 
+### Compendia are compressed at the end of a full build
+
+A finished build ships `compendia/*.txt.gz`, not `compendia/*.txt`. The uncompressed file is a
+Snakemake `temp()` output: `rule compress_compendium` (root `Snakefile`) gzips each compendium and
+Snakemake then deletes the `.txt`. That rule is gated behind every job that reads an uncompressed
+compendium — the DuckDB/Parquet export, the KGX export, `leftover_umls`, both conflations, and the
+per-compendium content reports — so the `.txt` survives for exactly as long as something needs it,
+and the two copies never sit on disk together for long.
+
+Two consequences worth knowing:
+
+* **Partial targets are unaffected.** `temp()` only fires for consumers that are actually in the
+  DAG, and a per-type target such as `uv run snakemake --cores 1 anatomy` does not pull in
+  `compress_compendium`. Partial builds leave their `compendia/*.txt` in place, uncompressed, which
+  is what you want while iterating on one semantic type.
+* **Getting a `.txt` back.** There is deliberately no `uncompress_compendium_file` rule — a wildcard
+  `.txt.gz → .txt` rule alongside the wildcard `.txt → .txt.gz` one would be mutually satisfiable
+  and risks an `AmbiguousRuleException`. Use `gunzip -k compendia/Gene.txt.gz` by hand. The repo's
+  own tools do not need this: `babel-clique-diff` and `source-impact-report` read either form (see
+  `resolve_compendium_path` in `src/model/compendium_diff.py`).
+
 ### Common build issues
 
 * **Stale Snakemake lock.** If a previous run was killed (Ctrl-C, OOM, power loss) Snakemake

--- a/src/exporters/duckdb_exporters.py
+++ b/src/exporters/duckdb_exporters.py
@@ -61,6 +61,10 @@ def log_duckdb_settings_on_error(db, operation):
 
 
 # Some configuration items for controlling loads.
+# NOTE: the over-threshold path below chunks the compendium with a plain open(), so it requires an
+# uncompressed input. That holds because export_compendia_to_duckdb runs strictly before
+# rule compress_compendium (see the root Snakefile), so it always sees the .txt. If that ordering
+# ever changes, this chunker needs a gzip-aware reader — DuckDB's read_json() already handles .gz.
 MIN_FILE_SIZE_FOR_SPLITTING_LOAD = 44_000_000_000
 CHUNK_LINE_SIZE = 60_000_000
 

--- a/src/model/compendium_diff.py
+++ b/src/model/compendium_diff.py
@@ -31,6 +31,7 @@ The CLI wrapper is :mod:`src.tools.clique_diff.cli` (``babel-clique-diff``); see
 
 from __future__ import annotations
 
+import gzip
 import heapq
 import json
 import pathlib
@@ -64,12 +65,33 @@ DROPPED_KEY = ("", DROPPED)
 
 
 def load_compendium(path: pathlib.Path | str) -> Iterator[dict]:
-    """Stream clique dicts from a JSONL compendium file, skipping blank lines."""
-    with open(path) as inf:
+    """Stream clique dicts from a JSONL compendium file, skipping blank lines.
+
+    Accepts both the uncompressed ``.txt`` a running pipeline produces and the ``.txt.gz`` a
+    finished build distributes (see ``rule compress_compendium`` in the root ``Snakefile``), so
+    the diff tools work against either an in-progress or a released build.
+    """
+    opener = gzip.open if str(path).endswith(".gz") else open
+    with opener(path, "rt") as inf:
         for line in inf:
             line = line.strip()
             if line:
                 yield json.loads(line)
+
+
+def resolve_compendium_path(root: pathlib.Path | str, filename: str) -> pathlib.Path | None:
+    """Find a compendium in ``root``, preferring the uncompressed form over the gzipped one.
+
+    ``filename`` is the bare compendium name as it appears in ``config.yaml``'s ``*_outputs``
+    lists (e.g. ``Disease.txt``). A build in progress has the ``.txt``; a finished one has only
+    the ``.txt.gz``. Returns ``None`` when neither exists, so callers keep their existing
+    "skip what isn't there" behaviour.
+    """
+    root = pathlib.Path(root)
+    for candidate in (root / filename, root / f"{filename}.gz"):
+        if candidate.exists():
+            return candidate
+    return None
 
 
 @dataclass
@@ -230,10 +252,13 @@ def diff_builds(before_dir, after_dir, filenames):
     before_by_file, after_by_file = {}, {}
     after_location = {}
     for fname in filenames:
-        before_path = pathlib.Path(before_dir) / fname
-        after_path = pathlib.Path(after_dir) / fname
-        if not before_path.exists() or not after_path.exists():
-            raise FileNotFoundError(f"Missing compendium {fname} in before ({before_path}) or after ({after_path})")
+        # Either build may be an in-progress one (.txt) or a released one (.txt.gz).
+        before_path = resolve_compendium_path(before_dir, fname)
+        after_path = resolve_compendium_path(after_dir, fname)
+        if before_path is None or after_path is None:
+            raise FileNotFoundError(
+                f"Missing compendium {fname} (as .txt or .txt.gz) in before ({before_dir}) or after ({after_dir})"
+            )
         before_by_file[fname] = load_cliques(before_path, need_curie_to_leader=False)
         after = load_cliques(after_path)
         after_by_file[fname] = after

--- a/src/snakefiles/anatomy.snakefile
+++ b/src/snakefiles/anatomy.snakefile
@@ -125,7 +125,7 @@ rule anatomy_compendia:
         idlists=expand("{dd}/anatomy/ids/{ap}", dd=config["intermediate_directory"], ap=config["anatomy_ids"]),
         icrdf_filename=config["download_directory"] + "/icRDF.tsv",
     output:
-        expand("{od}/compendia/{ap}", od=config["output_directory"], ap=config["anatomy_outputs"]),
+        temp(expand("{od}/compendia/{ap}", od=config["output_directory"], ap=config["anatomy_outputs"])),
         temp(expand("{od}/synonyms/{ap}", od=config["output_directory"], ap=config["anatomy_outputs"])),
         expand("{od}/metadata/{ap}.yaml", od=config["output_directory"], ap=config["anatomy_outputs"]),
     benchmark:

--- a/src/snakefiles/cell_line.snakefile
+++ b/src/snakefiles/cell_line.snakefile
@@ -32,7 +32,7 @@ rule cell_line_compendia:
         metadatafile=config["download_directory"] + "/CLO/metadata.yaml",
         icrdf_filename=config["download_directory"] + "/icRDF.tsv",
     output:
-        config["output_directory"] + "/compendia/CellLine.txt",
+        temp(config["output_directory"] + "/compendia/CellLine.txt"),
         temp(config["output_directory"] + "/synonyms/CellLine.txt"),
         config["output_directory"] + "/metadata/CellLine.txt.yaml",
     benchmark:

--- a/src/snakefiles/chemical.snakefile
+++ b/src/snakefiles/chemical.snakefile
@@ -399,7 +399,7 @@ rule chemical_compendia:
         # here; today that is only the DRUGBANK food-and-extract retype (issue #828).
         forced_type_files=[config["intermediate_directory"] + "/chemicals/ids/DRUGBANK_food_extracts"],
     output:
-        expand("{od}/compendia/{ap}", od=config["output_directory"], ap=config["chemical_outputs"]),
+        temp(expand("{od}/compendia/{ap}", od=config["output_directory"], ap=config["chemical_outputs"])),
         temp(expand("{od}/synonyms/{ap}", od=config["output_directory"], ap=config["chemical_outputs"])),
         expand("{od}/metadata/{ap}.yaml", od=config["output_directory"], ap=config["chemical_outputs"]),
     benchmark:

--- a/src/snakefiles/diseasephenotype.snakefile
+++ b/src/snakefiles/diseasephenotype.snakefile
@@ -278,7 +278,7 @@ rule disease_compendia:
         taxa=expand("{dd}/{ap}/taxa", dd=config["download_directory"], ap=config["disease_phenotype_taxa"]),
         icrdf_filename=config["download_directory"] + "/icRDF.tsv",
     output:
-        expand("{od}/compendia/{ap}", od=config["output_directory"], ap=config["disease_outputs"]),
+        temp(expand("{od}/compendia/{ap}", od=config["output_directory"], ap=config["disease_outputs"])),
         temp(expand("{od}/synonyms/{ap}", od=config["output_directory"], ap=config["disease_outputs"])),
         expand("{od}/metadata/{ap}.yaml", od=config["output_directory"], ap=config["disease_outputs"]),
     benchmark:

--- a/src/snakefiles/gene.snakefile
+++ b/src/snakefiles/gene.snakefile
@@ -195,7 +195,7 @@ rule gene_compendia:
         idlists=expand("{dd}/gene/ids/{ap}", dd=config["intermediate_directory"], ap=config["gene_ids"]),
         icrdf_filename=config["download_directory"] + "/icRDF.tsv",
     output:
-        expand("{od}/compendia/{ap}", od=config["output_directory"], ap=config["gene_outputs"]),
+        temp(expand("{od}/compendia/{ap}", od=config["output_directory"], ap=config["gene_outputs"])),
         temp(expand("{od}/synonyms/{ap}", od=config["output_directory"], ap=config["gene_outputs"])),
         expand("{od}/metadata/{ap}.yaml", od=config["output_directory"], ap=config["gene_outputs"]),
     benchmark:

--- a/src/snakefiles/genefamily.snakefile
+++ b/src/snakefiles/genefamily.snakefile
@@ -36,7 +36,7 @@ rule genefamily_compendia:
         ),
         icrdf_filename=config["download_directory"] + "/icRDF.tsv",
     output:
-        expand("{od}/compendia/{ap}", od=config["output_directory"], ap=config["genefamily_outputs"]),
+        temp(expand("{od}/compendia/{ap}", od=config["output_directory"], ap=config["genefamily_outputs"])),
         temp(expand("{od}/synonyms/{ap}", od=config["output_directory"], ap=config["genefamily_outputs"])),
         metadata_yaml=config["output_directory"] + "/metadata/GeneFamily.txt.yaml",
     benchmark:

--- a/src/snakefiles/leftover_umls.snakefile
+++ b/src/snakefiles/leftover_umls.snakefile
@@ -38,7 +38,7 @@ rule leftover_umls:
         umls_metadata_yaml=config["download_directory"] + "/UMLS/UMLS.metadata.yaml",
         icrdf_filename=config["download_directory"] + "/icRDF.tsv",
     output:
-        umls_compendium=config["output_directory"] + "/compendia/umls.txt",
+        umls_compendium=temp(config["output_directory"] + "/compendia/umls.txt"),
         umls_synonyms=temp(config["output_directory"] + "/synonyms/umls.txt"),
         umls_metadata_yaml=config["output_directory"] + "/metadata/umls.txt.yaml",
         report=config["output_directory"] + "/reports/umls/log.txt",

--- a/src/snakefiles/macromolecular_complex.snakefile
+++ b/src/snakefiles/macromolecular_complex.snakefile
@@ -13,7 +13,7 @@ rule macromolecular_complex_compendia:
         metadata_yaml=config["download_directory"] + "/ComplexPortal/metadata.yaml",
         icrdf_filename=config["download_directory"] + "/icRDF.tsv",
     output:
-        config["output_directory"] + "/compendia/MacromolecularComplex.txt",
+        temp(config["output_directory"] + "/compendia/MacromolecularComplex.txt"),
         temp(config["output_directory"] + "/synonyms/MacromolecularComplex.txt"),
         output_metadata_yaml=config["output_directory"] + "/metadata/MacromolecularComplex.txt.yaml",
     benchmark:

--- a/src/snakefiles/process.snakefile
+++ b/src/snakefiles/process.snakefile
@@ -136,7 +136,7 @@ rule process_compendia:
         idlists=expand("{dd}/process/ids/{ap}", dd=config["intermediate_directory"], ap=config["process_ids"]),
         icrdf_filename=config["download_directory"] + "/icRDF.tsv",
     output:
-        expand("{od}/compendia/{ap}", od=config["output_directory"], ap=config["process_outputs"]),
+        temp(expand("{od}/compendia/{ap}", od=config["output_directory"], ap=config["process_outputs"])),
         temp(expand("{od}/synonyms/{ap}", od=config["output_directory"], ap=config["process_outputs"])),
         expand("{od}/metadata/{ap}.yaml", od=config["output_directory"], ap=config["process_outputs"]),
     benchmark:

--- a/src/snakefiles/protein.snakefile
+++ b/src/snakefiles/protein.snakefile
@@ -149,7 +149,7 @@ rule protein_compendia:
         # Include the taxon information from UniProtKB
         uniprotkb_taxa_file=config["download_directory"] + "/UniProtKB/taxa",
     output:
-        expand("{od}/compendia/{ap}", od=config["output_directory"], ap=config["protein_outputs"]),
+        temp(expand("{od}/compendia/{ap}", od=config["output_directory"], ap=config["protein_outputs"])),
         temp(expand("{od}/synonyms/{ap}", od=config["output_directory"], ap=config["protein_outputs"])),
         expand("{od}/metadata/{ap}.yaml", od=config["output_directory"], ap=config["protein_outputs"]),
     benchmark:

--- a/src/snakefiles/publications.snakefile
+++ b/src/snakefiles/publications.snakefile
@@ -90,7 +90,7 @@ rule generate_pubmed_compendia:
         metadata_yaml=config["intermediate_directory"] + "/publications/concords/metadata.yaml",
         icrdf_filename=config["download_directory"] + "/icRDF.tsv",
     output:
-        publication_compendium=config["output_directory"] + "/compendia/Publication.txt",
+        publication_compendium=temp(config["output_directory"] + "/compendia/Publication.txt"),
         # We generate an empty Publication Synonyms files, but we still need to generate one.
         publication_synonyms_gz=config["output_directory"] + "/synonyms/Publication.txt.gz",
         publication_metadata_yaml=config["output_directory"] + "/metadata/Publication.txt.yaml",

--- a/src/snakefiles/reports.snakefile
+++ b/src/snakefiles/reports.snakefile
@@ -28,17 +28,19 @@ localrules:
     all_reports,
 
 
-# Make sure we have all the expected Compendia files.
-rule check_compendia_files:
+# Make sure we have all the expected Compendia files, in their distributed (gzipped) form.
+rule check_compendia_gzipped_files:
     input:
-        # Don't run this until all the outputs have been generated.
-        config["output_directory"] + "/reports/outputs_done",
+        # Taking the .gz files themselves as input (rather than reports/outputs_done) is what
+        # orders this check after rule compress_compendium. That rule in turn gates on the
+        # individual content reports rather than on reports_done, so this does not form a cycle.
+        gzipped=expand("{od}/compendia/{fn}.gz", od=config["output_directory"], fn=get_all_compendia(config)),
     output:
         donefile=config["output_directory"] + "/reports/check_compendia_files.done",
     benchmark:
-        config["output_directory"] + "/benchmarks/check_compendia_files.tsv"
+        config["output_directory"] + "/benchmarks/check_compendia_gzipped_files.tsv"
     run:
-        assert_files_in_directory(compendia_path, compendia_files, output.donefile)
+        assert_files_in_directory(compendia_path, get_all_gzipped(compendia_files), output.donefile)
 
 
 # Make sure we have all the expected Synonyms files.

--- a/src/snakefiles/taxon.snakefile
+++ b/src/snakefiles/taxon.snakefile
@@ -76,7 +76,7 @@ rule taxon_compendia:
         idlists=expand("{dd}/taxon/ids/{ap}", dd=config["intermediate_directory"], ap=config["taxon_ids"]),
         icrdf_filename=config["download_directory"] + "/icRDF.tsv",
     output:
-        expand("{od}/compendia/{ap}", od=config["output_directory"], ap=config["taxon_outputs"]),
+        temp(expand("{od}/compendia/{ap}", od=config["output_directory"], ap=config["taxon_outputs"])),
         temp(expand("{od}/synonyms/{ap}", od=config["output_directory"], ap=config["taxon_outputs"])),
         output_metadata=expand("{od}/metadata/{ap}.yaml", od=config["output_directory"], ap=config["taxon_outputs"]),
     benchmark:

--- a/src/tools/source_impact_report/cli.py
+++ b/src/tools/source_impact_report/cli.py
@@ -32,7 +32,7 @@ from src.categories import (
     GROSS_ANATOMICAL_STRUCTURE,
     PHENOTYPIC_FEATURE,
 )
-from src.model.compendium_diff import load_compendium
+from src.model.compendium_diff import load_compendium, resolve_compendium_path
 from src.model.glom_diff import (
     SourceImpactDiff,
     cliques_from_compendia,
@@ -175,8 +175,8 @@ def _final_compendium_breakdown(
     for st, cfg, source_curies in _iter_pipeline_contributions(contribution, pipelines):
         per_file: dict[str, int] = {}
         for fname in cfg["compendium_files"]:
-            path = compendia_root / fname
-            if not path.exists():
+            path = resolve_compendium_path(compendia_root, fname)
+            if path is None:
                 continue
             count = sum(
                 len({ident["i"] for ident in clique.get("identifiers", [])} & source_curies)
@@ -217,21 +217,28 @@ def _remote_comparison_summary(
         current_paths: list[pathlib.Path] = []
         missing = 0
         for fname in cfg["compendium_files"]:
-            current = compendia_root / fname
-            if not current.exists():
+            current = resolve_compendium_path(compendia_root, fname)
+            if current is None:
                 continue
-            cached = remote_cache_dir / fname
-            if not cached.exists():
-                url = f"{base}/compendia/{fname}"
-                logger.info("downloading remote compendium %s", url)
-                with requests.get(url, stream=True, timeout=60) as resp:
-                    if not resp.ok:
-                        logger.warning("remote download failed for %s: %s %s", url, resp.status_code, resp.reason)
-                        missing += 1
-                        continue
-                    with cached.open("wb") as out:
-                        for chunk in resp.iter_content(chunk_size=64 * 1024):
-                            out.write(chunk)
+            cached = resolve_compendium_path(remote_cache_dir, fname)
+            if cached is None:
+                # Builds published before compendia were gzipped host the plain .txt; newer ones
+                # host only the .txt.gz. Try both so the report can compare against either.
+                for name in (fname, f"{fname}.gz"):
+                    url = f"{base}/compendia/{name}"
+                    logger.info("downloading remote compendium %s", url)
+                    with requests.get(url, stream=True, timeout=60) as resp:
+                        if not resp.ok:
+                            logger.warning("remote download failed for %s: %s %s", url, resp.status_code, resp.reason)
+                            continue
+                        cached = remote_cache_dir / name
+                        with cached.open("wb") as out:
+                            for chunk in resp.iter_content(chunk_size=64 * 1024):
+                                out.write(chunk)
+                    break
+                if cached is None:
+                    missing += 1
+                    continue
             # Only compare a current compendium against its remote counterpart when we
             # actually obtained that counterpart; otherwise a missing remote file would make
             # every current clique in it look "current only" and inflate the net-new estimate.

--- a/tests/model/test_compendium_diff.py
+++ b/tests/model/test_compendium_diff.py
@@ -4,11 +4,18 @@ The CLI wrapper that drives these functions is tested separately in
 ``tests/tools/clique_diff/test_cli.py``.
 """
 
+import gzip
 import json
 
 import pytest
 
-from src.model.compendium_diff import diff_builds, diff_compendium, load_cliques, load_compendium
+from src.model.compendium_diff import (
+    diff_builds,
+    diff_compendium,
+    load_cliques,
+    load_compendium,
+    resolve_compendium_path,
+)
 
 
 def _clique(*curies, biolink_type="biolink:Disease"):
@@ -51,6 +58,34 @@ def test_load_compendium_skips_blank_lines(tmp_path):
     path = tmp_path / "Disease.txt"
     path.write_text(json.dumps(_clique("MONDO:1")) + "\n\n" + json.dumps(_clique("MONDO:2")) + "\n\n")
     assert len(list(load_compendium(path))) == 2
+
+
+@pytest.mark.unit
+def test_load_compendium_reads_gzipped(tmp_path):
+    """A gzipped compendium must yield exactly what the uncompressed one does.
+
+    Finished builds distribute compendia as ``.txt.gz`` (``rule compress_compendium``), so the
+    diff tools only ever see the compressed form once a build is done.
+    """
+    cliques = [_clique("MONDO:1"), _clique("MONDO:2")]
+    plain = _write_jsonl(tmp_path / "Disease.txt", cliques)
+    gzipped = tmp_path / "DiseaseGz.txt.gz"
+    with gzip.open(gzipped, "wt") as f:
+        f.write("".join(json.dumps(c) + "\n" for c in cliques))
+
+    assert list(load_compendium(gzipped)) == list(load_compendium(plain))
+
+
+@pytest.mark.unit
+def test_resolve_compendium_path_prefers_txt_then_gz(tmp_path):
+    """Uncompressed wins when both exist; the .gz is the fallback; None when neither is there."""
+    assert resolve_compendium_path(tmp_path, "Disease.txt") is None
+
+    (tmp_path / "Disease.txt.gz").write_bytes(gzip.compress(b""))
+    assert resolve_compendium_path(tmp_path, "Disease.txt") == tmp_path / "Disease.txt.gz"
+
+    (tmp_path / "Disease.txt").write_text("")
+    assert resolve_compendium_path(tmp_path, "Disease.txt") == tmp_path / "Disease.txt"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Compendia were the last large uncompressed outputs in the tree — synonyms, KGX and sapbert exports are already gzipped, and Parquet/DuckDB compress internally. They stayed uncompressed because the NodeNorm loader was slow on large files, which is also why the deployment SOP splits `Protein.txt`, `Publication.txt`, `SmallMolecule.txt` and `Gene.txt` with `split -d -l 10000000`. The loader rewrite in [NodeNormalization#384](https://github.com/NCATSTranslator/NodeNormalization/pull/384) removed that constraint.

## ⚠️ Release blocker

**Do not tag a Babel release built from this branch until [NodeNormalization#397](https://github.com/NCATSTranslator/NodeNormalization/issues/397) lands.** The loader still opens compendia with a plain `open()` (`node_normalizer/loader/loader.py`, at both the validation read and the main ingest read), so it cannot read `.txt.gz`. PR #384 changed loader structure and speed, not file I/O. `docs/Deployment.md` records the interim workaround (gunzip before loading).

## Approach

This follows the existing `synonyms/` pattern — the `.txt` becomes a `temp()` output replaced by a `.txt.gz` — with one structural difference. A synonyms file has exactly one consumer, its own semantic type's rule, so it is compressed there. A compendium is read across the pipeline: the DuckDB/Parquet export, the KGX export, `leftover_umls`, both conflations, and the per-compendium content reports. So compression gets its own rule, `compress_compendium`, gated behind all of them — which lets `temp()` reclaim each `.txt` immediately after compression rather than holding both copies for the length of the run.

Two consequences worth knowing:

- **Partial targets are unaffected.** `temp()` only fires for consumers actually in the DAG, and `snakemake anatomy` does not pull in `compress_compendium`. Partial builds leave their `.txt` in place, which is what you want while iterating on one semantic type.
- **No `uncompress_compendium_file` rule.** A wildcard `.txt.gz → .txt` rule alongside the wildcard `.txt → .txt.gz` one would be mutually satisfiable and risks an `AmbiguousRuleException`. Use `gunzip -k` by hand; the repo's own tools read either form.

`check_compendia_files` becomes `check_compendia_gzipped_files`, mirroring `check_synonyms_gzipped_files`. It asserts set equality on the directory, so it must run after compression; taking the `.gz` as explicit input is what orders it there, and `compress_compendium` correspondingly gates on the individual content reports rather than `reports_done` so the two do not cycle. The donefile path is unchanged, so `all_reports` needed no edit.

## Tooling

`load_compendium` in `src/model/compendium_diff.py` — the chokepoint shared by `babel-clique-diff`, `source-impact-report` and `glom_diff` — now dispatches on the `.gz` suffix, and a new `resolve_compendium_path` prefers the uncompressed form when both are present.

This fixed a latent trap: `source-impact-report`'s `_final_compendium_breakdown` did `if not path.exists(): continue`, so against a compressed build it would have silently reported **zero** source CURIEs per compendium rather than failing. Its remote-comparison download now tries both names, so the report can still compare against builds published before this change.

`src/exporters/duckdb_exporters.py` is deliberately untouched — its over-threshold chunking path uses a plain `open()`, which is fine because `export_compendia_to_duckdb` runs strictly before compression. There is now a comment saying so.

## Verification

Beyond dry-runs, the rule was exercised for real against a synthetic output tree: it produced valid gzip (`gunzip -t`), Snakemake removed the temp `.txt`, and `load_compendium` round-tripped the cliques.

- `snakemake -n all` — 25 compress jobs (matching the 25 compendia), 25 temp removals, no `AmbiguousRuleException`.
- `snakemake -n anatomy` — 22 jobs, no compress rule, confirming partial builds are unaffected.
- 357 unit tests pass; `ruff`, `ruff format`, `snakefmt` and `rumdl` all clean.

Full-pipeline confirmation still needs a cluster run.

## Follow-up

`util.gzip_files()` is the stdlib `gzip` module and therefore single-threaded, and all 25 compress jobs sit at the tail of the DAG. If that tail dominates wall-clock time, `pigz` is the upgrade — tracked in #946, to be decided from the `benchmarks/compress_compendium_*.tsv` timings after the next full run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)