### PR TITLE
Harden the Rust extension contract and close the maturin build gaps

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -24,7 +24,24 @@ jobs:
       - uses: actions/checkout@v7
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v7
-      - run: uv run snakefmt --check --compact-diff .
+      # --no-project: snakefmt does not need babel-pipeline installed, and a plain `uv run` here
+      # would sync the project, which since the maturin swap means invoking cargo. That left a lint
+      # job depending on the runner image happening to ship a Rust toolchain.
+      - run: uv run --no-project --with snakefmt snakefmt --check --compact-diff .
+
+  check-formatting-with-cargo:
+    name: Check Rust formatting and lints with cargo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+      - run: cargo fmt --manifest-path rust/Cargo.toml --check
+      - run: cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings
 
   check-formatting-with-rumdl:
     name: Check Markdown formatting with rumdl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,9 @@ jobs:
         with:
           python-version: "3.11"
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
       - run: uv sync --frozen
       - run: PYTHONPATH=. uv run pytest --collect-only -q
       - run: PYTHONPATH=. uv run pytest -m unit --no-cov -q
@@ -36,5 +39,8 @@ jobs:
         with:
           python-version: "3.11"
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
       - run: uv sync --frozen
       - run: PYTHONPATH=. uv run pytest --network -m "unit or network or slow" --no-cov -q

--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ htmlcov/
 
 # maturin / Rust build artifacts
 rust/target/
