### PR TITLE
Document the long-term archiving strategy for past runs

### DIFF
--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -13,7 +13,9 @@ to users who aren't system administrators for these tools:
 ## Release process and checkpoints
 
 1. Create a new Babel release (see README.md for information).
-2. Store the Babel outputs alongside other Babel releases on Hatteras.
+2. Store the Babel outputs alongside other Babel releases on Hatteras. How long past runs are kept
+   there is set by the retention policy in
+   [`slurm/README.md`](../slurm/README.md#storage-and-archiving-on-hatteras).
 3. Deploy a new NodeNorm instance
    1. Split the Babel outputs into smaller files to improve load times and put them on a public web
       server. The split sizes and the reason for splitting are documented in

--- a/docs/Downloads.md
+++ b/docs/Downloads.md
@@ -2,7 +2,10 @@
 
 Babel downloads are available at <https://stars.renci.org/var/babel_outputs/> with subdirectories
 for each release. Significant releases are documented in the
-[Releases directory](../releases/README.md).
+[Releases directory](../releases/README.md). This published copy is intended to be the permanent
+one — the working copies on Hatteras are pruned under the retention policy in
+[`slurm/README.md`](../slurm/README.md#storage-and-archiving-on-hatteras), which also records which
+older releases were published only partially, or not at all.
 
 There are several different Babel outputs that we make available for download:
 

--- a/docs/RunningBabel.md
+++ b/docs/RunningBabel.md
@@ -287,6 +287,8 @@ profile in [`slurm/`](../slurm/). See [`slurm/README.md`](../slurm/README.md) fo
 * Per-rule memory and runtime allocations, including which rules need a largemem node.
 * DuckDB memory tuning: `memory_limit` caps, single-threaded query settings, per-job spill
   subdirectories, and `write_buffer_row_group_count`.
+* Where a finished run is stored on Hatteras and on RENCI Stars, and the retention policy for how
+  long past runs are kept.
 * Known issues and their mitigations — notably the `vm.max_map_count` mmap-count limit that causes
   `bad allocation` failures with plenty of free RAM, what was investigated (`MALLOC_ARENA_MAX=2`,
   disabling the external file cache) and ruled out, and the `memory_limit` cap that keeps the rules

--- a/slurm/README.md
+++ b/slurm/README.md
@@ -238,6 +238,100 @@ filesystem — set `BABEL_DUCKDB_TEMP_DIR` in the job environment; an individual
 `temp_directory` / `max_temp_directory_size` in its `duckdb_config`. Do not point the
 500 GB-spilling `export_*` rules at `/tmp` or `/dev/shm`.
 
+## Storage and Archiving on Hatteras
+
+This section is the current retention policy for past Babel runs. It came out of
+[issue #454](https://github.com/NCATSTranslator/Babel/issues/454), which remains the record of how
+the policy was arrived at and of the 2025 cleanup that applied it; the sizes below are that issue's
+measurements. Update this section, not the issue, when the policy changes.
+
+Three sizes are worth remembering, per run:
+
+| Directory                                 | Size  | Kept? |
+|-------------------------------------------|-------|-------|
+| `babel_downloads/`                        | ~200G | **No** — see below |
+| `babel_outputs/` (compendia uncompressed) | ~800G | Yes — this is what "a run" means for archiving purposes |
+| `babel_outputs/` (compendia compressed)   | ~600G | Yes |
+
+`intermediate/` lives inside `babel_outputs/` and is archived along with everything else there; it
+is not a separate tier.
+
+What *is* lost is `babel_downloads/` — the per-source snapshot the run was built from: each source's
+downloaded files plus the `labels`, `synonyms` and related extracts derived from them. It is never
+archived, and it is not reproducible after the fact: re-running the download rules fetches whatever
+the upstream sources hold *today*, not what they held when the run was built. Deleting a run's
+downloads therefore permanently forecloses questions of the form "what did this source actually say
+at the time?" — those have to be answered from `babel_outputs/intermediate/` instead.
+
+### Where a run lives
+
+Hatteras holds the **working copy** under `/projects/babel/runs/<version>/` — the whole
+`babel_outputs/` tree as the pipeline wrote it.
+
+RENCI Stars holds the **published copy** at `https://stars.renci.org/var/babel_outputs/<version>/`,
+written by [`../scripts/rsync-to-server.sh`](../scripts/rsync-to-server.sh). That script copies all
+of `babel_outputs/` *except* `duckdb/duckdbs/`, so the `.duckdb` databases are the only current
+output not published — and they can be rebuilt from the Parquet exports, which are. See
+[`../docs/Downloads.md`](../docs/Downloads.md) for what the published tree contains.
+
+### Retention policy
+
+- Keep every run from the past 12 months.
+- Keep the most recent run of each earlier calendar year, so gross year-to-year comparisons stay
+  possible.
+- Delete every other run from Hatteras. The Stars copy stays.
+
+### Before deleting a run, check what Stars actually has for it
+
+The policy assumes deleting from Hatteras is safe because Stars holds a copy. **That assumption does
+not hold for every run** — check the specific run rather than trusting the assumption. Spot-checking
+`https://stars.renci.org/var/babel_outputs/` on 2026-07-31 found both failure modes:
+
+- **No copy at all.** `2024oct24` and `2025dec11-umls-level-0` both 404, even though `2024oct24` is
+  the build linked from
+  [`releases/TranslatorHammerheadNovember2024.md`](../releases/TranslatorHammerheadNovember2024.md).
+  Deleting these from Hatteras would lose them outright.
+- **A partial copy.** Older runs were published more selectively than `rsync-to-server.sh` does
+  today: `2023nov5` and `2022dec2-2` have `compendia/`, `conflation/` and `synonyms/` but no
+  `intermediate/` or `metadata/`, whereas `2025sep1` has the full tree.
+
+So: list the run's Stars directory, diff it against the Hatteras copy, and re-publish anything
+missing before removing anything.
+
+`intermediate/` is the part most likely to be wanted later, and the part most often absent from an
+older Stars copy. It is what [`../docs/AddingNewSources.md`](../docs/AddingNewSources.md) and
+[`../docs/tools/SourceImpactReport.md`](../docs/tools/SourceImpactReport.md) assemble a
+source-impact report from, and what makes it possible to replay a compendium-building function over
+a finished build instead of rebuilding it (see
+[`../docs/sources/CLAUDE.md`](../docs/sources/CLAUDE.md)). With `babel_downloads/` already gone, it
+is also the only surviving evidence of what the run's sources contained.
+
+`babel_outputs/benchmarks/` and `babel_outputs/reports/slurm/slurm_efficiency_reports/` are tiny and
+worth copying somewhere durable even for a run you are deleting — they are what
+`babel-slurm-resources` reads to right-size the allocations in this file
+([`../docs/tools/Resources.md`](../docs/tools/Resources.md)).
+
+### Housekeeping
+
+Run this when Hatteras space runs short — it is not on a schedule:
+
+```bash
+du -sh /projects/babel/runs/*
+```
+
+Apply the policy above to the listing, verify the Stars copy of each run you plan to remove (and
+re-publish it if it is missing or partial), then delete. Some run directories are owned by other
+users and can only be removed by their owner, so expect to ask.
+
+### Options if the policy stops being enough
+
+Issue #454 weighed three, and only the first is in place today:
+
+1. **Delete**, keeping the Stars copy. This is the current policy.
+2. **Low-cost archiving at RENCI** — not investigated.
+3. **Cloud cold storage** — e.g. Amazon S3 Glacier Deep Archive at ~$0.00099/GB/month (≈$1/TB/month,
+   up to 12 hours to restore), which is roughly $0.60 per month per retained run. Not set up.
+
 ## Known Issues
 
 ### `bad allocation` with plenty of free RAM (`vm.max_map_count` / mmap-count exhaustion)


### PR DESCRIPTION
Closes #454.

#454 has been the only record of how we decide which past Babel runs to keep on Hatteras, and its
body has been edited over time to track new runs — so it was already serving as a living document,
just in a place that is easy to lose and hard to review. This moves the durable part into
`slurm/README.md`, next to the other Hatteras filesystem facts (`## Temporary Scratch Space`
already documents `/tmp`, `/dev/shm`, `/scratch` and `/projects`).

The new `## Storage and Archiving on Hatteras` section covers the per-run sizes, where a run's
working copy and published copy each live, the retention policy from the issue (keep the last 12
months, keep one run per earlier calendar year, delete the rest), the housekeeping procedure, and
the two archiving options that were weighed but never set up. The per-run inventory and sizes stay
in the issue — the repo gets the rule, not the tally.

## Two corrections to the assumptions in #454

**The intermediate files are not the thing at risk.** They live inside `babel_outputs/` and are
archived with it. What is actually lost when a run is deleted is `babel_downloads/` — each source's
downloaded files and the `labels`/`synonyms` extracted from them — and that loss is permanent, since
re-running the download rules fetches whatever upstream holds *today*, not what it held when the run
was built.

**"Stars has a copy" is not true for every run.** Spot-checking
`https://stars.renci.org/var/babel_outputs/` on 2026-07-31 found both failure modes:

| Run | Stars status |
|-----|--------------|
| `2024oct24` | **404** — and it is the build linked from [`releases/TranslatorHammerheadNovember2024.md`](../blob/main/releases/TranslatorHammerheadNovember2024.md) |
| `2025dec11-umls-level-0` | **404** |
| `2023nov5`, `2022dec2-2` | partial — `compendia/`, `conflation/`, `synonyms/`, but no `intermediate/` or `metadata/` |
| `2025sep1` | full tree |

So the section tells you to list the run's Stars directory and re-publish anything missing *before*
removing the Hatteras copy. Those two 404s are worth a look independently of this PR — they may want
their own issue.

## Also changed

Three one-line cross-links: `docs/Deployment.md` (release step 2, "store the outputs on Hatteras"),
`docs/RunningBabel.md` (the summary of what `slurm/README.md` covers), and `docs/Downloads.md`.

## Verification

`uv run rumdl check .` passes (74 files). Every path assertion checked against the repo:
`/projects/babel/runs` (`slurm/run-babel-on-slurm.sh:22`), the `duckdb/duckdbs/` exclusion
(`scripts/rsync-to-server.sh:9`), and the published tree (`docs/Downloads.md`). The per-run sizes
are reproduced from #454 and labelled as that issue's measurements — they were not re-measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)