### PR TITLE
Detect encoding damage in labels and synonyms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,10 @@ canonical prefix-constant registry; its `id_prefixes` order in the Biolink Model
 - **`SynonymFilter`** (`src/synonyms/filter.py`) checks every label/synonym against
   `input_data/obsolete_synonyms.yaml` before it enters a compendium — see its docstring for the
   `action` field and the `should_suppress()` contract.
+- **Encoding check** (`src/synonyms/encoding.py`) — every label/synonym is checked as it loads in
+  `src/node.py`, and mojibake **aborts the build**. If a run dies with `RuntimeError: Encoding issue
+  in ...`, see [`docs/Development.md`](docs/Development.md#the-encoding-check) for the fix and the
+  `config.yaml` escape hatches; `uv run babel-check-encoding` surveys files without raising.
 - **Logging** — always use `get_logger(__name__)` from `src.util`, never `logging.getLogger`
   directly (see its docstring for why and the deferred-import exception).
 - **Leftover UMLS** — `src/createcompendia/leftover_umls.py` (rule `leftover_umls`) runs last and

--- a/config.yaml
+++ b/config.yaml
@@ -264,6 +264,21 @@ ensembl_datasets_to_skip:
 #  - aocellaris_gene_ensembl
   - omykiss_gene_ensembl        # 2026jun5: keeps getting stuck with this dataset for some reason.
 
+# Encoding damage check (src/synonyms/encoding.py). Every label and synonym is checked as it is
+# loaded in src/node.py; anything that looks like mojibake (UTF-8 misread as cp1252, e.g. 'Ã©' for
+# 'é'), a control character, or a replacement character aborts the build with a RuntimeError naming
+# the CURIE and the file. Failing loudly is the point: a mojibake label is valid UTF-8, so nothing
+# downstream would catch it, and it is far cheaper to re-run one download rule than a whole build.
+#
+# Set to false to push a build through while an encoding problem is still being fixed. Prefer the
+# allowlist below for individual strings -- disabling this turns the check off for everything.
+encoding_check_enabled: true
+
+# Exact strings that trip the check but are actually correct, so the build should not fail on them.
+# Add an entry only after confirming against the source file that the text is genuinely what the
+# source intends, and say so in a comment -- an unexplained entry here silently hides a real bug.
+encoding_check_allowlist: []
+
 # Labels longer than this limit are demoted (not used as preferred label if a shorter alternative exists).
 # Keyed by Biolink type; types not listed here are never demoted. Uses ancestor traversal, so
 # biolink:ChemicalEntity applies to all chemical subtypes (SmallMolecule, Drug, etc.).

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -99,6 +99,48 @@ See [`tests/README.md`](../tests/README.md) and
   per-source doc so the conclusion is reproducible and reviewable; see
   [`docs/sources/NCBIGene/quoting/`](sources/NCBIGene/quoting/).
 
+## The encoding check
+
+Every label and synonym is checked for encoding damage as it is loaded, in `src/node.py`, by
+`check_encoding()` from [`src/synonyms/encoding.py`](../src/synonyms/encoding.py). Damage means
+mojibake (UTF-8 misread as cp1252 — `Ã©` where `é` was meant), a control character, or a
+replacement character. **The check raises**, aborting the build.
+
+Failing loudly is deliberate. Mojibake is valid UTF-8, just wrong text, so nothing downstream would
+ever notice it: it flows through the compendia, the synonyms files, and into Node Normalization as
+if it were a real name. And it is far cheaper to re-run one download rule than to discover the
+problem in a released build.
+
+The check runs at _load_ time rather than at write time because there is no single place labels are
+written — twenty-odd datahandlers each write their own `babel_downloads/<PREFIX>/labels`. There is
+exactly one place they are all read, which is also where `SynonymFilter` hooks in. Checking there
+means each string is validated once per prefix load, and the error names the file the damage lives
+in, which is what you need in order to fix it.
+
+### When it fires
+
+The error names the CURIE, the source file, the offending text, and the repaired guess:
+
+```text
+RuntimeError: Encoding issue in babel_downloads/PUBCHEM.COMPOUND/labels for PUBCHEM.COMPOUND:1:
+looks like mojibake (UTF-8 read as cp1252); probably meant to be 'étude'. The text was 'Ã©tude'.
+```
+
+Fix the ingest that produced it. `src/datahandlers/datacollect.py` (PubChem) and
+`src/datahandlers/unii.py` (UNII) read their sources as `latin-1`/`windows-1252` and are the
+likeliest culprits. Before changing how one of those files is read, characterize the whole download
+first — see "Characterize a messy field before you parse it" above.
+
+If the text is genuinely correct and the heuristic is wrong, add the exact string to
+`encoding_check_allowlist` in `config.yaml` with a comment saying how you confirmed it against the
+source. `encoding_check_enabled: false` turns the check off entirely, which is a way to push a
+build through while a fix is in progress, not a fix.
+
+To survey a build without waiting for it to fail — or to check outputs that predate this check —
+use [`babel-check-encoding`](tools/CheckEncoding.md), which reports instead of raising.
+`check_for_encoding_issues` in `src/reports/duckdb_reports.py` runs the same idea over the finished
+Parquet as a backstop, writing `reports/duckdb/encoding_issues.tsv`.
+
 ## Current Development Process
 
 Developing a change to Babel is significantly more complicated than developing most software,

--- a/docs/sources/CLAUDE.md
+++ b/docs/sources/CLAUDE.md
@@ -106,3 +106,20 @@ reverse-engineering how the file was built. Prefer scripts that
 committed artifact cannot drift from the pipeline. Worked example:
 `docs/sources/DRUGBANK/food-and-extracts/scripts/generate_csvs.py`, which regenerates the two
 DrugBank retype CSVs from the same `classify_food_or_extract` the build uses.
+
+## Read source files as UTF-8
+
+Default to UTF-8 when opening a downloaded source file. Reaching for `latin-1` or `windows-1252`
+because a decode failed converts a loud `UnicodeDecodeError` into silent mojibake: the bytes always
+decode, and `é` quietly becomes `Ã©` in every label and synonym the source contributes. Mojibake is
+valid UTF-8, so it survives every downstream step and lands in Node Normalization as a real name.
+
+Only use a single-byte codec when the source genuinely publishes in one, and say so in a comment
+naming the evidence — `src/datahandlers/unii.py`'s `UNII_RECORDS_ENCODING` is the shape to follow.
+`src/datahandlers/datacollect.py` (PubChem) reads `latin-1` and predates this rule; treat it as a
+thing to verify, not a precedent.
+
+Labels and synonyms are checked as they load and a damaged one aborts the build — see
+[the encoding check](../Development.md#the-encoding-check). Survey a source's files before wiring
+it in with `uv run babel-check-encoding babel_downloads/<PREFIX>/labels`
+([docs](../tools/CheckEncoding.md)).

--- a/docs/tools/CheckEncoding.md
+++ b/docs/tools/CheckEncoding.md
@@ -1,0 +1,65 @@
+# Check encoding
+
+`uv run babel-check-encoding` surveys Babel's label, synonym, and compendium files for encoding
+damage, reporting what it finds instead of failing.
+
+The same detector (`src/synonyms/encoding.py`) runs inside the pipeline, where it *raises* — see
+[the encoding check](../Development.md#the-encoding-check) for that side. This tool is how you find
+out what a build already contains before relying on the raising check, and how you triage a build
+that failed it.
+
+## What counts as damage
+
+Two signals:
+
+**Mojibake** — UTF-8 bytes decoded with a single-byte codec. `é` becomes `Ã©`, `'` becomes `â€™`.
+The detector confirms it by encoding the text back to that codec and decoding those bytes as UTF-8:
+if the round-trip succeeds and produces something different, the text was damaged, and the tool
+reports the repaired guess alongside it.
+
+Both codecs Babel reads with are tried — `cp1252` (UNII) and `latin-1` (PubChem). They damage text
+differently: latin-1 turns bytes `0x80`-`0x9f` into C1 control characters where cp1252 turns them
+into printable punctuation, so an en-dash misread as latin-1 needs the latin-1 round-trip to be
+*repairable* rather than merely detectable.
+
+Legitimate non-ASCII text cannot round-trip and so is never flagged — `α` in
+`Nα-acetyl-L-lysine` has no cp1252 byte at all, and `Ménière disease` re-encodes to bytes that are
+not valid UTF-8.
+
+**Impossible characters** — C0 controls, DEL, U+FFFD REPLACEMENT CHARACTER (proof of a lossy
+decode), and a byte-order mark left embedded in the text.
+
+## Usage
+
+```bash
+# One file.
+uv run babel-check-encoding babel_downloads/PUBCHEM.COMPOUND/labels
+
+# A whole download or output directory.
+uv run babel-check-encoding --recursive babel_downloads
+uv run babel-check-encoding --recursive babel_outputs/compendia --out-tsv encoding_issues.tsv
+```
+
+`--recursive` picks up files named `labels` or `synonyms` (Babel's TSVs have no extension) and
+anything ending in `.txt` (the compendium and synonym JSONL outputs). Line shape is detected from
+the content, so all four formats can be scanned in one pass.
+
+`--examples N` sets how many example rows to print per file (default 5). `--out-tsv` writes every
+issue as `file, line, curie, text, reason`; the text is `repr()`-quoted so a control character in
+the data cannot corrupt the TSV.
+
+The exit code is 1 if anything was found, so a script can gate on it directly.
+
+## Where damage comes from
+
+Three ingests read their source with a single-byte codec, and are the first places to look:
+
+- `src/datahandlers/datacollect.py` — PubChem `CID-Title.gz` and `CID-Synonym-filtered.gz` as
+  `latin-1`.
+- `src/datahandlers/unii.py` — `UNII_RECORDS_ENCODING = "windows-1252"`, and a second file as
+  `latin-1`.
+
+If the survey shows damage concentrated in `PUBCHEM.COMPOUND` or `UNII`, that is why. Before
+changing how one of those files is read, characterize the whole download rather than a sample —
+see ["Characterize a messy field before you parse it"](../Development.md) and the worked example in
+[`docs/sources/NCBIGene/quoting/`](../sources/NCBIGene/quoting/).

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -10,6 +10,7 @@ pipeline. Each tool lives in `src/tools/<tool>/` and is installed as a console s
 |------|---------|-----------------|
 | [Source impact report](SourceImpactReport.md) | `uv run source-impact-report --source <SOURCE>` | "What does adding *this data source* do to the cliques?" |
 | [Clique diff](CliqueDiff.md) | `uv run babel-clique-diff --before <dir> --after <dir> …` | "How did the cliques change between *build A* and *build B*?" |
+| [Check encoding](CheckEncoding.md) | `uv run babel-check-encoding --recursive <dir>` | "Are any labels or synonyms encoding-damaged?" |
 | [SLURM errors](Errors.md) | `uv run babel-slurm-errors <version>` | "Which rules failed in this cluster run, and why?" |
 | [SLURM resources](Resources.md) | `uv run babel-slurm-resources <run-dir>` | "How much `mem`/`cpus` should each rule actually request?" |
 | [RDF load memory](Memory.md) | `uv run python src/tools/memory/estimate_rdf_load_memory.py FILE` | "How much RAM will bulk-loading this RDF dump need?" |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
 babel-slurm-errors = "src.tools.slurm.errors:main"
 babel-slurm-resources = "src.tools.slurm.resources:main"
 babel-clique-diff = "src.tools.clique_diff.cli:main"
+babel-check-encoding = "src.tools.check_encoding.cli:main"
 source-impact-report = "src.tools.source_impact_report.cli:main"
 
 [tool.uv]

--- a/src/model/compendium_diff.py
+++ b/src/model/compendium_diff.py
@@ -64,8 +64,13 @@ DROPPED_KEY = ("", DROPPED)
 
 
 def load_compendium(path: pathlib.Path | str) -> Iterator[dict]:
-    """Stream clique dicts from a JSONL compendium file, skipping blank lines."""
-    with open(path) as inf:
+    """Stream clique dicts from a JSONL compendium file, skipping blank lines.
+
+    Compendia are written as UTF-8, so read them as UTF-8 rather than inheriting the locale
+    default -- which varies by machine and would decode a non-ASCII label differently (or fail)
+    depending on where the tool runs.
+    """
+    with open(path, encoding="utf-8") as inf:
         for line in inf:
             line = line.strip()
             if line:

--- a/src/node.py
+++ b/src/node.py
@@ -10,6 +10,7 @@ import curies
 from src.LabeledID import LabeledID
 from src.predicates import HAS_EXACT_SYNONYM
 from src.prefixes import PUBCHEMCOMPOUND
+from src.synonyms.encoding import check_encoding
 from src.synonyms.filter import get_synonym_filter
 from src.util import (
     Text,
@@ -59,6 +60,7 @@ class SynonymFactory:
                 # option.
                 for line in synonymsf:
                     row = json.loads(line)
+                    check_encoding(row["synonym"], row["curie"], common_synonyms_path)
                     self.common_synonyms[row["curie"]].add((row["predicate"], row["synonym"]))
                     count_common_file_synonyms += 1
             logger.info(
@@ -80,6 +82,7 @@ class SynonymFactory:
                     if len(x) == 1:
                         lbs[x[0]].add((HAS_EXACT_SYNONYM, ""))
                     elif len(x) == 2:
+                        check_encoding(x[1], x[0], labelfname)
                         lbs[x[0]].add((HAS_EXACT_SYNONYM, x[1]))
                         if x[1]:
                             count_labels += 1
@@ -90,6 +93,7 @@ class SynonymFactory:
                     x = line.strip().split("\t")
                     if len(x) < 3:
                         continue
+                    check_encoding(x[2], x[0], synfname)
                     lbs[x[0]].add((x[1], x[2]))
                     count_synonyms += 1
         self.synonyms[prefix] = lbs
@@ -549,6 +553,7 @@ class NodeFactory:
                     if len(x) == 1:
                         lbs[x[0]] = ""
                     else:
+                        check_encoding(x[1], x[0], labelfname)
                         lbs[x[0]] = x[1]
         self.extra_labels[prefix] = lbs
 
@@ -569,6 +574,7 @@ class NodeFactory:
                         x = line.strip().split("\t")
                         curie = x[0]
                         new_label = x[1]
+                        check_encoding(new_label, curie, common_labels_path)
                         if curie in self.common_labels:
                             # We have multiple labels! For simplicity's sake, let's choose the longest one.
                             if len(new_label) <= len(self.common_labels[curie]):
@@ -590,6 +596,9 @@ class NodeFactory:
                 raise ValueError(f"LabeledID don't belong here ({iid}), pass in labels separately.")
             if iid in labels:
                 label = labels[iid]
+                # The only label path that doesn't come from a labels file on disk: whatever the
+                # calling pipeline passed to write_compendium(). Check it here or nowhere.
+                check_encoding(label, iid, "labels passed to write_compendium()")
                 if synonym_filter.should_suppress(label, source=f"explicit labels for {iid}", node_types=node_types):
                     label = ""
                 labeled_list.append(LabeledID(identifier=iid, label=label))

--- a/src/reports/duckdb_reports.py
+++ b/src/reports/duckdb_reports.py
@@ -74,6 +74,64 @@ def check_for_identically_labeled_cliques(
         db.close()
 
 
+# Encoding damage, as a regex DuckDB can evaluate over a Parquet column. This is the backstop for
+# the raising check in src/synonyms/encoding.py, which runs at load time in src/node.py; it catches
+# anything that reached an output without passing through a labels/synonyms file (the properties
+# path), plus any build made before that check existed.
+#
+# DuckDB can't do the cp1252 round-trip the Python detector uses, so this is the pattern half of it:
+#
+#   [ÂÃ][\x80-\xbf]   a 2-byte UTF-8 sequence read as cp1252 -- 'é' becomes 'Ã©', '°' becomes 'Â°'.
+#                     Covers the Latin-1 supplement, which is the bulk of real damage.
+#   â€               the same for 3-byte punctuation -- ''' becomes 'â€™', '—' becomes 'â€"'.
+#   ï¿½              U+FFFD that was itself misread, i.e. damage applied twice.
+#   \x{FFFD}          an actual replacement character: proof of a lossy decode.
+#   [\x00-\x08...]    C0 controls (minus tab/newline) and DEL.
+#
+# RE2 interprets the \x escapes itself, so the backslashes pass through DuckDB's string literal
+# untouched. In UTF-8 mode these ranges are codepoints, not bytes, which is what we want.
+ENCODING_ISSUE_REGEX = r"[ÂÃ][\x80-\xbf]|â€|ï¿½|\x{FFFD}|[\x00-\x08\x0b-\x1f\x7f]"
+
+
+def check_for_encoding_issues(parquet_root, duckdb_filename, encoding_issues_tsv, duckdb_config=None):
+    """
+    Generate a list of labels and synonyms that look encoding-damaged.
+
+    :param parquet_root: The root directory for the Parquet files. We expect these to have subdirectories named
+        e.g. `filename=AnatomicalEntity/Node.parquet`, etc.
+    :param duckdb_filename: A temporary DuckDB file to use.
+    :param encoding_issues_tsv: The output file listing damaged labels and synonyms.
+    """
+
+    db = setup_duckdb(duckdb_filename, duckdb_config)
+    nodes = db.read_parquet(os.path.join(parquet_root, "**/Node.parquet"), hive_partitioning=True)
+    synonyms = db.read_parquet(os.path.join(parquet_root, "**/Synonyms.parquet"), hive_partitioning=True)
+
+    # A single streaming filter over both tables -- no aggregate, so nothing to spill and no need
+    # for the two-pass treatment the duplicate-detection reports require.
+    with log_duckdb_settings_on_error(db, "check_for_encoding_issues (regex scan over Node and Synonyms)"):
+        db.sql(f"""
+            SELECT 'Node.label' AS source, filename, curie, label AS text
+            FROM nodes
+            WHERE label IS NOT NULL AND regexp_matches(label, '{ENCODING_ISSUE_REGEX}')
+            UNION ALL
+            SELECT 'Synonyms.label' AS source, filename, clique_leader AS curie, label AS text
+            FROM synonyms
+            WHERE label IS NOT NULL AND regexp_matches(label, '{ENCODING_ISSUE_REGEX}')
+            UNION ALL
+            SELECT 'Synonyms.preferred_name' AS source, filename, clique_leader AS curie, preferred_name AS text
+            FROM synonyms
+            WHERE preferred_name IS NOT NULL AND regexp_matches(preferred_name, '{ENCODING_ISSUE_REGEX}')
+            ORDER BY source, filename, curie
+        """).write_csv(encoding_issues_tsv, sep="\t")
+
+    log_memory_snapshot(db, "check_for_encoding_issues complete")
+    with log_duckdb_settings_on_error(db, "check_for_encoding_issues teardown"):
+        nodes.close()
+        synonyms.close()
+        db.close()
+
+
 def check_for_duplicate_curies(parquet_root, duckdb_filename, duplicate_curies_tsv, duckdb_config=None):
     """
     Generate a list of duplicate CURIEs.

--- a/src/snakefiles/duckdb.snakefile
+++ b/src/snakefiles/duckdb.snakefile
@@ -229,6 +229,34 @@ rule check_for_identically_labeled_cliques:
         )
 
 
+rule check_for_encoding_issues:
+    input:
+        config["output_directory"] + "/duckdb/done",
+        config["output_directory"] + "/duckdb/compendia_done",
+    output:
+        duckdb_filename=temp(config["output_directory"] + "/duckdb/duckdbs/encoding_issues.duckdb"),
+        encoding_issues=config["output_directory"] + "/reports/duckdb/encoding_issues.tsv",
+    benchmark:
+        config["output_directory"] + "/benchmarks/check_for_encoding_issues.tsv"
+    resources:
+        # A streaming regex filter with no aggregate, so this is far cheaper than its report
+        # siblings: nothing is materialised beyond the (expected to be tiny) result set.
+        mem="200G",
+    params:
+        parquet_dir=config["output_directory"] + "/duckdb/parquet/",
+    run:
+        src.reports.duckdb_reports.check_for_encoding_issues(
+            params.parquet_dir,
+            output.duckdb_filename,
+            output.encoding_issues,
+            {
+                "memory_limit": "150G",
+                "threads": 1,
+                "preserve_insertion_order": False,
+            },
+        )
+
+
 rule check_for_duplicate_curies:
     input:
         config["output_directory"] + "/duckdb/done",
@@ -359,6 +387,7 @@ rule all_duckdb_reports:
         identically_labeled_cliques_tsv=config["output_directory"]
         + "/reports/duckdb/identically_labeled_cliques.tsv.gz",
         duplicate_curies=config["output_directory"] + "/reports/duckdb/duplicate_curies.tsv",
+        encoding_issues=config["output_directory"] + "/reports/duckdb/encoding_issues.tsv",
         duplicate_clique_leaders_tsv=config["output_directory"] + "/reports/duckdb/duplicate_clique_leaders.tsv",
         curie_report_json=config["output_directory"] + "/reports/duckdb/curie_report.json",
         by_clique_report_json=config["output_directory"] + "/reports/duckdb/clique_leaders.json",

--- a/src/synonyms/encoding.py
+++ b/src/synonyms/encoding.py
@@ -1,0 +1,160 @@
+"""Detect encoding damage in labels and synonyms.
+
+Babel reads several sources with a single-byte codec (PUBCHEM.COMPOUND and UNII are read as
+`latin-1`/`windows-1252` in `src/datahandlers/`). When the source bytes are really UTF-8, that
+misread produces mojibake: `é` becomes `Ã©`, `–` becomes `â€"`. The damage is invisible to every
+downstream check because mojibake *is* valid UTF-8 -- just wrong text.
+
+`find_encoding_issue()` is the detector; `check_encoding()` is the raising wrapper the pipeline
+calls at the points where labels and synonyms are loaded (see `src/node.py`). Both are cheap enough
+to run over every string in a full build -- see the `isascii()` note in `find_encoding_issue()`.
+"""
+
+import json
+import re
+from pathlib import Path
+
+from src.util import get_config, get_logger
+
+logger = get_logger(__name__)
+
+# Characters that never legitimately appear in a label or synonym:
+#   \x00-\x08, \x0b-\x1f  C0 controls, minus tab (\x09) and newline (\x0a). Those two are field and
+#                         record separators, and a label is allowed to contain a tab:
+#                         `NodeFactory.load_extra_labels()` in src/node.py splits with maxsplit=1
+#                         precisely so that such a label survives, and a test pins that behaviour.
+#   \x7f-\x9f             DEL and the C1 controls. Nothing emits these deliberately; in practice
+#                         they are cp1252 bytes 0x80-0x9f (curly quotes, en-dashes) that were
+#                         decoded as latin-1 instead, so they are themselves an encoding-bug tell.
+#   �                U+FFFD REPLACEMENT CHARACTER -- unambiguous proof of a lossy decode.
+#   ﻿                U+FEFF BOM left embedded in the text rather than consumed by the reader.
+_SUSPECT = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f�﻿]")
+
+# The ASCII subset of the above. Needed separately because `str.isprintable()` -- the cheap gate on
+# the ASCII fast path -- also rejects tab and newline, which as noted are not damage.
+_ASCII_CONTROL = re.compile(r"[\x00-\x08\x0b-\x1f\x7f]")
+
+_allowlist: frozenset[str] | None = None
+
+
+def _get_allowlist() -> frozenset[str]:
+    """Load (once) the set of strings that look damaged but are known to be correct."""
+    global _allowlist
+    if _allowlist is None:
+        _allowlist = frozenset(get_config().get("encoding_check_allowlist", []) or [])
+        if _allowlist:
+            logger.info(f"Encoding check: loaded {len(_allowlist)} allowlisted strings.")
+    return _allowlist
+
+
+def find_encoding_issue(text: str) -> str | None:
+    """Return a short human-readable reason if `text` looks encoding-damaged, else None.
+
+    Two signals:
+
+    1.  A successful single-byte -> UTF-8 round-trip that changes the string. This is the classic
+        mojibake test (the core of what `ftfy` does): if the text can be encoded back to the codec
+        that damaged it *and* those bytes decode as valid UTF-8 into something different, then it
+        was UTF-8 misread as that codec. Legitimate non-ASCII text fails one of those two steps --
+        `α` in `Nα-acetyltransferase` has no cp1252 byte, and `Ménière disease` re-encodes to bytes
+        that aren't valid UTF-8 -- and so is never flagged.
+    2.  A character from `_SUSPECT`: a control character, a replacement character, or a stray BOM.
+
+    The round-trip runs first because it is the only signal that can name the *original* text, which
+    is what makes the report actionable. Both codecs Babel actually reads with are tried:
+    `datacollect.py` uses latin-1 and `unii.py` uses windows-1252, and they damage text differently
+    (latin-1 turns bytes 0x80-0x9f into C1 controls, cp1252 into printable punctuation), so trying
+    only one leaves the other diagnosable but unrepairable.
+
+    The `isascii()` gate at the top matters for cost, not correctness: the overwhelming majority of
+    biomedical labels are pure ASCII, and `str.isascii()` is a C-level scan that exits in
+    nanoseconds. Only non-ASCII strings pay for the round-trip or the regex, which is what makes it
+    affordable to check every label and synonym in a full build. ASCII text can still be damaged --
+    a C0 control or DEL is never legitimate -- so the fast path falls through to `isprintable()`,
+    also C-level, and only pays for a regex on the rare string that fails it.
+    """
+    if text.isascii():
+        if text.isprintable():
+            return None
+        # isprintable() also rejects tab and newline, so confirm with the range that excludes them.
+        return "contains a control character" if _ASCII_CONTROL.search(text) else None
+    for codec in ("cp1252", "latin-1"):
+        try:
+            repaired = text.encode(codec).decode("utf-8")
+        except (UnicodeEncodeError, UnicodeDecodeError):
+            continue  # Doesn't round-trip through this codec; try the next.
+        if repaired != text:
+            return f"looks like mojibake (UTF-8 read as {codec}); probably meant to be {repaired!r}"
+    if _SUSPECT.search(text):
+        return "contains a control, replacement or byte-order-mark character"
+    return None
+
+
+def check_encoding(text: str, curie: str, source: str) -> None:
+    """Raise RuntimeError if `text` is encoding-damaged.
+
+    `curie` and `source` are only used to build the error message, but they are what makes it
+    actionable -- the message has to say which identifier in which file to go and look at.
+
+    Set `encoding_check_enabled: false` in `config.yaml` to disable the check entirely, or add a
+    specific string to `encoding_check_allowlist` to exempt it.
+    """
+    if not text or not get_config().get("encoding_check_enabled", True):
+        return
+    if text in _get_allowlist():
+        return
+    reason = find_encoding_issue(text)
+    if reason is None:
+        return
+    raise RuntimeError(
+        f"Encoding issue in {source} for {curie}: {reason}. The text was {text!r}. "
+        f"Fix the source ingest, or -- if this text is actually correct -- add it to "
+        f"encoding_check_allowlist in config.yaml."
+    )
+
+
+def scan_file(path: Path) -> list[tuple[int, str, str, str]]:
+    """Scan a labels, synonyms, or JSONL file and return every encoding issue found.
+
+    Unlike `check_encoding()` this reports rather than raises, so it can survey a whole download
+    directory in one pass. Returns `(line_number, curie, text, reason)` tuples.
+
+    Supported shapes, chosen by what the line looks like rather than by the filename, because
+    Babel's labels and synonyms files have no extension:
+      - `<curie>\\t<label>`                    (a `labels` file)
+      - `<curie>\\t<predicate>\\t<synonym>`    (a `synonyms` file)
+      - a JSON object                          (a compendium or synonyms output file)
+    """
+    issues = []
+    with open(path, encoding="utf-8", errors="replace") as inf:
+        for line_no, line in enumerate(inf, start=1):
+            line = line.rstrip("\n")
+            if not line:
+                continue
+            if line.startswith("{"):
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                # Synonyms records are keyed on `curie`; compendium records lead with `identifiers`.
+                curie = row.get("curie") or (row.get("identifiers") or [{}])[0].get("i", "?")
+                texts = _texts_from_json(row)
+            else:
+                fields = line.split("\t")
+                curie = fields[0]
+                # A labels line is 2 fields, a synonyms line is 3+; the text is always last.
+                texts = [fields[-1]] if len(fields) > 1 else []
+            for text in texts:
+                reason = find_encoding_issue(text)
+                if reason:
+                    issues.append((line_no, curie, text, reason))
+    return issues
+
+
+def _texts_from_json(row: dict) -> list[str]:
+    """Pull every label-ish string out of a compendium or synonyms JSONL record."""
+    texts = [identifier["l"] for identifier in row.get("identifiers", []) if identifier.get("l")]
+    texts.extend(row.get("names", []))
+    if row.get("preferred_name"):
+        texts.append(row["preferred_name"])
+    return texts

--- a/src/tools/check_encoding/__init__.py
+++ b/src/tools/check_encoding/__init__.py
@@ -1,0 +1,9 @@
+"""Survey Babel label, synonym and compendium files for encoding damage.
+
+A thin CLI (:mod:`src.tools.check_encoding.cli`, installed as ``babel-check-encoding``) over
+:mod:`src.synonyms.encoding`, which holds the detector. The same detector runs inside the pipeline
+via :func:`src.synonyms.encoding.check_encoding`, where it *raises* rather than reports -- so use
+this tool to find out what a build already contains before relying on the raising check.
+
+See ``docs/tools/CheckEncoding.md``.
+"""

--- a/src/tools/check_encoding/cli.py
+++ b/src/tools/check_encoding/cli.py
@@ -1,0 +1,87 @@
+"""``babel-check-encoding`` — survey Babel files for encoding damage.
+
+Argument parsing and output formatting only; the detector lives in :mod:`src.synonyms.encoding`,
+so the pipeline's raising check and this report share one definition of "damaged".
+
+Invocation::
+
+    uv run babel-check-encoding babel_downloads/PUBCHEM.COMPOUND/labels
+    uv run babel-check-encoding --recursive babel_downloads
+    uv run babel-check-encoding --recursive babel_outputs/compendia --out-tsv issues.tsv
+
+Accepts `labels` and `synonyms` files, compendium/synonym JSONL, or directories with
+``--recursive``. Prints a per-file count with example rows, and exits 1 if anything was found so it
+can gate a script.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+from src.synonyms.encoding import scan_file
+
+# Files worth scanning when walking a directory. Babel's label and synonym files have no
+# extension, so we match on name; the JSONL outputs are `.txt`.
+SCANNABLE_NAMES = {"labels", "synonyms"}
+SCANNABLE_SUFFIXES = {".txt"}
+
+
+def find_files(paths, recursive):
+    """Expand the given paths into a sorted list of files to scan."""
+    files = []
+    for raw in paths:
+        path = Path(raw)
+        if path.is_dir():
+            if not recursive:
+                raise RuntimeError(f"{path} is a directory; pass --recursive to walk it.")
+            files.extend(
+                p
+                for p in path.rglob("*")
+                if p.is_file() and (p.name in SCANNABLE_NAMES or p.suffix in SCANNABLE_SUFFIXES)
+            )
+        else:
+            files.append(path)
+    return sorted(set(files))
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Survey Babel files for encoding damage.")
+    parser.add_argument("paths", nargs="+", help="Files or (with --recursive) directories to scan.")
+    parser.add_argument("--recursive", action="store_true", help="Walk directories for labels/synonyms/*.txt files.")
+    parser.add_argument(
+        "--examples", type=int, default=5, help="Example rows to print per file (default: 5, 0 for none)."
+    )
+    parser.add_argument("--out-tsv", help="Optional path to write every issue as a TSV.")
+    args = parser.parse_args(argv)
+
+    files = find_files(args.paths, args.recursive)
+    all_issues = []
+    files_with_issues = 0
+
+    for path in files:
+        issues = scan_file(path)
+        if not issues:
+            continue
+        files_with_issues += 1
+        all_issues.extend((path, *issue) for issue in issues)
+        print(f"{path}: {len(issues):,} issue(s)")
+        for _line_no, curie, text, reason in issues[: args.examples]:
+            print(f"    {curie}\t{text!r}\t{reason}")
+        if len(issues) > args.examples:
+            print(f"    ... and {len(issues) - args.examples:,} more")
+
+    if args.out_tsv:
+        with open(args.out_tsv, "w", encoding="utf-8", newline="\n") as fh:
+            fh.write("file\tline\tcurie\ttext\treason\n")
+            for path, line_no, curie, text, reason in all_issues:
+                # The damaged text can itself contain a control character, which would corrupt the
+                # TSV; repr() keeps every row on one line and makes the bad bytes visible.
+                fh.write(f"{path}\t{line_no}\t{curie}\t{text!r}\t{reason}\n")
+        print(f"Wrote {len(all_issues):,} issue(s) to {args.out_tsv}.")
+
+    print(f"Scanned {len(files):,} file(s): {len(all_issues):,} issue(s) in {files_with_issues:,} file(s).")
+    return 1 if all_issues else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/node/test_node_factory.py
+++ b/tests/node/test_node_factory.py
@@ -1,5 +1,6 @@
 import pytest
 
+import src.node as node_module
 import src.prefixes as pref
 from src import categories
 from src.LabeledID import LabeledID
@@ -313,3 +314,114 @@ def test_load_extra_labels_tab_in_label(tmp_path):
     fac.common_labels = {}
     fac.load_extra_labels("CHEMBL.COMPOUND")
     assert fac.extra_labels["CHEMBL.COMPOUND"]["CHEMBL.COMPOUND:CHEMBL3"] == "Water\tbottle"
+
+
+# ---------------------------------------------------------------------------
+# ENCODING CHECK
+#
+# check_encoding() (src/synonyms/encoding.py) raises on an encoding-damaged label, so these are the
+# wiring tests for the three label paths NodeFactory owns. The detector itself is tested in
+# tests/synonyms/test_encoding.py; these only prove it is reached.
+# ---------------------------------------------------------------------------
+
+
+def _patch_common_labels_config(monkeypatch, download_dir, filenames):
+    """Point apply_labels()'s common-labels loading at ``download_dir/common/``.
+
+    Patches ``src.node.get_config`` only, so the real config still backs the encoding check and the
+    synonym filter, which resolve get_config through their own modules.
+    """
+    monkeypatch.setattr(
+        node_module,
+        "get_config",
+        lambda: {"download_directory": str(download_dir), "common": {"labels": filenames}},
+        raising=True,
+    )
+
+
+@pytest.mark.unit
+def test_load_extra_labels_rejects_a_damaged_label(tmp_path):
+    """A mojibake label in a <PREFIX>/labels file must abort the build, naming CURIE and file."""
+    label_dir = tmp_path / "PUBCHEM.COMPOUND"
+    label_dir.mkdir()
+    (label_dir / "labels").write_text("PUBCHEM.COMPOUND:1\tÃ©tude\n", encoding="utf-8")
+    fac = NodeFactory(str(tmp_path), BIOLINK_VERSION)
+    fac.common_labels = {}
+
+    with pytest.raises(RuntimeError) as excinfo:
+        fac.load_extra_labels("PUBCHEM.COMPOUND")
+
+    message = str(excinfo.value)
+    assert "PUBCHEM.COMPOUND:1" in message
+    assert "labels" in message
+    assert "étude" in message  # the repaired guess, which is what makes the error actionable
+
+
+@pytest.mark.unit
+def test_load_extra_labels_accepts_legitimate_non_ascii(tmp_path):
+    """Real accented labels must load untouched — a false positive here would halt the pipeline."""
+    label_dir = tmp_path / "MONDO"
+    label_dir.mkdir()
+    (label_dir / "labels").write_text("MONDO:1\tMénière disease\n", encoding="utf-8")
+    fac = NodeFactory(str(tmp_path), BIOLINK_VERSION)
+    fac.common_labels = {}
+
+    fac.load_extra_labels("MONDO")
+
+    assert fac.extra_labels["MONDO"]["MONDO:1"] == "Ménière disease"
+
+
+@pytest.mark.unit
+def test_apply_labels_rejects_a_damaged_explicit_label(tmp_path):
+    """The labels dict passed to write_compendium() is the one label path with no file behind it.
+
+    Nothing else checks it, so this is the only place a damaged label supplied by a calling
+    pipeline (rather than read from babel_downloads) can be caught.
+    """
+    fac = NodeFactory(str(tmp_path), BIOLINK_VERSION)
+    fac.common_labels = {}
+
+    with pytest.raises(RuntimeError) as excinfo:
+        fac.apply_labels([f"{pref.CHEBI}:1"], {f"{pref.CHEBI}:1": "Ã©tude"})
+
+    message = str(excinfo.value)
+    assert f"{pref.CHEBI}:1" in message
+    assert "write_compendium()" in message
+
+
+@pytest.mark.unit
+def test_apply_labels_accepts_a_clean_explicit_label(tmp_path):
+    fac = NodeFactory(str(tmp_path), BIOLINK_VERSION)
+    fac.common_labels = {}
+
+    labeled = fac.apply_labels([f"{pref.CHEBI}:1"], {f"{pref.CHEBI}:1": "Ménière disease"})
+
+    assert labeled[0].label == "Ménière disease"
+
+
+@pytest.mark.unit
+def test_apply_labels_rejects_a_damaged_common_label(tmp_path, monkeypatch):
+    """The common/ labels files are a fallback for any prefix, so they are checked on load too."""
+    common_dir = tmp_path / "common"
+    common_dir.mkdir()
+    (common_dir / "common_labels.tsv").write_text("PUBCHEM.COMPOUND:1\tÃ©tude\n", encoding="utf-8")
+    _patch_common_labels_config(monkeypatch, tmp_path, ["common_labels.tsv"])
+
+    fac = NodeFactory(str(tmp_path), BIOLINK_VERSION)
+    assert fac.common_labels is None  # force the load path rather than the preset shortcut
+
+    with pytest.raises(RuntimeError, match="PUBCHEM.COMPOUND:1"):
+        fac.apply_labels([f"{pref.CHEBI}:1"], {})
+
+
+@pytest.mark.unit
+def test_apply_labels_accepts_clean_common_labels(tmp_path, monkeypatch):
+    common_dir = tmp_path / "common"
+    common_dir.mkdir()
+    (common_dir / "common_labels.tsv").write_text("MONDO:1\tMénière disease\n", encoding="utf-8")
+    _patch_common_labels_config(monkeypatch, tmp_path, ["common_labels.tsv"])
+
+    fac = NodeFactory(str(tmp_path), BIOLINK_VERSION)
+    fac.apply_labels([f"{pref.CHEBI}:1"], {})
+
+    assert fac.common_labels["MONDO:1"] == "Ménière disease"

--- a/tests/node/test_synonym_factory.py
+++ b/tests/node/test_synonym_factory.py
@@ -1,7 +1,9 @@
+import json
 from collections import defaultdict
 
 import pytest
 
+import src.node as node_module
 from src.node import SynonymFactory
 from src.util import get_config
 
@@ -80,3 +82,31 @@ def test_load_synonyms_accepts_legitimate_non_ascii(tmp_path):
     sf.load_synonyms("MONDO")
 
     assert (HAS_EXACT_SYNONYM, "Ménière disease") in sf.synonyms["MONDO"]["MONDO:1"]
+
+
+@pytest.mark.unit
+def test_init_rejects_a_damaged_common_synonym(tmp_path, monkeypatch):
+    """The common/ synonyms files are a fallback for any CURIE, so they are checked on load too.
+
+    Patches ``src.node.get_config`` only: the encoding check and the synonym filter resolve
+    get_config through their own modules, so both keep using the real config.
+    """
+    common_dir = tmp_path / "common"
+    common_dir.mkdir()
+    (common_dir / "common_synonyms.jsonl").write_text(
+        json.dumps({"curie": "PUBCHEM.COMPOUND:1", "predicate": HAS_EXACT_SYNONYM, "synonym": "Ã©tude"}) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        node_module,
+        "get_config",
+        lambda: {"download_directory": str(tmp_path), "common": {"synonyms": ["common_synonyms.jsonl"]}},
+        raising=True,
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        SynonymFactory(str(tmp_path))
+
+    message = str(excinfo.value)
+    assert "PUBCHEM.COMPOUND:1" in message
+    assert "étude" in message

--- a/tests/node/test_synonym_factory.py
+++ b/tests/node/test_synonym_factory.py
@@ -25,3 +25,58 @@ def test_load_synonyms_single_column(tmp_path):
 
     assert (HAS_EXACT_SYNONYM, "Water") in sf.synonyms["CHEMBL.COMPOUND"]["CHEMBL.COMPOUND:CHEMBL1"]
     assert (HAS_EXACT_SYNONYM, "") in sf.synonyms["CHEMBL.COMPOUND"]["CHEMBL.COMPOUND:CHEMBL2"]
+
+
+def _bare_synonym_factory(tmp_path):
+    """A SynonymFactory over tmp_path, bypassing __init__ (which loads the common synonym files)."""
+    sf = object.__new__(SynonymFactory)
+    sf.synonym_dir = tmp_path
+    sf.synonyms = {}
+    sf.common_synonyms = defaultdict(set)
+    return sf
+
+
+@pytest.mark.unit
+def test_load_synonyms_rejects_a_damaged_label(tmp_path):
+    """A mojibake label must abort the load, naming the CURIE and the file it came from.
+
+    This is the wiring test for src/synonyms/encoding.py: the detector is tested on its own in
+    tests/synonyms/test_encoding.py, this proves it is actually reached from the load path.
+    """
+    label_dir = tmp_path / "PUBCHEM.COMPOUND"
+    label_dir.mkdir()
+    (label_dir / "labels").write_text("PUBCHEM.COMPOUND:1\tÃ©tude\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _bare_synonym_factory(tmp_path).load_synonyms("PUBCHEM.COMPOUND")
+
+    message = str(excinfo.value)
+    assert "PUBCHEM.COMPOUND:1" in message
+    assert "labels" in message
+    assert "étude" in message  # the repaired guess, which is what makes the error actionable
+
+
+@pytest.mark.unit
+def test_load_synonyms_rejects_a_damaged_synonym(tmp_path):
+    """The synonyms file is checked too, on its third column rather than its second."""
+    label_dir = tmp_path / "PUBCHEM.COMPOUND"
+    label_dir.mkdir()
+    (label_dir / "synonyms").write_text(f"PUBCHEM.COMPOUND:1\t{HAS_EXACT_SYNONYM}\tÃ©tude\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="PUBCHEM.COMPOUND:1"):
+        _bare_synonym_factory(tmp_path).load_synonyms("PUBCHEM.COMPOUND")
+
+
+@pytest.mark.unit
+def test_load_synonyms_accepts_legitimate_non_ascii(tmp_path):
+    """Real accented and Greek-letter labels must load without complaint."""
+    label_dir = tmp_path / "MONDO"
+    label_dir.mkdir()
+    (label_dir / "labels").write_text(
+        "MONDO:1\tMénière disease\nMONDO:2\tNα-acetyl-L-lysine deficiency\n", encoding="utf-8"
+    )
+
+    sf = _bare_synonym_factory(tmp_path)
+    sf.load_synonyms("MONDO")
+
+    assert (HAS_EXACT_SYNONYM, "Ménière disease") in sf.synonyms["MONDO"]["MONDO:1"]

--- a/tests/reports/test_duckdb_reports.py
+++ b/tests/reports/test_duckdb_reports.py
@@ -225,3 +225,72 @@ def test_generate_clique_leaders_report_totals(parquet_root, tmp_path):
         "approx_distinct_curie_count": 2,
         "curie_count": 2,
     }
+
+
+@pytest.fixture
+def encoding_parquet_root(tmp_path):
+    """A hive-partitioned tree with Node.parquet and Synonyms.parquet, for the encoding check.
+
+    Kept separate from the ``parquet_root`` fixture, which only carries the Clique and Edge tables
+    the duplicate-detection reports read.
+    """
+    con = duckdb.connect()
+    foo_dir = tmp_path / "filename=Foo"
+    foo_dir.mkdir()
+
+    _write_parquet(
+        con,
+        str(foo_dir / "Node.parquet"),
+        ["curie", "curie_prefix", "label", "label_lc", "description", "taxa"],
+        [
+            ("CHEBI:15377", "CHEBI", "water", "water", "", ""),
+            # 'é' read as cp1252 -- the damage PUBCHEM.COMPOUND's latin-1 ingest can produce.
+            ("PUBCHEM.COMPOUND:1", "PUBCHEM.COMPOUND", "Ã©tude", "ã©tude", "", ""),
+            # Legitimate non-ASCII, which must not be reported.
+            ("MONDO:1", "MONDO", "Ménière disease", "ménière disease", "", ""),
+        ],
+    )
+    _write_parquet(
+        con,
+        str(foo_dir / "Synonyms.parquet"),
+        ["clique_leader", "preferred_name", "preferred_name_lc", "biolink_type", "label", "label_lc"],
+        [
+            ("CHEBI:15377", "water", "water", "biolink:SmallMolecule", "dihydrogen oxide", "dihydrogen oxide"),
+            # A damaged synonym under a clean preferred name.
+            ("CHEBI:15377", "water", "water", "biolink:SmallMolecule", "Ã©au", "ã©au"),
+            # A replacement character in the preferred name.
+            ("MESH:1", "acetyl�choline", "acetyl�choline", "biolink:SmallMolecule", "ACh", "ach"),
+        ],
+    )
+    con.close()
+    return str(tmp_path) + "/"
+
+
+@pytest.mark.unit
+def test_check_for_encoding_issues(encoding_parquet_root, tmp_path):
+    out = str(tmp_path / "encoding_issues.tsv")
+    duckdb_reports.check_for_encoding_issues(encoding_parquet_root, str(tmp_path / "db.duckdb"), out)
+
+    rows = _read_tsv(out)
+    header, data = rows[0], rows[1:]
+    assert header == ["source", "filename", "curie", "text"]
+
+    found = {(r[0], r[2], r[3]) for r in data}
+    assert found == {
+        ("Node.label", "PUBCHEM.COMPOUND:1", "Ã©tude"),
+        ("Synonyms.label", "CHEBI:15377", "Ã©au"),
+        ("Synonyms.preferred_name", "MESH:1", "acetyl�choline"),
+    }
+
+
+@pytest.mark.unit
+def test_check_for_encoding_issues_ignores_legitimate_text(encoding_parquet_root, tmp_path):
+    """Accented text and plain ASCII must never be reported -- false positives are the failure
+    mode that matters, since the sibling check in src/synonyms/encoding.py aborts the build."""
+    out = str(tmp_path / "encoding_issues.tsv")
+    duckdb_reports.check_for_encoding_issues(encoding_parquet_root, str(tmp_path / "db.duckdb"), out)
+
+    reported = {r[3] for r in _read_tsv(out)[1:]}
+    assert "Ménière disease" not in reported
+    assert "water" not in reported
+    assert "dihydrogen oxide" not in reported

--- a/tests/synonyms/test_encoding.py
+++ b/tests/synonyms/test_encoding.py
@@ -1,0 +1,210 @@
+"""Unit tests for src/synonyms/encoding.py."""
+
+import json
+
+import pytest
+
+import src.synonyms.encoding as encoding_module
+from src.synonyms.encoding import check_encoding, find_encoding_issue, scan_file
+
+
+@pytest.fixture(autouse=True)
+def _clear_allowlist():
+    """The allowlist is a module-level cache; reset it so tests don't leak into each other."""
+    encoding_module._allowlist = None
+    yield
+    encoding_module._allowlist = None
+
+
+# ---------------------------------------------------------------------------
+# find_encoding_issue: damaged text
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_mojibake_is_detected_and_repair_suggested():
+    """The classic case: UTF-8 'é' read as cp1252 becomes 'Ã©'."""
+    reason = find_encoding_issue("Ã©tude")
+    assert reason is not None
+    assert "étude" in reason
+
+
+@pytest.mark.unit
+def test_mojibake_via_cp1252_suggests_the_original():
+    """windows-1252 is what src/datahandlers/unii.py reads with."""
+    damaged = "N,N–dimethyl".encode().decode("cp1252")
+    assert damaged != "N,N–dimethyl"  # sanity: the misread really did damage it
+    reason = find_encoding_issue(damaged)
+    assert reason is not None
+    assert "N,N–dimethyl" in reason
+    assert "cp1252" in reason
+
+
+@pytest.mark.unit
+def test_mojibake_via_latin1_suggests_the_original():
+    """latin-1 is what src/datahandlers/datacollect.py reads PubChem with.
+
+    It damages text differently from cp1252 -- bytes 0x80-0x9f become C1 control characters rather
+    than printable punctuation -- so it needs its own round-trip to be repairable rather than just
+    detectable.
+    """
+    damaged = "N,N–dimethyl".encode().decode("latin-1")
+    reason = find_encoding_issue(damaged)
+    assert reason is not None
+    assert "N,N–dimethyl" in reason
+    assert "latin-1" in reason
+
+
+@pytest.mark.unit
+def test_replacement_character_is_detected():
+    assert find_encoding_issue("acetyl�choline") is not None
+
+
+@pytest.mark.unit
+def test_byte_order_mark_is_detected():
+    assert find_encoding_issue("﻿water") is not None
+
+
+@pytest.mark.unit
+def test_control_character_is_detected():
+    assert find_encoding_issue("water\x01") is not None
+
+
+# ---------------------------------------------------------------------------
+# find_encoding_issue: text that must NOT be flagged
+#
+# False positives are the expensive failure here: check_encoding() raises, so anything wrongly
+# flagged halts the pipeline.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_plain_ascii_is_clean():
+    assert find_encoding_issue("water") is None
+
+
+@pytest.mark.unit
+def test_legitimate_greek_letter_is_clean():
+    """'α' has no cp1252 byte, so it cannot round-trip and is never mistaken for mojibake."""
+    assert find_encoding_issue("Nα-acetyl-L-lysine") is None
+
+
+@pytest.mark.unit
+def test_legitimate_accented_text_is_clean():
+    assert find_encoding_issue("Ménière disease") is None
+    assert find_encoding_issue("Sjögren syndrome") is None
+
+
+@pytest.mark.unit
+def test_embedded_tab_is_clean():
+    """A label may legitimately contain a tab, so it must not be treated as a control character.
+
+    `NodeFactory.load_extra_labels()` in src/node.py splits with maxsplit=1 specifically to preserve
+    such labels; `tests/node/test_node_factory.py::test_load_extra_labels_tab_in_label` pins that.
+    Flagging tab here would abort the build on data the pipeline deliberately supports.
+    """
+    assert find_encoding_issue("Water\tbottle") is None
+    assert find_encoding_issue("beta\tsubunit\n") is None
+
+
+@pytest.mark.unit
+def test_empty_string_is_clean():
+    assert find_encoding_issue("") is None
+
+
+# ---------------------------------------------------------------------------
+# check_encoding: the raising wrapper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_check_encoding_raises_with_an_actionable_message():
+    with pytest.raises(RuntimeError) as excinfo:
+        check_encoding("Ã©tude", curie="PUBCHEM.COMPOUND:123", source="PUBCHEM.COMPOUND labels file")
+    message = str(excinfo.value)
+    assert "PUBCHEM.COMPOUND:123" in message
+    assert "PUBCHEM.COMPOUND labels file" in message
+    assert "étude" in message
+
+
+@pytest.mark.unit
+def test_check_encoding_passes_clean_text():
+    check_encoding("water", curie="CHEBI:15377", source="CHEBI labels file")
+
+
+@pytest.mark.unit
+def test_allowlisted_text_does_not_raise(monkeypatch):
+    monkeypatch.setattr(encoding_module, "get_config", lambda: {"encoding_check_allowlist": ["Ã©tude"]}, raising=True)
+    check_encoding("Ã©tude", curie="X:1", source="test")
+
+
+@pytest.mark.unit
+def test_check_can_be_disabled(monkeypatch):
+    monkeypatch.setattr(encoding_module, "get_config", lambda: {"encoding_check_enabled": False}, raising=True)
+    check_encoding("Ã©tude", curie="X:1", source="test")
+
+
+# ---------------------------------------------------------------------------
+# scan_file: the reporting path used by the survey tool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_scan_labels_file(tmp_path):
+    path = tmp_path / "labels"
+    path.write_text("CHEBI:15377\twater\nPUBCHEM.COMPOUND:1\tÃ©tude\n", encoding="utf-8")
+    issues = scan_file(path)
+    assert len(issues) == 1
+    line_no, curie, text, _reason = issues[0]
+    assert (line_no, curie, text) == (2, "PUBCHEM.COMPOUND:1", "Ã©tude")
+
+
+@pytest.mark.unit
+def test_scan_synonyms_file(tmp_path):
+    """A synonyms line is three fields; the synonym is the last one, not the second."""
+    path = tmp_path / "synonyms"
+    path.write_text(
+        "CHEBI:15377\thttp://example.org/exactSynonym\tdihydrogen oxide\n"
+        "PUBCHEM.COMPOUND:1\thttp://example.org/relatedSynonym\tÃ©tude\n",
+        encoding="utf-8",
+    )
+    issues = scan_file(path)
+    assert [(curie, text) for _line, curie, text, _reason in issues] == [("PUBCHEM.COMPOUND:1", "Ã©tude")]
+
+
+@pytest.mark.unit
+def test_scan_compendium_jsonl(tmp_path):
+    path = tmp_path / "Chemical.txt"
+    path.write_text(
+        json.dumps(
+            {
+                "type": "biolink:SmallMolecule",
+                "identifiers": [{"i": "PUBCHEM.COMPOUND:1", "l": "Ã©tude"}],
+                "preferred_name": "Ã©tude",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    issues = scan_file(path)
+    # Once for the identifier label, once for the preferred name.
+    assert len(issues) == 2
+    assert all(curie == "PUBCHEM.COMPOUND:1" for _line, curie, _text, _reason in issues)
+
+
+@pytest.mark.unit
+def test_scan_synonyms_jsonl(tmp_path):
+    path = tmp_path / "Chemical.txt"
+    path.write_text(
+        json.dumps({"curie": "PUBCHEM.COMPOUND:1", "names": ["water", "Ã©tude"], "preferred_name": "water"}) + "\n",
+        encoding="utf-8",
+    )
+    issues = scan_file(path)
+    assert [(curie, text) for _line, curie, text, _reason in issues] == [("PUBCHEM.COMPOUND:1", "Ã©tude")]
+
+
+@pytest.mark.unit
+def test_scan_clean_file_returns_nothing(tmp_path):
+    path = tmp_path / "labels"
+    path.write_text("CHEBI:15377\twater\nMONDO:1\tMénière disease\n", encoding="utf-8")
+    assert scan_file(path) == []

--- a/tests/tools/check_encoding/test_cli.py
+++ b/tests/tools/check_encoding/test_cli.py
@@ -1,0 +1,60 @@
+"""Unit tests for the ``babel-check-encoding`` CLI (src/tools/check_encoding/cli.py).
+
+Only the CLI layer — path expansion, exit code, and the TSV it writes. The detector itself lives in
+``src/synonyms/encoding.py`` and is tested in ``tests/synonyms/test_encoding.py``.
+"""
+
+import pytest
+
+from src.tools.check_encoding.cli import find_files, main
+
+
+def _write_labels(path, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(f"{curie}\t{label}\n" for curie, label in rows), encoding="utf-8")
+
+
+@pytest.mark.unit
+def test_exit_code_is_zero_when_clean(tmp_path):
+    _write_labels(tmp_path / "labels", [("CHEBI:15377", "water")])
+    assert main([str(tmp_path / "labels")]) == 0
+
+
+@pytest.mark.unit
+def test_exit_code_is_one_when_damaged(tmp_path):
+    """A non-zero exit lets a script gate on the survey without parsing its output."""
+    _write_labels(tmp_path / "labels", [("PUBCHEM.COMPOUND:1", "Ã©tude")])
+    assert main([str(tmp_path / "labels")]) == 1
+
+
+@pytest.mark.unit
+def test_recursive_finds_labels_synonyms_and_txt(tmp_path):
+    _write_labels(tmp_path / "PUBCHEM.COMPOUND" / "labels", [("PUBCHEM.COMPOUND:1", "water")])
+    _write_labels(tmp_path / "PUBCHEM.COMPOUND" / "synonyms", [("PUBCHEM.COMPOUND:1", "water")])
+    (tmp_path / "Chemical.txt").write_text("{}\n", encoding="utf-8")
+    (tmp_path / "notes.md").write_text("ignore me\n", encoding="utf-8")
+
+    found = {p.name for p in find_files([str(tmp_path)], recursive=True)}
+    assert found == {"labels", "synonyms", "Chemical.txt"}
+
+
+@pytest.mark.unit
+def test_directory_without_recursive_is_an_error(tmp_path):
+    with pytest.raises(RuntimeError, match="--recursive"):
+        find_files([str(tmp_path)], recursive=False)
+
+
+@pytest.mark.unit
+def test_out_tsv_lists_every_issue(tmp_path):
+    _write_labels(
+        tmp_path / "labels",
+        [("CHEBI:15377", "water"), ("PUBCHEM.COMPOUND:1", "Ã©tude"), ("PUBCHEM.COMPOUND:2", "Ã¤ther")],
+    )
+    out_tsv = tmp_path / "issues.tsv"
+    main([str(tmp_path / "labels"), "--out-tsv", str(out_tsv)])
+
+    lines = out_tsv.read_text(encoding="utf-8").splitlines()
+    assert lines[0] == "file\tline\tcurie\ttext\treason"
+    assert len(lines) == 3  # header + the two damaged rows; `water` is clean
+    assert "PUBCHEM.COMPOUND:1" in lines[1]
+    assert "PUBCHEM.COMPOUND:2" in lines[2]


### PR DESCRIPTION
## Context

Babel has no encoding validation anywhere — no `unicodedata`, no mojibake detection, no
normalization. Meanwhile three ingest points read their source with a single-byte codec:

- `src/datahandlers/datacollect.py` — PubChem `CID-Title.gz` / `CID-Synonym-filtered.gz` as `latin-1`
- `src/datahandlers/unii.py` — `UNII_RECORDS_ENCODING = "windows-1252"`, plus a second file as `latin-1`

Reading UTF-8 bytes that way produces mojibake (`é` → `Ã©`), and nothing downstream notices, because
mojibake *is* valid UTF-8 — just wrong text. It flows through the compendia and the synonyms files
and lands in Node Normalization as if it were a real name. The one place Python's codec is touched
on the way out (`duckdb_exporters.py`) raises on *invalid* UTF-8, which this isn't.

## What this adds

| Layer | Where | Behavior |
|---|---|---|
| Detector | `src/synonyms/encoding.py` | round-trip + suspect-character test |
| Pipeline check | 5 load sites in `src/node.py` | **raises** |
| Survey tool | `babel-check-encoding` | reports, exits 1 |
| Backstop | `check_for_encoding_issues` in `duckdb_reports.py` | writes `reports/duckdb/encoding_issues.tsv` |

### The detector

Non-ASCII text is re-encoded to the codec that would have damaged it and decoded as UTF-8. If that
round-trip succeeds and changes the string, it was mojibake — and the repair is reported, which is
what makes the error actionable (`Ã©` alone is a puzzle; "probably meant to be `'é'`" is a
diagnosis). Legitimate non-ASCII fails one of the two steps, so `Ménière disease` and
`Nα-acetyl-L-lysine` stay clean. Secondary signals: C0/C1 controls, `U+FFFD`, a stray BOM.

Both `cp1252` and `latin-1` are tried. They damage bytes `0x80`-`0x9f` differently, and only the
matching one can name the original:

```
PUBCHEM.COMPOUND:3  'N,Nâ\x80\x93dimethyl'
    looks like mojibake (UTF-8 read as latin-1); probably meant to be 'N,N–dimethyl'
```

An `isascii()` gate keeps this affordable at full-build scale — nearly every biomedical label is
pure ASCII and exits in nanoseconds, so only the rare non-ASCII string pays for the round-trip.

### Why the load side, and why it raises

There is **no single write choke point**: twenty-odd datahandlers each write their own
`babel_downloads/<PREFIX>/labels` with a bare `write(f"{curie}\t{label}\n")`. There *is* a single
read choke point — the same one `SynonymFilter` already hooks into. Checking there means each string
is validated once per prefix load, and the error names the file the damage lives in.

Raising rather than warning was a deliberate call: a warning scrolls past in a build log, and the
bad name ships. Re-running one download rule is far cheaper than finding it in a release.
`encoding_check_enabled` and `encoding_check_allowlist` in `config.yaml` are the escape hatches, so
a false positive doesn't need a code change to work around.

No separate write-side pass in `write_compendium()` — everything it writes already arrived through
one of the five load sites, so it would re-check the same strings and report nothing new.

## ⚠️ Before merging: the survey has not been run

The check is armed but **unvalidated against real data**. There's no local `babel_downloads`, and
pulling a snapshot is a large download I didn't want to start unprompted. A full build could halt on
PubChem or UNII. Please run one of these first:

```bash
uv run babel-check-encoding --recursive babel_downloads --out-tsv encoding_issues.tsv
```

against a `stars.renci.org` snapshot — or set `encoding_check_enabled: false` for the first build
and read `reports/duckdb/encoding_issues.tsv` instead.

If that shows real damage, **fixing the latin-1 reads is a follow-up PR, not this one**: changing
PubChem's decode alters millions of records, and `AGENTS.md` is clear that a parsing change needs
the whole file characterized first. This PR produces exactly that evidence.

Also out of scope: NFC/NFKC normalization. That's a deduplication concern, not a corruption one.

## Testing

385 unit tests pass; `ruff`, `snakefmt`, and `rumdl` are clean; `check_for_encoding_issues` resolves
in a `snakemake --dry-run`. New coverage in `tests/synonyms/test_encoding.py`,
`tests/tools/check_encoding/`, `tests/node/test_synonym_factory.py`, `tests/reports/test_duckdb_reports.py`
— weighted toward the false-positive cases, since those are what would halt a build.

One bug worth surfacing: I first treated an embedded tab as damage. `NodeFactory.load_extra_labels()`
splits with `maxsplit=1` specifically to preserve tab-containing labels, and
`test_load_extra_labels_tab_in_label` pins that. The full suite caught it; tab is now explicitly
excluded, with a comment pointing at the loader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