-# native extension dropped into src/ by `maturin develop` (don't commit compiled binaries)
-src/rs.*.so
-src/rs.*.pyd
-src/rs.*.dylib
+# native extension dropped into src/ by an editable install (don't commit compiled binaries)
+src/_accel*.so
+src/_accel*.pyd
+src/_accel*.dylib

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ Memory-hungry tests also carry a parametrized `min_memory_gb(n)` guard (register
 - `docs/Testing.md` — testing strategy: cadence per environment (per-PR, nightly, weekly,
   pre-release), GitHub Actions vs HPC self-hosted runner trade-offs, and other strategies.
 
-### Linting (all four checked in CI on PRs)
+### Linting (all five checked in CI on PRs)
 
 ```bash
 uv run ruff check                        # Python lint
@@ -81,6 +81,8 @@ uv run snakefmt --check --compact-diff . # Snakemake format check
 uv run snakefmt .                        # Snakemake auto-fix
 uv run rumdl check .                     # Markdown lint
 uv run rumdl fmt .                       # Markdown auto-fix
+cargo fmt --manifest-path rust/Cargo.toml           # Rust format
+cargo clippy --manifest-path rust/Cargo.toml        # Rust lint
 ```
 
 ### Configuration
@@ -259,6 +261,15 @@ ingest is in `docs/Development.md` ("Enhancing a data source ingest"); datahandl
 - **Docstrings** — give modules, classes, and non-trivial functions a docstring covering what they
   do and any non-obvious behavior. Name functions for what they do — `fetch_*` (not `get_*`) when
   the call hits the network.
+
+- **Rust accelerators** — a `#[pyfunction]` takes a file path and returns the whole parsed result;
+  never export one that is called once per row, because crossing pyo3 per CURIE costs more than the
+  Python it replaces. Every accelerated function keeps its Python implementation as the reference,
+  with a test asserting the two agree, and is reached through `src/accel.py` (never `src._accel`
+  directly) so a missing extension falls back rather than breaking DAG parsing for all 245 rules.
+  Pick targets from a run's `benchmark:` TSVs, not by reading code — see
+  [`docs/Rust.md`](docs/Rust.md), which also records the three targets chosen that way that turned
+  out to be pure-Python bugs.
 
 ## Debugging
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,16 @@ RUN adduser --home ${ROOT} --uid 1000 nru
 RUN mkdir -p ${ROOT}
 WORKDIR ${ROOT}
 
-# Rust toolchain — required because the build backend is maturin (compiles a native extension).
-RUN apt-get update && apt-get install -y cargo
+# Rust toolchain — required because the build backend is maturin, which compiles a native
+# extension on every `uv sync`. Installed via rustup rather than `apt install cargo`: Debian
+# bookworm ships cargo 1.63, which is *exactly* pyo3 0.23's minimum, so the next pyo3 bump would
+# break this image with an error that reads as unrelated. rustup also honours rust-toolchain.toml,
+# which apt's cargo ignores.
+ENV RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo
+ENV PATH=${CARGO_HOME}/bin:${PATH}
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --no-modify-path --profile minimal --default-toolchain stable \
+    && chmod -R a+rX ${RUSTUP_HOME} ${CARGO_HOME}
 
 USER nru
 COPY --chown=nru . ${ROOT}

--- a/docs/Rust.md
+++ b/docs/Rust.md
@@ -1,0 +1,139 @@
+# Rust in Babel
+
+Babel's expensive rules are CPU-bound single-threaded Python. From the `babel-1.18` Snakemake
+`benchmark:` TSVs, the five costliest rules all run at ~100% of one core:
+
+| Rule | Wall | CPU | `mean_load` | `max_rss` |
+|------|------|-----|-------------|-----------|
+| `generate_pubmed_concords` | 71,947 s (20 h) | 71,753 s | 99.7% | 31 GB |
+| `protein_compendia` | 19,876 s | 19,844 s | 99.8% | 246 GB |
+| `chemical_compendia` | 19,643 s | 19,569 s | 99.5% | 335 GB |
+| `geneprotein_conflated_synonyms` | 15,719 s | 15,702 s | 99.8% | 98 GB |
+| `gene_compendia` | 15,400 s | 15,178 s | 98.5% | 179 GB |
+
+The build backend is therefore [maturin](https://www.maturin.rs/), and the project builds as a
+mixed Rust/Python package: a `cdylib` crate under `rust/` compiled into `src/_accel`, alongside the
+ordinary Python in `src/`.
+
+## Rules for adding a Rust function
+
+**Measure first, from the benchmark TSVs.** Not from reading code for quadratic-looking shapes.
+Three candidate targets picked that way all turned out to be wrong: `SynonymFilter.should_suppress`
+looks like an O(labels × entries) scan but `input_data/obsolete_synonyms.yaml` holds three entries;
+concord parsing looks like the obvious string-manipulation target but runs 159,283 lines in
+0.148 s; and each genuinely expensive rule examined had a pure-Python defect (an eagerly evaluated
+f-string feeding a suppressed `logger.debug`, a missing `elem.clear()`) worth more than any port.
+Check `mean_load` before assuming a slow rule is CPU-bound — `get_ensembl` is 6,665 s wall but only
+257 s CPU, so Rust would do nothing for it.
+
+**The FFI boundary is coarse.** A `#[pyfunction]` takes a file path and returns the whole parsed
+result. It never takes one row. Crossing pyo3 once per CURIE costs more than the Python it
+replaces, so a per-row entry point would be *slower* while looking like an optimisation. This is
+enforced structurally: Rust functions open their own files, so there is no entry point that could
+accept a row.
+
+**Keep the Python implementation as the reference.** Every accelerated function keeps its Python
+version in the tree, and a unit test asserts the two produce identical output over the same input.
+The Python is the specification; the test is the proof the Rust matches it. This is also what makes
+the fallback below safe, and what lets a differential test be written before the Rust exists.
+
+**Bump `ABI_VERSION` in the same commit** as any change to an accelerated function's signature or
+semantics — in both `rust/src/lib.rs` and `_REQUIRED_ABI_VERSION` in `src/accel.py`. See
+"Staleness" below.
+
+## Using it from Python
+
+Import through [`src/accel.py`](../src/accel.py), never `src._accel` directly:
+
+```python
+from src.accel import accel
+
+def read_something(path):
+    if accel is not None:
+        return accel.read_something(path)
+    return _read_something_python(path)
+```
+
+`accel` is the compiled module when it is present, importable and current, and `None` otherwise.
+
+**A missing extension falls back to Python rather than raising.** Every snakefile does a top-level
+`import src.foo` at DAG-parse time, so an `ImportError` would take down all 245 rules for a
+contributor without a Rust toolchain, for a reviewer, and for a fork's CI — not just the rules that
+would have used Rust. AGENTS.md's "a log warning is not a control" is about *wrong output*; a slower
+path producing identical bytes is not that. The active implementation is logged once at INFO, which
+lands in the SLURM job log that `babel-slurm-errors` reads.
+
+**`BABEL_DISABLE_RUST=1` forces the Python path**, which is how you A/B a port in one checkout. It
+is an environment variable rather than a `config.yaml` entry deliberately: which of two
+byte-identical implementations runs is an implementation detail with no user-facing meaning, and
+`config.yaml` is threaded into Snakemake `params` and output paths, where changing it risks
+perturbing the DAG of a running build. Precedent: `BABEL_DUCKDB_TEMP_DIR`.
+
+## Staleness
+
+The extension is installed **editable**: the compiled artifact lands in the checkout at
+`src/_accel.*.so` (gitignored), and that is the copy `PYTHONPATH=.` finds. A `git pull` that brings
+new Rust source does **not** rebuild it, so without a guard a stale binary would be used silently
+— potentially for a 12-hour rule.
+
+So `src/accel.py` compares the extension's `ABI_VERSION` against its own `_REQUIRED_ABI_VERSION`
+and raises if they disagree. The check runs at import, i.e. at DAG-parse time, so a stale build
+fails in the first second of a run. To fix one:
+
+```bash
+uv sync --reinstall-package babel-pipeline
+```
+
+What the guard does not catch is editing the Rust body without bumping the constant. That is what
+the differential tests are for — they compare against the Python reference regardless of where the
+`.so` came from, which also covers a `.so` served from a stale uv or cargo cache in CI.
+
+## Building
+
+A Rust toolchain is a build prerequisite for **every** environment now, because `[tool.uv] package
+= true` means every `uv run` and `uv sync` builds the project, and building the project invokes
+cargo.
+
+- **Locally:** `uv sync`. If `cargo` is not on `$PATH`, uv bootstraps a toolchain itself (via
+  `puccinialin`) rather than failing — convenient, but it silently downloads ~600 MB into a
+  platform cache directory that `UV_CACHE_DIR` does **not** cover. Installing rustup yourself
+  (`brew install rustup && rustup default stable`, or <https://rustup.rs>) avoids that.
+- **CI:** `dtolnay/rust-toolchain@stable` plus `Swatinem/rust-cache@v2` in `test.yml`. The
+  formatting workflow deliberately runs snakefmt with `uv run --no-project` so that a lint job does
+  not build the project at all.
+- **Docker:** the image installs rustup rather than `apt install cargo`. Debian bookworm ships
+  cargo 1.63, which is *exactly* pyo3 0.23's minimum, so the next pyo3 bump would break the image
+  with an error that reads as unrelated. rustup also honours `rust-toolchain.toml`, which apt's
+  cargo ignores.
+- **Hatteras:** `uv sync` runs once on the login node and compute nodes reuse the `.venv` from
+  `/projects`, so compilation happens in one place. Make sure a toolchain is available there before
+  a build — `uv sync --frozen` fails outright without one, before Snakemake starts. See
+  [`slurm/README.md`](../slurm/README.md).
+
+`rust-toolchain.toml` pins the channel (`stable`) rather than an exact version: nothing here
+publishes a wheel, so the value of pinning is that everyone's cargo comes from the same place
+rather than from whatever a distro packages. The hard floor is `rust-version` in `rust/Cargo.toml`.
+
+## Layout
+
+| Path | What |
+|------|------|
+| `rust/Cargo.toml` | the crate. `version` is `0.0.0` on purpose — maturin takes the distribution version from the root `pyproject.toml`, and nothing publishes this crate |
+| `rust/src/lib.rs` | the `#[pymodule]`: module doc, `ABI_VERSION`, registrations. Functions go in their own modules, split from the first one |
+| `src/accel.py` | the only thing that imports the compiled module |
+| `src/_accel.pyi` | hand-written stub. There is no mypy here, so it enforces nothing; it exists so a reader who does not read Rust can see what the module offers |
+| `rust-toolchain.toml` | channel pin |
+
+## History
+
+[PR #588](https://github.com/NCATSTranslator/Babel/pull/588) took a different approach — 19
+standalone binaries under `babel_io/src/bin/` invoked from Snakemake `shell:` blocks — and is worth
+reading as a cautionary tale. It targeted datacollect label/synonym rules totalling roughly 1.5 h of
+CPU, under 2% of the pipeline, two of them download-bound where Rust does nothing; the one binary
+aimed at an expensive rule (`build_compendia.rs`) is a 72-line stub. 3,252 lines across 44 files,
+unmerged. Hence the "measure first" and "one path, deep" rules above.
+
+The in-process pyo3 model that replaced it fits the codebase better regardless: 245 of Babel's
+Snakemake rules are `run:` blocks with no `script:` directives and no subprocess boundaries, so an
+importable extension needs no rule rewriting, whereas standalone binaries would mean converting
+rules to `shell:` one at a time.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,11 +61,15 @@ build-backend = "maturin"
 
 [tool.maturin]
 # The importable Python package is literally named `src` (flat layout). A dotted module-name
-# places the compiled extension at `src/rs.*` and tells maturin the package to bundle is `src`
-# (auto-resolved to the repo root since src-layout detection won't fire).
-module-name = "src.rs"
+# places the compiled extension at `src/_accel.*` and tells maturin the package to bundle is `src`
+# (auto-resolved to the repo root since src-layout detection won't fire). Import it through
+# src/accel.py, never directly -- see docs/Rust.md.
+module-name = "src._accel"
 # Rust source lives under rust/ so Cargo never collides with the Python `src/` dir.
 manifest-path = "rust/Cargo.toml"
+# maturin bundles the whole `src` tree, which otherwise ships the per-directory agent instruction
+# files to anyone who installs the wheel.
+exclude = ["**/CLAUDE.md"]
 
 
 # Linting/formatting configuration

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+# Pin the channel, not an exact version: nothing here publishes a wheel, so the value of pinning is
+# that everyone's cargo comes from the same place rather than from whatever a distro packages.
+# The hard floor is `rust-version` in rust/Cargo.toml.
+[toolchain]
+channel = "stable"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "babel-pipeline"
-version = "1.17.0"
+version = "0.0.0"
 dependencies = [
  "pyo3",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,10 +1,17 @@
 [package]
 name = "babel-pipeline"
-version = "1.17.0"   # valid SemVer (3 parts); published version is "1.17" from root pyproject
+# Not the distribution version: maturin takes that from the root pyproject.toml (the built wheel is
+# babel_pipeline-<pyproject version>-cp311-abi3-*.whl), and nothing publishes this crate to
+# crates.io. Kept at 0.0.0 so there is no second version number to remember to bump.
+version = "0.0.0"
 edition = "2021"
+# The floor pyo3 0.23 itself requires. Declared so a too-old cargo fails with a clear MSRV message
+# rather than a syntax error from somewhere inside a dependency. Note this binds rustup-managed
+# toolchains only -- see docs/Rust.md on why the Dockerfile installs rustup rather than apt cargo.
+rust-version = "1.63"
 
 [lib]
-name = "rs"                   # matches the #[pymodule] fn + module-name's last component
+name = "_accel"               # matches the #[pymodule] fn + module-name's last component
 crate-type = ["cdylib"]
 
 [dependencies]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,13 +1,36 @@
-//! Placeholder native extension for babel-pipeline.
+//! Native accelerators for babel-pipeline, importable as `from src import _accel`.
 //!
-//! The build backend is maturin; this empty module exists only so the project builds as a
-//! mixed Rust/Python package. Real functionality will land in a follow-up PR.
+//! Every function here must have a byte-identical Python implementation that stays in the tree as
+//! the reference, and a test asserting the two agree (see `src/accel.py` and docs/Rust.md). Rust is
+//! an optimisation, never the only way to produce a given output: `src/accel.py` falls back to the
+//! Python implementation when this extension is missing, because every snakefile imports `src.*` at
+//! DAG-parse time and a hard import failure would take down all 245 rules for anyone without a
+//! Rust toolchain.
+//!
+//! **The FFI boundary is coarse, and that is a rule, not a preference.** A `#[pyfunction]` here
+//! takes a file path and returns the whole parsed result; it never takes one row. Crossing pyo3
+//! once per CURIE costs more than the Python it would replace, so a per-row entry point would be
+//! slower while looking like an optimisation. Functions open their own files so there is no entry
+//! point that *could* accept a row.
+//!
+//! Real accelerators land once the Python `read_concord_file` they mirror is on main; this module
+//! currently exports only the ABI version that guards against a stale build.
 
 use pyo3::prelude::*;
 
-/// Empty pyo3 module, importable as `from src import rs`. Name must match the last component
-/// of `[tool.maturin] module-name` ("src.rs" → `rs`).
+/// Bumped by hand whenever a function's signature or semantics change, in the same commit.
+///
+/// `src/accel.py` compares this against its own `_REQUIRED_ABI_VERSION` at import time and raises
+/// if they disagree. That matters because the extension is installed editable: the compiled
+/// artifact sits in the checkout at `src/_accel.*.so` and a `git pull` does not rebuild it, so
+/// without this check a stale binary would be used silently for a 12-hour rule.
+///
+// ponytail: a hand-bumped integer. Move to a build-time hash of this crate's sources if anyone
+// forgets to bump it twice.
+const ABI_VERSION: u32 = 1;
+
 #[pymodule]
-fn rs(_m: &Bound<'_, PyModule>) -> PyResult<()> {
+fn _accel(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add("ABI_VERSION", ABI_VERSION)?;
     Ok(())
 }

--- a/slurm/README.md
+++ b/slurm/README.md
@@ -12,6 +12,14 @@ running it in a low-memory low-CPU node (by running `sbatch run-babel-on-slurm.s
 [run-babel-on-slurm.sh](./run-babel-on-slurm.sh)) works fine, and ensures that you don't get
 complaints from your cluster manager about long-running login node processes.
 
+`uv sync` now needs a Rust toolchain on the login node: the build backend is maturin, which
+compiles a native extension (see [`docs/Rust.md`](../docs/Rust.md)). Without `cargo` on `$PATH`, uv
+downloads a toolchain itself into a platform cache directory that the `UV_CACHE_DIR` override in
+[`run-babel-on-slurm.sh`](./run-babel-on-slurm.sh) does **not** cover, which on a quota'd home
+directory is its own problem — so install rustup (or `module load` a Rust toolchain) first. Only
+the login node needs it: `uv sync` runs once there and the compute nodes reuse the resulting
+`.venv` from `/projects`.
+
 ```bash
 # Activate the environment
 uv sync

--- a/src/_accel.pyi
+++ b/src/_accel.pyi
@@ -1,0 +1,9 @@
+"""Type stub for the compiled Rust extension built from rust/src/lib.rs.
+
+Hand-written and hand-maintained: there is no mypy in this repo, so nothing enforces that this
+matches the Rust. It exists so a reader who does not read Rust can see what the module offers.
+Import through src/accel.py rather than importing this module directly.
+"""
+
+# Bumped in lockstep with ABI_VERSION in rust/src/lib.rs; see src/accel.py.
+ABI_VERSION: int

--- a/src/accel.py
+++ b/src/accel.py
@@ -1,0 +1,82 @@
+"""Access to the optional Rust accelerators, with the Python implementations as the reference.
+
+Babel's expensive rules are CPU-bound single-threaded Python (`generate_pubmed_concords` alone is
+20 h at 99.7% CPU in the babel-1.18 benchmarks), so some of them will get Rust implementations.
+This module is the one place that decides whether a Rust implementation is available and safe to
+use. Nothing else should import ``src._accel`` directly.
+
+Three rules govern how Rust is used here, and each exists for a specific reason:
+
+**Rust is an accelerator, never the only implementation.** Every accelerated function keeps its
+Python version in the tree, and a unit test asserts the two produce identical output. That is what
+makes a Rust port reviewable: the Python is the specification, and the test is the proof the Rust
+matches it. It also means a differential test can be written before the Rust exists.
+
+**A missing extension falls back to Python; it does not raise.** Every snakefile does a top-level
+``import src.foo`` at DAG-parse time, so an ImportError here would take down all 245 rules for a
+contributor without a Rust toolchain, for a reviewer, and for a fork's CI. AGENTS.md's "a log
+warning is not a control" is about *wrong output*; a slower path that produces identical bytes is
+not that. The active implementation is logged once, at INFO, so it lands in the SLURM job log.
+
+**A stale extension raises.** That is a bug, not a configuration. The extension is installed
+editable -- the compiled artifact lives in the checkout at ``src/_accel.*.so`` -- so ``git pull``
+does not rebuild it and a stale binary would otherwise be used silently. The check runs at import
+of this module, i.e. at DAG-parse time, so a stale build fails in the first second of a run rather
+than eleven hours into a 12-hour rule.
+
+Set ``BABEL_DISABLE_RUST=1`` to force the Python path (for an A/B measurement, or to rule the
+extension out while debugging). This is an environment variable rather than a ``config.yaml``
+entry deliberately: which of two byte-identical implementations runs is an implementation detail
+with no user-facing meaning, and ``config.yaml`` is threaded into Snakemake ``params`` and output
+paths where changing it risks perturbing the DAG of a running build. Precedent:
+``BABEL_DUCKDB_TEMP_DIR`` in ``src/exporters/duckdb_exporters.py``.
+"""
+
+import os
+
+from src.util import get_logger
+
+logger = get_logger(__name__)
+
+# Must equal ABI_VERSION in rust/src/lib.rs. Both are bumped by hand, in the same commit, whenever
+# an accelerated function's signature or semantics change.
+_REQUIRED_ABI_VERSION = 1
+
+
+def check_abi_version(compiled, required=_REQUIRED_ABI_VERSION):
+    """Return ``compiled`` if its ABI_VERSION matches ``required``, else raise RuntimeError.
+
+    Separate from the import below so it can be tested against a stub module: building a genuinely
+    stale extension to exercise this would mean compiling Rust inside a unit test.
+    """
+    found = getattr(compiled, "ABI_VERSION", None)
+    if found != required:
+        raise RuntimeError(
+            f"The compiled Rust extension src/_accel is stale: it reports ABI_VERSION {found!r}, "
+            f"but this checkout needs {required!r}. The extension is installed editable, so "
+            f"pulling new Rust source does not rebuild it. Run "
+            f"`uv sync --reinstall-package babel-pipeline`, or set BABEL_DISABLE_RUST=1 to run "
+            f"the Python implementations instead."
+        )
+    return compiled
+
+
+# Set to the compiled module when it is present, importable and current; None otherwise. Callers
+# should treat it as "use the Rust path if this is not None".
+accel = None
+
+if os.environ.get("BABEL_DISABLE_RUST"):
+    logger.info("BABEL_DISABLE_RUST is set; using the Python implementations.")
+else:
+    try:
+        from src import _accel as _compiled
+    except ImportError:
+        # Expected whenever the extension has not been built. Not an error: see the module
+        # docstring on why this must not take down the whole DAG.
+        logger.info(
+            "The Rust extension src/_accel is not built; using the Python implementations. "
+            "Build it with `uv sync` (see docs/Rust.md)."
+        )
+    else:
+        accel = check_abi_version(_compiled)
+        logger.info("Using the Rust extension src/_accel (ABI_VERSION %s).", accel.ABI_VERSION)

--- a/tests/test_accel.py
+++ b/tests/test_accel.py
@@ -1,0 +1,120 @@
+"""Unit tests for src/accel.py, the gateway to the optional Rust extension.
+
+src/accel.py decides whether the compiled extension is available and safe to use. Its three
+branches each have a consequence that is expensive to discover late:
+
+- a missing extension must fall back to Python, because every snakefile imports `src.*` at
+  DAG-parse time and raising would take down all 245 rules for anyone without a Rust toolchain;
+- a stale extension must raise, because the extension is installed editable and a `git pull` does
+  not rebuild it, so a silent stale binary could run for a 12-hour rule;
+- `BABEL_DISABLE_RUST` must force the Python path, which is what makes an A/B measurement possible.
+
+The module resolves availability at import time, so the fallback branches are tested by reloading
+it under a patched environment. The staleness check is tested directly against stub modules --
+building a genuinely stale extension would mean compiling Rust inside a unit test.
+"""
+
+import builtins
+import importlib
+import types
+
+import pytest
+
+import src.accel
+
+
+def reload_accel(monkeypatch, *, disable=None, hide_extension=False):
+    """Re-import src.accel under a patched environment and return the fresh module."""
+    monkeypatch.delenv("BABEL_DISABLE_RUST", raising=False)
+    if disable is not None:
+        monkeypatch.setenv("BABEL_DISABLE_RUST", disable)
+
+    if hide_extension:
+        real_import = builtins.__import__
+
+        def fail_on_accel(name, globals=None, locals=None, fromlist=(), level=0):
+            if fromlist and "_accel" in fromlist:
+                raise ImportError("no compiled extension in this test")
+            return real_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", fail_on_accel)
+
+    return importlib.reload(src.accel)
+
+
+@pytest.fixture(autouse=True)
+def restore_accel():
+    """Leave src.accel in its real state, so reloads here can't leak into other tests."""
+    yield
+    importlib.reload(src.accel)
+
+
+def stub_extension(version):
+    """A stand-in for the compiled module, carrying just the attribute the guard reads."""
+    module = types.ModuleType("src._accel")
+    if version is not None:
+        module.ABI_VERSION = version
+    return module
+
+
+# FALLING BACK TO PYTHON
+
+
+@pytest.mark.unit
+def test_a_missing_extension_falls_back_instead_of_raising(monkeypatch):
+    """Without a compiled extension, importing src.accel must succeed and expose accel = None.
+
+    Raising here would break every Snakemake target for a contributor with no Rust toolchain, not
+    just the rules that would have used Rust.
+    """
+    assert reload_accel(monkeypatch, hide_extension=True).accel is None
+
+
+@pytest.mark.unit
+def test_babel_disable_rust_forces_the_python_path(monkeypatch):
+    """BABEL_DISABLE_RUST=1 should select the Python implementations even when the extension is
+    built, so the two can be timed against each other in one checkout."""
+    assert reload_accel(monkeypatch, disable="1").accel is None
+
+
+# GUARDING AGAINST A STALE BUILD
+
+
+@pytest.mark.unit
+def test_a_matching_abi_version_is_accepted():
+    """The guard returns the module untouched when the versions agree."""
+    stub = stub_extension(src.accel._REQUIRED_ABI_VERSION)
+    assert src.accel.check_abi_version(stub) is stub
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "version,description",
+    [
+        (src.accel._REQUIRED_ABI_VERSION + 1, "extension newer than the checkout"),
+        (src.accel._REQUIRED_ABI_VERSION - 1, "extension older than the checkout"),
+        (None, "extension predates ABI_VERSION existing at all"),
+    ],
+)
+def test_a_mismatched_abi_version_raises_with_a_rebuild_instruction(version, description):
+    """Any mismatch must raise, and the message must say how to fix it.
+
+    The rebuild command is asserted because that is the whole point of the error: the person who
+    hits it is mid-run and needs the fix, not a diagnosis.
+    """
+    assert description  # names the case in the failure output
+    with pytest.raises(RuntimeError, match="uv sync --reinstall-package babel-pipeline"):
+        src.accel.check_abi_version(stub_extension(version))
+
+
+@pytest.mark.unit
+def test_the_built_extension_matches_the_version_python_expects():
+    """If the extension is built, its ABI_VERSION must be the one this checkout expects.
+
+    Both constants are bumped by hand in the same commit. Failing in CI after a Rust change means
+    the bump was forgotten; failing locally means the checkout needs
+    `uv sync --reinstall-package babel-pipeline`.
+    """
+    if src.accel.accel is None:
+        pytest.skip("compiled extension not built")
+    assert src.accel.accel.ABI_VERSION == src.accel._REQUIRED_ABI_VERSION


### PR DESCRIPTION
> **Targets #975's branch, not `main`.** @SkyeAv — this is offered *to* you, to merge into #975 if you like it, or ignore. It does not modify your commits. Written by Claude at @gaurav's request; @gaurav has reviewed the outcome but not line-by-line.

Two things: hardening the extension's contract, and closing three gaps where the maturin swap has consequences that had not been followed through.

## Naming and the two failure modes

**`rs` → `_accel`.** The name should say what it is (a compiled accelerator), not what it is written in. While the module is empty this rename is as cheap as it will ever be — not worth a fight if you prefer `rs`.

**`src/accel.py` is now the only thing that imports the compiled module**, because the two failure modes need opposite handling and neither is obvious at the call site:

- **A missing extension falls back to Python** and logs at INFO. Every snakefile does a top-level `import src.foo` at DAG-parse time, so raising would take down **all 243 rules** for a contributor without a Rust toolchain, for a reviewer, and for a fork's CI — not just the rules that would have used Rust. AGENTS.md's "a log warning is not a control" is about *wrong output*; a slower path emitting identical bytes is not that.
- **A stale extension raises.** The extension is installed editable, so the compiled artifact sits in the checkout at `src/_accel.*.so` and a `git pull` does **not** rebuild it. `ABI_VERSION` is compared against `_REQUIRED_ABI_VERSION` at import — i.e. at DAG-parse time — so a stale build fails in the first second rather than partway through a 12 h rule. The check is a separate function so it can be tested against a stub; building a genuinely stale extension inside a unit test would mean compiling Rust.

`BABEL_DISABLE_RUST=1` forces the Python path, which is what makes an A/B measurement possible in one checkout. An environment variable rather than a `config.yaml` entry: which of two byte-identical implementations runs has no user-facing meaning, and `config.yaml` is threaded into Snakemake `params` and output paths where changing it could perturb a running DAG. Precedent is `BABEL_DUCKDB_TEMP_DIR`.

All three paths verified by hand, not just by test.

## Three gaps the maturin swap opens

Since `[tool.uv] package = true`, every `uv run` and `uv sync` builds the project, and building it invokes cargo.

- **`check-formatting.yml`'s snakefmt job runs `uv run` with no toolchain step.** It would have passed *by accident*, because `ubuntu-latest` ships Rust — which is worse than failing, since it makes a lint job depend on the runner image. Fixed by not building at all: `uv run --no-project --with snakefmt`.
- **The Dockerfile installed Debian bookworm's cargo, which is 1.63 — exactly pyo3 0.23's minimum.** It builds today and breaks on the next pyo3 bump with an error that reads as unrelated. Swapped for rustup, which also honours `rust-toolchain.toml` (apt's cargo ignores it).
- **Nothing in `slurm/`, `kubernetes/` or `docs/` mentioned Rust**, while `uv sync --frozen` on the Hatteras login node now **fails outright** without a toolchain — before Snakemake starts. `slurm/README.md` now says so, and notes that uv's own fallback downloads ~600 MB into a cache directory the `UV_CACHE_DIR` override in `run-babel-on-slurm.sh` does *not* cover.

## Housekeeping

- `cargo fmt`/`clippy` job mirroring the one-linter-per-job structure of the other three, so "all four linters checked in CI" does not quietly become four of five languages. Plus `Swatinem/rust-cache` so every PR does not rebuild pyo3.
- `rust/Cargo.toml` version → `0.0.0`: maturin takes the distribution version from `pyproject.toml` (the wheel is still `babel_pipeline-1.17-cp311-abi3`) and nothing publishes this crate, so a second version number is only a thing to forget to bump. `rust-version` declares pyo3's 1.63 floor; `rust-toolchain.toml` pins the channel.
- **`[tool.maturin] exclude` stops the four per-directory `CLAUDE.md` agent-instruction files shipping to anyone who installs the wheel.** Verified by rebuilding: the wheel holds `src/_accel.abi3.so`, `src/_accel.pyi`, 98 `.py` files and the 19 `.snakefile`s, and no `CLAUDE.md`.

## One thing worth flagging about #975 itself

Comparing wheels: `main`'s ships **zero** non-Python files, while the maturin wheel adds the 19 `.snakefile`s. That is an accidental **fix** — an installed `babel-pipeline` previously could not run the pipeline — but it is a behaviour change worth knowing about.

Also, the "Rust toolchain is now a build prerequisite" caveat in #975's description is a little stronger than reality: **uv bootstraps a toolchain itself** (via `puccinialin`) when cargo is missing. Verified by building with no cargo on `$PATH`. The real cost is a silent ~600 MB download, not a failure — except on Hatteras, where `--frozen` does fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
